### PR TITLE
 Upgrade boost::parameter::aux::unwrap_cv_reference

### DIFF
--- a/include/boost/parameter/aux_/unwrap_cv_reference.hpp
+++ b/include/boost/parameter/aux_/unwrap_cv_reference.hpp
@@ -10,6 +10,11 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/mpl/eval_if.hpp>
+#include <boost/config.hpp>
+
+#if !defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#include <functional>
+#endif
 
 namespace boost { template<class T> class reference_wrapper; }
 
@@ -26,6 +31,11 @@ namespace boost { namespace parameter { namespace aux {
 // reference_wrapper<U> cv
 template <class U>
 yes_tag is_cv_reference_wrapper_check(reference_wrapper<U> const volatile*);
+#if !defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+// Support for std::ref(x) -- Cromwell D. Enage
+template <class U>
+yes_tag is_cv_reference_wrapper_check(::std::reference_wrapper<U> const volatile*);
+#endif
 no_tag is_cv_reference_wrapper_check(...);
 
 template <class T>

--- a/test/unwrap_cv_reference.cpp
+++ b/test/unwrap_cv_reference.cpp
@@ -6,6 +6,11 @@
 #include <boost/mpl/assert.hpp>
 #include <boost/ref.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <boost/config.hpp>
+
+#if !defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#include <functional>
+#endif
 
 namespace test
 {
@@ -17,14 +22,21 @@ namespace test
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<int const>::type,int const>));
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<int volatile>::type,int volatile>));
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<int const volatile>::type,int const volatile>));
-  
+
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<foo>::type,foo>));
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<foo const>::type,foo const>));
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<foo volatile>::type,foo volatile>));
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<foo const volatile>::type,foo const volatile>));
-  
+
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<reference_wrapper<foo> >::type,foo>));
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<reference_wrapper<foo> const>::type,foo>));
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<reference_wrapper<foo> volatile>::type,foo>));
   BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<reference_wrapper<foo> const volatile>::type,foo>));
+
+#if !defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+  BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<std::reference_wrapper<foo> >::type,foo>));
+  BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<std::reference_wrapper<foo> const>::type,foo>));
+  BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<std::reference_wrapper<foo> volatile>::type,foo>));
+  BOOST_MPL_ASSERT((is_same<unwrap_cv_reference<std::reference_wrapper<foo> const volatile>::type,foo>));
+#endif
 }


### PR DESCRIPTION
Add support for std::reference_wrapper<> and std::ref().