### PR TITLE
 Upgrade boost::parameter::aux::tagged_argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ matrix:
   include:
     - os: linux
       compiler: g++
-      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03,11
+      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03,11 TEST_SUITE=parameter
 
     - os: linux
       compiler: g++-4.4
-      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=98,0x
+      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=98,0x TEST_SUITE=parameter
       addons:
         apt:
           packages:
@@ -40,7 +40,7 @@ matrix:
 
     - os: linux
       compiler: g++-4.6
-      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03,0x
+      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03,0x TEST_SUITE=parameter
       addons:
         apt:
           packages:
@@ -50,7 +50,7 @@ matrix:
 
     - os: linux
       compiler: g++-5
-      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=03,11,14,1z
+      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=03,11,14,1z TEST_SUITE=parameter
       addons:
         apt:
           packages:
@@ -60,7 +60,7 @@ matrix:
 
     - os: linux
       compiler: g++-6
-      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=03,11,14,1z
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=03,11,14,1z TEST_SUITE=parameter
       addons:
         apt:
           packages:
@@ -71,7 +71,7 @@ matrix:
     - os: linux
       dist: trusty
       compiler: g++-7
-      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03,11,14,17
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03,11,14,17 TEST_SUITE=parameter
       addons:
         apt:
           packages:
@@ -81,7 +81,7 @@ matrix:
 
     - os: linux
       compiler: g++-8
-      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=03,11,14,17
+      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=03,11,14,17 TEST_SUITE=parameter
       addons:
         apt:
           packages:
@@ -91,7 +91,7 @@ matrix:
 
     - os: linux
       compiler: clang++
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z TEST_SUITE=parameter
       addons:
         apt:
           packages:
@@ -101,7 +101,7 @@ matrix:
 
     - os: linux
       compiler: clang++-libc++
-      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=03,11,14,1z
+      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=03,11,14,1z TEST_SUITE=parameter
       addons:
         apt:
           packages:
@@ -109,7 +109,7 @@ matrix:
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z TEST_SUITE=parameter
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
@@ -129,7 +129,9 @@ script:
   - |-
     echo "using $TOOLSET : : $COMPILER ;" > ~/user-config.jam
   - ./b2 --verbose-test libs/config/test//config_info toolset=$TOOLSET cxxstd=$CXXSTD || true
-  - ./b2 -j3 libs/parameter/test toolset=$TOOLSET cxxstd=$CXXSTD
+  - cd libs/parameter/test
+  - ../../../b2 $TEST_SUITE -j`(nproc || sysctl -n hw.ncpu) 2> /dev/null` toolset=$TOOLSET cxxstd=$CXXSTD $CXXSTD_DIALECT
+  - cd ../../..
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 # Copyright 2017 Edward Diener
 # Distributed under the Boost Software License, Version 1.0.
-# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://boost.org/LICENSE_1_0.txt)
 
 version: 1.0.{build}-{branch}
 
@@ -13,10 +14,30 @@ branches:
 
 environment:
   matrix:
+    - ARGS: --toolset=gcc address-model=32
+      TEST_SUITE: parameter
+      PATH: C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin;%PATH%
+    - ARGS: --toolset=gcc address-model=32 linkflags=-Wl,-allow-multiple-definition
+      TEST_SUITE: parameter
+      PATH: C:\MinGW\bin;%PATH%
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      ARGS: --toolset=msvc-9.0  address-model=32
+      TEST_SUITE: parameter
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      ARGS: --toolset=msvc-10.0 address-model=32
+      TEST_SUITE: parameter
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      ARGS: --toolset=msvc-11.0 address-model=32
+      TEST_SUITE: parameter_msvc11_tests
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      ARGS: --toolset=msvc-12.0 address-model=32
+      TEST_SUITE: parameter
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0,msvc-12.0,msvc-14.0
+      ARGS: --toolset=msvc-14.0 address-model=32
+      TEST_SUITE: parameter
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      TOOLSET: msvc-14.1
+      ARGS: --toolset=msvc-14.1 address-model=32
+      TEST_SUITE: parameter
 
 install:
   - cd ..
@@ -34,4 +55,6 @@ install:
 build: off
 
 test_script:
-  - b2 libs/parameter/test toolset=%TOOLSET%
+  - cd libs\parameter\test
+  - ..\..\..\b2 -j%NUMBER_OF_PROCESSORS% --hash %ARGS% %TEST_SUITE%
+  - cd ..\..\..

--- a/include/boost/parameter/aux_/tagged_argument.hpp
+++ b/include/boost/parameter/aux_/tagged_argument.hpp
@@ -20,10 +20,7 @@
 # include <boost/config.hpp>
 # include <boost/config/workaround.hpp>
 
