### PR TITLE
Remove unneeded and incorrect #line directives, which just confuse so…

### DIFF
--- a/test/literate/building-argumentpacks0.cpp
+++ b/test/literate/building-argumentpacks0.cpp
@@ -1,8 +1,6 @@
 
-#line 1744 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <iostream>
-#line 1733 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_PARAMETER_NAME(index)
 
 template <class ArgumentPack>
@@ -14,7 +12,6 @@ int print_index(ArgumentPack const& args)
 
 int x = print_index(_index = 3);  // prints "index = 3"
 
-#line 1752 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_PARAMETER_NAME(name)
 
 template <class ArgumentPack>
@@ -27,13 +24,11 @@ int print_name_and_index(ArgumentPack const& args)
 int y = print_name_and_index((_index = 3, _name = "jones"));
 
 
-#line 1787 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace parameter = boost::parameter;
 using parameter::required;
 using parameter::optional;
 using boost::is_convertible;
 using boost::mpl::_;
-#line 1773 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 parameter::parameters<
     required<tag::name, is_convertible<_,char const*> >
   , optional<tag::index, is_convertible<_,int> >
@@ -47,7 +42,6 @@ int z0 = print_name_and_index( spec(sam, twelve) );
 int z1 = print_name_and_index(
    spec(_index=12, _name="sam")
 );
-#line 1794 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main()
 {}
 

--- a/test/literate/class-template-skeleton0.cpp
+++ b/test/literate/class-template-skeleton0.cpp
@@ -1,7 +1,5 @@
 
-#line 1387 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
-#line 1373 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace boost { namespace python {
 
 template <

--- a/test/literate/deduced-parameters0.cpp
+++ b/test/literate/deduced-parameters0.cpp
@@ -1,5 +1,4 @@
 
-#line 1062 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 
 BOOST_PARAMETER_NAME(name)
@@ -31,7 +30,6 @@ default_call_policies some_policies;
 
 void f()
 {}
-#line 1029 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace mpl = boost::mpl;
 
 BOOST_PARAMETER_FUNCTION(
@@ -64,17 +62,13 @@ BOOST_PARAMETER_FUNCTION(
  }
 
 
-#line 1111 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main()
 {
-#line 1108 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 def("f", &f, some_policies, "Documentation for f");
 def("f", &f, "Documentation for f", some_policies);
 
-#line 1121 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 def(
     "f", &f
    , _policies = some_policies, "Documentation for f");
-#line 1124 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 }
 

--- a/test/literate/deduced-template-parameters0.cpp
+++ b/test/literate/deduced-template-parameters0.cpp
@@ -1,5 +1,4 @@
 
-#line 1557 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <boost/mpl/is_sequence.hpp>
 #include <boost/noncopyable.hpp>
@@ -16,7 +15,6 @@ BOOST_PARAMETER_TEMPLATE_KEYWORD(held_type)
 BOOST_PARAMETER_TEMPLATE_KEYWORD(copyable)
 
 }}
-#line 1546 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace boost { namespace python {
 
 namespace detail { struct bases_base {}; }
@@ -28,10 +26,8 @@ struct bases : detail::bases_base
 }}
 
 
-#line 1600 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/type_traits/is_class.hpp>
 namespace boost { namespace python {
-#line 1578 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 typedef parameter::parameters<
     required<tag::class_type, is_class<_> >
 
@@ -53,7 +49,6 @@ typedef parameter::parameters<
   , parameter::optional<deduced<tag::copyable>, is_same<noncopyable,_> >
 
 > class_signature;
-#line 1604 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 template <
     class A0
   , class A1 = parameter::void_
@@ -85,16 +80,13 @@ struct class_
 
 
 
-#line 1644 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 struct B {};
 struct D {};
 
 using boost::python::bases;
-#line 1640 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 typedef boost::python::class_<B, boost::noncopyable> c1;
 
 typedef boost::python::class_<D, std::auto_ptr<D>, bases<B> > c2;
-#line 1650 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_MPL_ASSERT((boost::is_same<c1::class_type, B>));
 BOOST_MPL_ASSERT((boost::is_same<c1::base_list, bases<> >));
 BOOST_MPL_ASSERT((boost::is_same<c1::held_type, B>));

--- a/test/literate/default-expression-evaluation0.cpp
+++ b/test/literate/default-expression-evaluation0.cpp
@@ -1,5 +1,4 @@
 
-#line 730 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <iostream>
 
@@ -8,7 +7,6 @@ BOOST_PARAMETER_NAME(visitor)
 BOOST_PARAMETER_NAME(root_vertex)
 BOOST_PARAMETER_NAME(index_map)
 BOOST_PARAMETER_NAME(color_map)
-#line 702 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/graph/depth_first_search.hpp> // for dfs_visitor
 
 BOOST_PARAMETER_FUNCTION(

--- a/test/literate/defining-the-keywords0.cpp
+++ b/test/literate/defining-the-keywords0.cpp
@@ -1,4 +1,3 @@
-#line 397 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter/name.hpp>
 
 namespace graphs

--- a/test/literate/defining-the-keywords1.cpp
+++ b/test/literate/defining-the-keywords1.cpp
@@ -1,7 +1,5 @@
 
-#line 424 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter/keyword.hpp>
-#line 413 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace graphs
 {
   namespace tag { struct graph; } // keyword tag type

--- a/test/literate/exercising-the-code-so-far0.cpp
+++ b/test/literate/exercising-the-code-so-far0.cpp
@@ -1,5 +1,4 @@
 
-#line 1415 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <boost/mpl/is_sequence.hpp>
 #include <boost/noncopyable.hpp>
@@ -20,7 +19,6 @@ struct bases
 {};
 
 }}
-#line 1402 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace boost { namespace python {
 
 using boost::mpl::_;
@@ -34,7 +32,6 @@ typedef parameter::parameters<
 
 }}
 
