### PR TITLE
improve aux::arg_list<>::operator[]()

### DIFF
--- a/include/boost/parameter/aux_/arg_list.hpp
+++ b/include/boost/parameter/aux_/arg_list.hpp
@@ -339,6 +339,7 @@ struct arg_list : Next
     template <class Default>
     reference operator[](lazy_default<key_type, Default>) const
     {
+        BOOST_MPL_ASSERT_NOT((holds_maybe));
         return arg.value;
     }
 


### PR DESCRIPTION
Add the assert to avoid ugly message when invoked `arg_list<>::operator[](lazy_default<>)` with `maybe<>`