-#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || ( \
-        BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
-        BOOST_WORKAROUND(BOOST_MSVC, < 1800) \
-    )
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function.hpp>
 #else
 #include <functional>
@@ -51,10 +48,7 @@ public:
     // a boost::function or a std::function. -- Cromwell D. Enage
     typedef typename ::boost::mpl::if_<
         ::boost::is_function<arg_type>
-#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || ( \
-        BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
-        BOOST_WORKAROUND(BOOST_MSVC, < 1800) \
-    )
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
       , ::boost::function<arg_type>
 #else
       , ::std::function<arg_type>

--- a/include/boost/parameter/aux_/tagged_argument.hpp
+++ b/include/boost/parameter/aux_/tagged_argument.hpp
@@ -20,7 +20,10 @@
 # include <boost/config.hpp>
 # include <boost/config/workaround.hpp>
 
-#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || ( \
+        BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+        BOOST_WORKAROUND(BOOST_MSVC, < 1800) \
+    )
 #include <boost/function.hpp>
 #else
 #include <functional>
@@ -48,7 +51,10 @@ public:
     // a boost::function or a std::function. -- Cromwell D. Enage
     typedef typename ::boost::mpl::if_<
         ::boost::is_function<arg_type>
-#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || ( \
+        BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+        BOOST_WORKAROUND(BOOST_MSVC, < 1800) \
+    )
       , ::boost::function<arg_type>
 #else
       , ::std::function<arg_type>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -14,6 +14,7 @@ build-project literate ;
   
 test-suite "parameter"
   :  [ run basics.cpp ]
+     [ run compose.cpp ]
      [ run sfinae.cpp ]
      [ run macros.cpp ]
      [ run earwicker.cpp ]
@@ -33,7 +34,6 @@ test-suite "parameter"
      [ compile unwrap_cv_reference.cpp ]
      [ compile-fail duplicates.cpp ]
      [ compile-fail deduced_unmatched_arg.cpp ]
-     [ compile compose.cpp ]
      [ bpl-test python_test ]
   ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -11,8 +11,8 @@ project boost/parameter
   ;
 
 build-project literate ;
-  
-test-suite "parameter"
+
+alias parameter
   :  [ run basics.cpp ]
      [ run compose.cpp ]
      [ run sfinae.cpp ]
@@ -35,5 +35,14 @@ test-suite "parameter"
      [ compile-fail duplicates.cpp ]
      [ compile-fail deduced_unmatched_arg.cpp ]
      [ bpl-test python_test ]