-#line 1454 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace boost { namespace python {
 
 template <
@@ -67,7 +64,6 @@ struct class_
 }}
 
 
-#line 1 "None"
 using boost::python::class_type;
 using boost::python::copyable;
 using boost::python::held_type;
@@ -76,7 +72,6 @@ using boost::python::bases;
 
 struct B {};
 struct D {};
-#line 1495 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 typedef boost::python::class_<
     class_type<B>, copyable<boost::noncopyable>
 > c1;
@@ -85,7 +80,6 @@ typedef boost::python::class_<
     D, held_type<std::auto_ptr<D> >, base_list<bases<B> >
 > c2;
 
-#line 1515 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_MPL_ASSERT((boost::is_same<c1::class_type, B>));
 BOOST_MPL_ASSERT((boost::is_same<c1::base_list, bases<> >));
 BOOST_MPL_ASSERT((boost::is_same<c1::held_type, B>));

--- a/test/literate/extracting-parameter-types0.cpp
+++ b/test/literate/extracting-parameter-types0.cpp
@@ -1,8 +1,6 @@
 
-#line 1830 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <cassert>
-#line 1813 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_PARAMETER_NAME(name)
 BOOST_PARAMETER_NAME(index)
 
@@ -19,7 +17,6 @@ int deduce_arg_types(ArgumentPack const& args)
 {
     return deduce_arg_types_impl(args[_name], args[_index|42]);
 }
-#line 1834 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int a1 = deduce_arg_types((_name = "foo"));
 int a2 = deduce_arg_types((_name = "foo", _index = 3));
 

--- a/test/literate/extracting-parameter-types1.cpp
+++ b/test/literate/extracting-parameter-types1.cpp
@@ -1,11 +1,9 @@
 
-#line 1863 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <cassert>
 
 namespace parameter = boost::parameter;
-#line 1852 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_PARAMETER_NAME(index)
 
 template <class ArgumentPack>
@@ -16,7 +14,6 @@ twice_index(ArgumentPack const& args)
 }
 
 int six = twice_index(_index = 3);