+  ;
+
+alias parameter_msvc11_fail
+  :  [ run-fail compose.cpp : : : <define>LIBS_PARAMETER_TEST_RUN_FAILURE : compose_fail_0 : <preserve-target-tests>off ]
+  ;
+
+alias parameter_msvc11_tests
+  :  parameter
+     parameter_msvc11_fail
   ;
 

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -1,43 +1,172 @@
-//~ Copyright Rene Rivera 2006.
-//~ Use, modification and distribution is subject to the Boost Software License,
-//~ Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at 
-//~ http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Rene Rivera 2006.
+// Copyright Cromwell D. Enage 2017.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
-namespace param
-{
-    BOOST_PARAMETER_KEYWORD(Tag,a0)
-    BOOST_PARAMETER_KEYWORD(Tag,a1)
-    BOOST_PARAMETER_KEYWORD(Tag,a2)
+namespace param {
+
+    BOOST_PARAMETER_NAME(a0)
+    BOOST_PARAMETER_NAME(a1)
+    BOOST_PARAMETER_NAME(a2)
+    BOOST_PARAMETER_NAME(a3)
+    BOOST_PARAMETER_NAME(lrc)
+    BOOST_PARAMETER_NAME(lr)
+    BOOST_PARAMETER_NAME(rr)
 }
 
-namespace test
-{
+#include <boost/config.hpp>
+#include <boost/config/workaround.hpp>
+
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || ( \
+        BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+        BOOST_WORKAROUND(BOOST_MSVC, < 1800) \
+    )
+#include <boost/function.hpp>
+#else
+#include <functional>
+#endif
+
+namespace test {
+
     struct A
     {
         int i;
         int j;
         
-        template <typename ArgPack> A(ArgPack const & args)
+        template <typename ArgPack>
+        A(ArgPack const& args) : i(args[param::_a0]), j(args[param::_a1])
         {
-            i = args[param::a0];
-            j = args[param::a1];
+        }
+    };
+
+    float F()
+    {
+        return 4.0f;
+    }
+
+    float E()
+    {
+        return 4.625f;
+    }
+
+    double D()
+    {
+        return 198.9;
+    }
+
+    struct C
+    {
+        struct result_type
+        {
+            double operator()() const
+            {
+                return 2.5;
+            }
+        };
+
+        result_type operator()() const
+        {
+            return result_type();
         }
     };
 
     struct B : A
     {
-        template <typename ArgPack> B(ArgPack const & args)
-            : A((args, param::a0 = 1))
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || ( \
+        BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+        BOOST_WORKAROUND(BOOST_MSVC, < 1800) \
+    )
+        boost::function<float()> k;
+        boost::function<double()> l;
+#else
+        std::function<float()> k;
+        std::function<double()> l;
+#endif
+
+        template <typename ArgPack>
+        B(ArgPack const& args)
+          : A((args, param::_a0 = 1))
+          , k(args[param::_a2 | E])
+          , l(args[param::_a3 || C()])
         {
         }
     };
-}
+
+    struct G
+    {
+        int i;
+        int& j;
+        int const& k;
+
+        template <typename ArgPack>
+        G(ArgPack const& args)
+          : i(args[param::_rr])
+          , j(args[param::_lr])
+          , k(args[param::_lrc])
+        {
+        }
+    };
+} // namespace test
+
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-    test::A a((param::a0 = 1, param::a1 = 13, param::a2 = 6));
-    test::B b0((param::a1 = 13));
-    test::B b1((param::a1 = 13, param::a2 = 6));
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+    // MSVC 11.0 on AppVeyor reports error C2528:
+    // 'abstract declarator': pointer to reference is illegal
+    test::A a((
+        param::_a0 = 1
+      , param::_a1 = 13
+      , param::_a2 = boost::function<double()>(test::D)
+    ));
+#else
+    test::A a((param::_a0 = 1, param::_a1 = 13, param::_a2 = test::D));
+#endif
+    BOOST_TEST_EQ(1, a.i);
+    BOOST_TEST_EQ(13, a.j);
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+    // MSVC 11.0 on AppVeyor reports error C2528:
+    // 'abstract declarator': pointer to reference is illegal
+    test::B b0((
+        param::_a1 = 13
+      , param::_a2 = boost::function<float()>(test::F)
+    ));
+#else
+    test::B b0((param::_a1 = 13, param::_a2 = test::F));
+#endif
+    BOOST_TEST_EQ(1, b0.i);
+    BOOST_TEST_EQ(13, b0.j);
+    BOOST_TEST_EQ(4.0f, b0.k());
+    BOOST_TEST_EQ(2.5, b0.l());
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+    // MSVC 11.0 on AppVeyor reports error C2528:
+    // 'abstract declarator': pointer to reference is illegal
+    test::B b1((
+        param::_a3 = boost::function<double()>(test::D)
+      , param::_a1 = 13
+    ));
+#else
+    test::B b1((param::_a3 = test::D, param::_a1 = 13));
+#endif
+    BOOST_TEST_EQ(1, b1.i);
+    BOOST_TEST_EQ(13, b1.j);
+    BOOST_TEST_EQ(4.625f, b1.k());
+    BOOST_TEST_EQ(198.9, b1.l());
+    int x = 7;
+    int const y = 9;
+    test::G g((param::_lr = x, param::_rr = 8, param::_lrc = y));
+    BOOST_TEST_EQ(7, g.j);
+    BOOST_TEST_EQ(8, g.i);
+    BOOST_TEST_EQ(9, g.k);
+    x = 1;
+    BOOST_TEST_EQ(1, g.j);
+    return boost::report_errors();
 }
+

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -20,10 +20,7 @@ namespace param {
 #include <boost/config.hpp>
 #include <boost/config/workaround.hpp>
 
-#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || ( \
-        BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
-        BOOST_WORKAROUND(BOOST_MSVC, < 1800) \
-    )
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function.hpp>
 #else
 #include <functional>
@@ -75,12 +72,7 @@ namespace test {
 
     struct B : A
     {
-#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || ( \
-        BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
-        BOOST_WORKAROUND(BOOST_MSVC, < 1800) \
-    )
-        // MSVC 11.0 on AppVeyor reports error C2528:
-        // 'abstract declarator': pointer to reference is illegal
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
         boost::function<float()> k;
         boost::function<double()> l;
 #else
@@ -117,25 +109,27 @@ namespace test {
 
 int main()
 {
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+#if !defined(LIBS_PARAMETER_TEST_RUN_FAILURE) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails at runtime without this workaround.
     test::A a((
         param::_a0 = 1
       , param::_a1 = 13
-      , param::_a2 = boost::function<double()>(test::D)
+      , param::_a2 = std::function<double()>(test::D)
     ));
 #else
     test::A a((param::_a0 = 1, param::_a1 = 13, param::_a2 = test::D));
 #endif
     BOOST_TEST_EQ(1, a.i);
     BOOST_TEST_EQ(13, a.j);
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+#if !defined(LIBS_PARAMETER_TEST_RUN_FAILURE) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails at runtime without this workaround.
     test::B b0((
         param::_a1 = 13
-      , param::_a2 = boost::function<float()>(test::F)
+      , param::_a2 = std::function<float()>(test::F)
     ));
 #else
     test::B b0((param::_a1 = 13, param::_a2 = test::F));
@@ -144,11 +138,12 @@ int main()
     BOOST_TEST_EQ(13, b0.j);
     BOOST_TEST_EQ(4.0f, b0.k());
     BOOST_TEST_EQ(2.5, b0.l());
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+#if !defined(LIBS_PARAMETER_TEST_RUN_FAILURE) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails at runtime without this workaround.
     test::B b1((
-        param::_a3 = boost::function<double()>(test::D)
+        param::_a3 = std::function<double()>(test::D)
       , param::_a1 = 13
     ));
 #else

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -79,6 +79,8 @@ namespace test {
         BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
         BOOST_WORKAROUND(BOOST_MSVC, < 1800) \
     )
+        // MSVC 11.0 on AppVeyor reports error C2528:
+        // 'abstract declarator': pointer to reference is illegal
         boost::function<float()> k;
         boost::function<double()> l;
 #else
@@ -115,15 +117,43 @@ namespace test {
 
 int main()
 {
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+    // MSVC 11.0 on AppVeyor fails at runtime without this workaround.
+    test::A a((
+        param::_a0 = 1
+      , param::_a1 = 13
+      , param::_a2 = boost::function<double()>(test::D)
+    ));
+#else
     test::A a((param::_a0 = 1, param::_a1 = 13, param::_a2 = test::D));
+#endif
     BOOST_TEST_EQ(1, a.i);
     BOOST_TEST_EQ(13, a.j);
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+    // MSVC 11.0 on AppVeyor fails at runtime without this workaround.
+    test::B b0((
+        param::_a1 = 13
+      , param::_a2 = boost::function<float()>(test::F)
+    ));
+#else
     test::B b0((param::_a1 = 13, param::_a2 = test::F));
+#endif
     BOOST_TEST_EQ(1, b0.i);
     BOOST_TEST_EQ(13, b0.j);
     BOOST_TEST_EQ(4.0f, b0.k());
     BOOST_TEST_EQ(2.5, b0.l());
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+    // MSVC 11.0 on AppVeyor fails at runtime without this workaround.
+    test::B b1((
+        param::_a3 = boost::function<double()>(test::D)
+      , param::_a1 = 13
+    ));
+#else
     test::B b1((param::_a3 = test::D, param::_a1 = 13));
+#endif
     BOOST_TEST_EQ(1, b1.i);
     BOOST_TEST_EQ(13, b1.j);
     BOOST_TEST_EQ(4.625f, b1.k());

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -35,7 +35,7 @@ namespace test {
     {
         int i;
         int j;
-        
+
         template <typename ArgPack>
         A(ArgPack const& args) : i(args[param::_a0]), j(args[param::_a1])
         {
@@ -115,46 +115,15 @@ namespace test {
 
 int main()
 {
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
-    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
-    // MSVC 11.0 on AppVeyor reports error C2528:
-    // 'abstract declarator': pointer to reference is illegal
-    test::A a((
-        param::_a0 = 1
-      , param::_a1 = 13
-      , param::_a2 = boost::function<double()>(test::D)
-    ));
-#else
     test::A a((param::_a0 = 1, param::_a1 = 13, param::_a2 = test::D));
-#endif
     BOOST_TEST_EQ(1, a.i);
     BOOST_TEST_EQ(13, a.j);
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
-    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
-    // MSVC 11.0 on AppVeyor reports error C2528:
-    // 'abstract declarator': pointer to reference is illegal
-    test::B b0((
-        param::_a1 = 13
-      , param::_a2 = boost::function<float()>(test::F)
-    ));
-#else
     test::B b0((param::_a1 = 13, param::_a2 = test::F));
-#endif
     BOOST_TEST_EQ(1, b0.i);
     BOOST_TEST_EQ(13, b0.j);
     BOOST_TEST_EQ(4.0f, b0.k());
     BOOST_TEST_EQ(2.5, b0.l());
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
-    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
-    // MSVC 11.0 on AppVeyor reports error C2528:
-    // 'abstract declarator': pointer to reference is illegal
-    test::B b1((
-        param::_a3 = boost::function<double()>(test::D)
-      , param::_a1 = 13
-    ));
-#else
     test::B b1((param::_a3 = test::D, param::_a1 = 13));
-#endif
     BOOST_TEST_EQ(1, b1.i);
     BOOST_TEST_EQ(13, b1.j);
     BOOST_TEST_EQ(4.625f, b1.k());


### PR DESCRIPTION
Add support for passing functions as arguments to Boost.Parameter-enabled functions.