-#line 1871 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main()
 {
     assert(six == 6);

--- a/test/literate/fine-grained-name-control0.cpp
+++ b/test/literate/fine-grained-name-control0.cpp
@@ -1,7 +1,5 @@
 
-#line 1703 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
-#line 1693 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_PARAMETER_NAME((pass_foo, keywords) foo)
 
 BOOST_PARAMETER_FUNCTION(
@@ -12,7 +10,6 @@ BOOST_PARAMETER_FUNCTION(
 }
 
 int x = f(pass_foo = 41);
-#line 1704 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main()
 {}
 

--- a/test/literate/handling-out-parameters0.cpp
+++ b/test/literate/handling-out-parameters0.cpp
@@ -1,5 +1,4 @@
 
-#line 620 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 
 namespace boost
@@ -20,7 +19,6 @@ BOOST_PARAMETER_NAME(color_map)
 
 BOOST_PARAMETER_FUNCTION((void), f, tag,
   (required (graph, *))
-#line 612 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 (optional
     (visitor,            *, boost::dfs_visitor<>())
     (root_vertex,        *, *vertices(graph).first)
@@ -28,6 +26,5 @@ BOOST_PARAMETER_FUNCTION((void), f, tag,
     (in_out(color_map), *,
       default_color_map(num_vertices(graph), index_map) )
 )
-#line 642 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 ) {}
 

--- a/test/literate/headers-and-namespaces0.cpp
+++ b/test/literate/headers-and-namespaces0.cpp
@@ -1,5 +1,3 @@
-#line 274 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter/keyword.hpp>
-#line 283 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 using boost::parameter::keyword;
 

--- a/test/literate/lazy-default-computation0.cpp
+++ b/test/literate/lazy-default-computation0.cpp
@@ -1,10 +1,8 @@
 
-#line 1911 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <string>
 
 namespace parameter = boost::parameter;
-#line 1894 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_PARAMETER_NAME(s1)
 BOOST_PARAMETER_NAME(s2)
 BOOST_PARAMETER_NAME(s3)
@@ -21,7 +19,6 @@ std::string f(ArgumentPack const& args)
 }
 
 std::string x = f((_s1="hello,", _s2=" world", _s3="hi world"));
-#line 1917 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main()
 {}
 

--- a/test/literate/lazy-default-computation1.cpp
+++ b/test/literate/lazy-default-computation1.cpp
@@ -1,5 +1,4 @@
 
-#line 1943 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/bind.hpp>
 #include <boost/ref.hpp>
 #include <boost/parameter.hpp>
@@ -17,12 +16,10 @@ std::string f(ArgumentPack const& args)
 {
     std::string const& s1 = args[_s1];
     std::string const& s2 = args[_s2];
-#line 1938 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 typename parameter::binding<
     ArgumentPack, tag::s3, std::string
 >::type s3 = args[_s3
     || boost::bind(std::plus<std::string>(), boost::ref(s1), boost::ref(s2)) ];
-#line 1962 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
     return s3;
 }
 

--- a/test/literate/namespaces0.cpp
+++ b/test/literate/namespaces0.cpp
@@ -1,9 +1,6 @@
 
-#line 2082 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
-#line 2085 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <iostream>
-#line 2071 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace lib
 {
   BOOST_PARAMETER_NAME(name)
@@ -18,8 +15,6 @@ namespace lib
       return index;
   }
 }
-#line 2098 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int x = lib::f(lib::_name = "jill", lib::_index = 1);
-#line 2102 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main() {}
 

--- a/test/literate/namespaces1.cpp
+++ b/test/literate/namespaces1.cpp
@@ -1,9 +1,6 @@
 
-#line 2100 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
-#line 2085 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <iostream>
-#line 2071 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace lib
 {
   BOOST_PARAMETER_NAME(name)
@@ -18,11 +15,9 @@ namespace lib
       return index;
   }
 }
-#line 2111 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 using lib::_name;
 using lib::_index;
 
 int x = lib::f(_name = "jill", _index = 1);
-#line 2120 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main() {}
 

--- a/test/literate/namespaces2.cpp
+++ b/test/literate/namespaces2.cpp
@@ -1,9 +1,6 @@
 
-#line 2114 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
-#line 2085 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <iostream>
-#line 2071 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace lib
 {
   BOOST_PARAMETER_NAME(name)
@@ -18,9 +15,7 @@ namespace lib
       return index;
   }
 }
-#line 2128 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 using namespace lib;
 int x = f(_name = "jill", _index = 3);
-#line 2134 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main() {}
 

--- a/test/literate/namespaces3.cpp
+++ b/test/literate/namespaces3.cpp
@@ -1,8 +1,6 @@
 
-#line 2161 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <iostream>
-#line 2143 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace lib
 {
   namespace keywords
@@ -21,9 +19,7 @@ namespace lib
   }
 }
 
-#line 2170 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 using namespace lib::keywords;
 int y = lib::f(_name = "bob", _index = 2);
-#line 2172 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main() {}
 

--- a/test/literate/optional-parameters0.cpp
+++ b/test/literate/optional-parameters0.cpp
@@ -1,5 +1,4 @@
 
-#line 571 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 
 namespace boost
@@ -19,13 +18,11 @@ BOOST_PARAMETER_NAME(color_map)
 
 BOOST_PARAMETER_FUNCTION((void), f, tag,
   (required (graph, *))
-#line 563 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 (optional     (visitor,           *, boost::dfs_visitor<>())
     (root_vertex,       *, *vertices(graph).first)
     (index_map,         *, get(boost::vertex_index,graph))
     (in_out(color_map), *,
       default_color_map(num_vertices(graph), index_map) )
 )
-#line 592 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 ) {}
 

--- a/test/literate/parameter-enabled-constructors0.cpp
+++ b/test/literate/parameter-enabled-constructors0.cpp
@@ -1,8 +1,6 @@
 
-#line 1248 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <iostream>
-#line 1234 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_PARAMETER_NAME(name)
 BOOST_PARAMETER_NAME(index)
 
@@ -17,7 +15,6 @@ struct myclass_impl
     }
 };
 
-#line 1261 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 struct myclass : myclass_impl
 {
     BOOST_PARAMETER_CONSTRUCTOR(
@@ -26,12 +23,9 @@ struct myclass : myclass_impl
 };
 
 
-#line 1275 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 int main() {
-#line 1272 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 myclass x("bob", 3);                     // positional
 myclass y(_index = 12, _name = "sally"); // named
 myclass z("june");                       // positional/defaulted
-#line 1275 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 }
 

--- a/test/literate/parameter-enabled-member-functions0.cpp
+++ b/test/literate/parameter-enabled-member-functions0.cpp
@@ -1,9 +1,7 @@
 
-#line 1154 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <iostream>
 using namespace boost::parameter;
-#line 1142 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_PARAMETER_NAME(arg1)
 BOOST_PARAMETER_NAME(arg2)
 

--- a/test/literate/parameter-enabled-member-functions1.cpp
+++ b/test/literate/parameter-enabled-member-functions1.cpp
@@ -1,11 +1,9 @@
 
-#line 1177 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 
 BOOST_PARAMETER_NAME(arg1)
 BOOST_PARAMETER_NAME(arg2)
 using namespace boost::parameter;
-#line 1166 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 struct callable2
 {
     BOOST_PARAMETER_CONST_MEMBER_FUNCTION(

--- a/test/literate/predicate-requirements0.cpp
+++ b/test/literate/predicate-requirements0.cpp
@@ -1,5 +1,4 @@
 
-#line 935 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/depth_first_search.hpp>
@@ -11,7 +10,6 @@ BOOST_PARAMETER_NAME((_index_map, graphs) index_map)
 BOOST_PARAMETER_NAME((_color_map, graphs) color_map)
 
 using boost::mpl::_;
-#line 859 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 // We first need to define a few metafunction that we use in the
 // predicates below.
 
@@ -87,7 +85,6 @@ BOOST_PARAMETER_FUNCTION(
        , default_color_map(num_vertices(graph), index_map) )
     )
 )
-#line 949 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 {}
 
 int main()

--- a/test/literate/required-parameters0.cpp
+++ b/test/literate/required-parameters0.cpp
@@ -1,12 +1,9 @@
 
-#line 540 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 
 BOOST_PARAMETER_NAME(graph)
 
 BOOST_PARAMETER_FUNCTION((void), f, tag,
-#line 531 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 (required (graph, *) )
-#line 547 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 ) {}
 

--- a/test/literate/static-member-functions0.cpp
+++ b/test/literate/static-member-functions0.cpp
@@ -1,9 +1,7 @@
 
-#line 1206 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 #include <iostream>
 using namespace boost::parameter;
-#line 1195 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 BOOST_PARAMETER_NAME(arg1)
 
 struct somebody

--- a/test/literate/template-keywords0.cpp
+++ b/test/literate/template-keywords0.cpp
@@ -1,7 +1,5 @@
 
-#line 1337 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
-#line 1329 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace boost { namespace python {
 
 BOOST_PARAMETER_TEMPLATE_KEYWORD(class_type)

--- a/test/literate/template-keywords1.cpp
+++ b/test/literate/template-keywords1.cpp
@@ -1,7 +1,5 @@
 
-#line 1353 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
-#line 1344 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 namespace boost { namespace python {
 
 namespace tag { struct class_type; } // keyword tag type

--- a/test/literate/top-level0.cpp
+++ b/test/literate/top-level0.cpp
@@ -1,5 +1,4 @@
 
-#line 35 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter.hpp>
 
 namespace test
@@ -31,7 +30,6 @@ namespace test
 }
 using namespace test;
 int x = 
-#line 19
 new_window("alert", _width=10, _titlebar=false);
 
 smart_ptr<

--- a/test/literate/writing-the-function0.cpp
+++ b/test/literate/writing-the-function0.cpp
@@ -1,5 +1,4 @@
 
-#line 472 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter/name.hpp>
 
 BOOST_PARAMETER_NAME(graph)
@@ -17,7 +16,6 @@ struct dfs_visitor
 int vertex_index = 0;
 
 }
-#line 446 "/home/daniel/dev/boost/trunk/libs/parameter/doc/index.rst"
 #include <boost/parameter/preprocessor.hpp>
 
 namespace graphs


### PR DESCRIPTION
…me compilers, most notably VC++ which fails some tests purely on its confusion.