### PR TITLE
 Support additional parameter categories

### DIFF
--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -535,7 +535,7 @@ expression representing the parameter's default value:</p>
 (optional <strong>    (visitor,           *, boost::dfs_visitor&lt;&gt;())
     (root_vertex,       *, *vertices(graph).first)
     (index_map,         *, get(boost::vertex_index,graph))
-    (in_out(color_map), *,
+    (color_map,         *,
       default_color_map(num_vertices(graph), index_map) )</strong>
 )
 </pre>
@@ -556,7 +556,7 @@ BOOST_PARAMETER_NAME(graph)
 BOOST_PARAMETER_NAME(visitor)
 BOOST_PARAMETER_NAME(root_vertex)
 BOOST_PARAMETER_NAME(index_map)
-BOOST_PARAMETER_NAME(color_map)
+BOOST_PARAMETER_NAME(in_out(color_map))
 
 BOOST_PARAMETER_FUNCTION((void), f, tag,
   (required (graph, *))
@@ -565,67 +565,101 @@ BOOST_PARAMETER_FUNCTION((void), f, tag,
 <!-- @test('compile') -->
 </div>
 <div class="section" id="handling-out-parameters">
-<h4>2.1.5.3&nbsp;&nbsp;&nbsp;Handling “Out” Parameters</h4>
+<h4>2.1.5.3&nbsp;&nbsp;&nbsp;Handling “In”, “Out”, and “Forward”
+Parameters</h4>
 <div class="compound">
-<p class="compound-first">Within the function body, a parameter name such as <tt class="docutils literal">visitor</tt> is
-a <em>C++ reference</em>, bound either to an actual argument passed by
-the caller or to the result of evaluating a default expression.
-In most cases, parameter types are of the form <tt class="docutils literal">T const&amp;</tt> for
-some <tt class="docutils literal">T</tt>.  Parameters whose values are expected to be modified,
-however, must be passed by reference to <em>non</em>-<tt class="docutils literal">const</tt>.  To
-indicate that <tt class="docutils literal">color_map</tt> is both read and written, we wrap
-its name in <tt class="docutils literal"><span class="pre">in_out(…)</span></tt>:</p>
+<p class="compound-first">By default, Boost.Parameter treats all parameters as
+if they were <em>forward</em> <a class="reference external" href=
+"http://www.modernescpp.com/index.php/c-core-guidelines-how-to-pass-function-parameters"
+>parameters</a>, which functions would take in by rvalue reference and only
+<tt class="docutils literal">std::forward</tt> or
+<tt class="docutils literal">boost::forward</tt> to other functions.  Such
+parameters can be <tt class="docutils literal">const</tt> lvalues or mutable
+lvalues.  Therefore, the default configuration grants the most flexibility to
+user code.  However:</p>
+<ul>
+<li>Users can configure one or more parameters to be <em>in</em>
+<a class="reference external" href=
+"http://www.modernescpp.com/index.php/c-core-guidelines-how-to-pass-function-parameters"
+>parameters</a>, which can fall into the same categories as <em>forward</em>
+<a class="reference external" href=
+"http://www.modernescpp.com/index.php/c-core-guidelines-how-to-pass-function-parameters"
+>parameters</a> but are now passed by <tt class="docutils literal">const</tt>
+lvalue reference and so must only be read from.  Continuing from the previous
+example, to indicate that <tt class="docutils literal">root_vertex</tt> and
+<tt class="docutils literal">index_map</tt> are read-only, we wrap their names
+in <tt class="docutils literal">in(…)</tt>.</li>
+<li>Users can configure one or more parameters to be either <em>out</em>
+<a class="reference external" href=
+"http://www.modernescpp.com/index.php/c-core-guidelines-how-to-pass-function-parameters"
+>parameters</a>, which functions would strictly write to, or <em>in-out</em>
+<a class="reference external" href=
+"http://www.modernescpp.com/index.php/c-core-guidelines-how-to-pass-function-parameters"
+>parameters</a>, which functions would both read from and write to.  Such
+parameters can only be mutable lvalues.  In the example, to indicate that
+<tt class="docutils literal">color_map</tt> is read-write, we wrap its name in
+<tt class="docutils literal">in_out(…)</tt>.  Note that Boost.Parameter sees
+no functional difference between <tt class="docutils literal">out(…)</tt> and
+<tt class="docutils literal">in_out(…)</tt>, so you may choose whichever makes
+your interfaces more self-documenting.</li>
+</ul>
 <pre class="compound-last literal-block">
-(optional
-    (visitor,            *, boost::dfs_visitor&lt;&gt;())
-    (root_vertex,        *, *vertices(graph).first)
-    (index_map,          *, get(boost::vertex_index,graph))
-    (<strong>in_out(color_map)</strong>, *,
-      default_color_map(num_vertices(graph), index_map) )
-)
+    BOOST_PARAMETER_NAME(graph)
+    BOOST_PARAMETER_NAME(visitor)
+    BOOST_PARAMETER_NAME(<strong>in(root_vertex)</strong>)
+    BOOST_PARAMETER_NAME(<strong>in(index_map)</strong>)
+    BOOST_PARAMETER_NAME(<strong>in_out(color_map)</strong>)
 </pre>
+<p>In order to see what happens when parameters are bound to arguments that
+violate their category constraints, attempt to compile the
+<a class="reference external" href="../../test/compose.cpp"
+>test/compose.cpp</a> test program with the
+<tt class="docutils literal">LIBS_PARAMETER_TEST_COMPILE_FAILURE_0</tt> macro
+<tt class="docutils literal">#defined</tt>.  You should encounter a compiler
+error caused by a specific constraint violation.</p>
 </div>
 <!-- @example.prepend('''
 #include <boost/parameter.hpp>
 
-namespace boost
-{
-  int vertex_index = 0;
+namespace boost {
 
-  template <class T = int>
-  struct dfs_visitor
-  {};
+    int vertex_index = 0;
+
+    template <typename T = int>
+    struct dfs_visitor
+    {
+    };
 }
-
-BOOST_PARAMETER_NAME(graph)
-
-BOOST_PARAMETER_NAME(visitor)
-BOOST_PARAMETER_NAME(root_vertex)
-BOOST_PARAMETER_NAME(index_map)
-BOOST_PARAMETER_NAME(color_map)
-
-BOOST_PARAMETER_FUNCTION((void), f, tag,
-  (required (graph, *))
 ''') -->
-<!-- @example.append(') {}') -->
+<!-- @example.append('''
+BOOST_PARAMETER_FUNCTION((void), f, tag,
+    (required (graph, *))
+    (optional
+        (visitor,     *, boost::dfs_visitor&lt;&gt;())
+        (root_vertex, *, *vertices(graph).first)
+        (index_map,   *, get(boost::vertex_index, graph))
+        (color_map,   *,
+            default_color_map(num_vertices(graph), index_map)
+        )
+    )
+)
+{
+}
+''') -->
 <!-- @test('compile') -->
-<p>If <tt class="docutils literal">color_map</tt> were strictly going to be modified but not examined,
-we could have written <tt class="docutils literal">out(color_map)</tt>.  There is no functional
-difference between <tt class="docutils literal">out</tt> and <tt class="docutils literal">in_out</tt>; the library provides
-both so you can make your interfaces more self-documenting.</p>
 </div>
 <div class="section" id="positional-arguments">
 <h4>2.1.5.4&nbsp;&nbsp;&nbsp;Positional Arguments</h4>
-<p>When arguments are passed positionally (without the use of
-keywords), they will be mapped onto parameters in the order the
-parameters are given in the signature, so for example in this
-call</p>
+<p>When arguments are passed positionally (without the use of keywords), they
+will be mapped onto parameters in the order the parameters are given in the
+signature, so for example in this call</p>
 <pre class="literal-block">
 graphs::depth_first_search(x, y);
 </pre>
 <!-- @ignore() -->
-<p><tt class="docutils literal">x</tt> will always be interpreted as a graph and <tt class="docutils literal">y</tt> will always
-be interpreted as a visitor.</p>
+<p><tt class="docutils literal">x</tt> will always be interpreted as a graph
+and <tt class="docutils literal">y</tt> will always be interpreted as a
+visitor.</p>
 </div>
 <div class="section" id="default-expression-evaluation">
 <h4>2.1.5.5&nbsp;&nbsp;&nbsp;Default Expression Evaluation</h4>
@@ -639,7 +673,7 @@ used in the default expressions for <tt class="docutils literal">root_vertex</tt
   (visitor,           *, boost::dfs_visitor&lt;&gt;())
   (root_vertex,       *, *vertices(<strong>graph</strong>).first)
   (index_map,         *, get(boost::vertex_index,<strong>graph</strong>))
-  (in_out(color_map), *,
+  (color_map,         *,
     default_color_map(num_vertices(<strong>graph</strong>), index_map) )
 )
 </pre>
@@ -689,7 +723,7 @@ BOOST_PARAMETER_NAME(graph)
 BOOST_PARAMETER_NAME(visitor)
 BOOST_PARAMETER_NAME(root_vertex)
 BOOST_PARAMETER_NAME(index_map)
-BOOST_PARAMETER_NAME(color_map)''') -->
+BOOST_PARAMETER_NAME(in_out(color_map))''') -->
 <!-- @example.replace_emphasis('''
 , (required
     (graph, *)
@@ -861,7 +895,7 @@ BOOST_PARAMETER_FUNCTION(
           &gt;)</strong>
         , get(boost::vertex_index,graph))
 
-      (in_out(color_map)
+      (color_map
         , <strong>*(boost::is_same&lt;
               vertex_descriptor&lt;graphs::graph::_&gt;, key_type&lt;_&gt;
           &gt;)</strong>
@@ -878,7 +912,7 @@ BOOST_PARAMETER_NAME((_graph, graphs) graph)
 BOOST_PARAMETER_NAME((_visitor, graphs) visitor)
 BOOST_PARAMETER_NAME((_root_vertex, graphs) root_vertex)
 BOOST_PARAMETER_NAME((_index_map, graphs) index_map)
-BOOST_PARAMETER_NAME((_color_map, graphs) color_map)
+BOOST_PARAMETER_NAME((_color_map, graphs) in_out(color_map))
 
 using boost::mpl::_;
 ''') -->

--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -315,34 +315,283 @@ arguments that will be matched by <a class="reference external" href="index.html
 </tbody>
 </table>
 <pre class="literal-block">
-template &lt;class Tag&gt;
+template &lt;typename Tag&gt;
 struct keyword
 {
-    template &lt;class T&gt; <a class="reference internal" href="#argumentpack"><span class="concept">ArgumentPack</span></a> <a class="reference internal" href="#operator">operator=</a>(T&amp; value) const;
-    template &lt;class T&gt; <a class="reference internal" href="#argumentpack"><span class="concept">ArgumentPack</span></a> <a class="reference internal" href="#operator">operator=</a>(T const&amp; value) const;
+    template &lt;typename T&gt;
+    typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">enable_if</tt></a>&lt;
+        typename boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/eval-if.html"><tt
+class="docutils literal">eval_if</tt></a>&lt;
+            boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_scalar.html"
+><tt class="docutils literal">is_scalar</tt></a>&lt;T&gt;
+          , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+          , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/eval-if.html"><tt
+class="docutils literal">eval_if</tt></a>&lt;
+                boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_same.html"
+><tt class="docutils literal">is_same</tt></a>&lt;
+                    typename Tag::qualifier
+                  , boost::parameter::in_reference
+                &gt;
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/if.html"><tt
+class="docutils literal">if_</tt></a>&lt;
+                    boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_same.html"
+><tt class="docutils literal">is_same</tt></a>&lt;
+                        typename Tag::qualifier
+                      , boost::parameter::forward_reference
+                    &gt;
+                  , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+                  , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">false_</tt></a>
+                &gt;
+            &gt;
+        &gt;::type
+      , <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a>
+    &gt;::type constexpr
+        <a class="reference internal"
+href="#operator">operator=</a>(T const&amp; value) const;
 
-    template &lt;class T&gt; <em>tagged default</em> <a class="reference internal" href="#id9">operator|</a>(T&amp; x) const;
-    template &lt;class T&gt; <em>tagged default</em> <a class="reference internal" href="#id9">operator|</a>(T const&amp; x) const;
+    template &lt;typename T&gt;
+    typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">enable_if</tt></a>&lt;
+        typename boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/eval-if.html"><tt
+class="docutils literal">eval_if</tt></a>&lt;
+            typename boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/eval-if.html"><tt
+class="docutils literal">eval_if</tt></a>&lt;
+                boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_same.html"
+><tt class="docutils literal">is_same</tt></a>&lt;
+                    typename Tag::qualifier
+                  , boost::parameter::out_reference
+                &gt;
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/if.html"><tt
+class="docutils literal">if_</tt></a>&lt;
+                    boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_same.html"
+><tt class="docutils literal">is_same</tt></a>&lt;
+                        typename Tag::qualifier
+                      , boost::parameter::forward_reference
+                    &gt;
+                  , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+                  , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">false_</tt></a>
+                &gt;
+            &gt;
+          , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/if.html"><tt
+class="docutils literal">if_</tt></a>&lt;
+                boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_const.html"
+><tt class="docutils literal">is_const</tt></a>&lt;T&gt;
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">false_</tt></a>
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+            &gt;
+          , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">false_</tt></a>
+        &gt;::type
+      , <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a>
+    &gt;::type constexpr
+        <a class="reference internal"
+href="#operator">operator=</a>(T&amp; value) const;
 
-    template &lt;class F&gt; <em>tagged lazy default</em> <a class="reference internal" href="#id10">operator||</a>(F const&amp;) const;
+    template &lt;typename T&gt;
+    typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">enable_if</tt></a>&lt;
+        typename boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/eval-if.html"><tt
+class="docutils literal">eval_if</tt></a>&lt;
+            boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_scalar.html"
+><tt class="docutils literal">is_scalar</tt></a>&lt;T&gt;
+          , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+          , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/eval-if.html"><tt
+class="docutils literal">eval_if</tt></a>&lt;
+                boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_same.html"
+><tt class="docutils literal">is_same</tt></a>&lt;
+                    typename Tag::qualifier
+                  , boost::parameter::in_reference
+                &gt;
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/if.html"><tt
+class="docutils literal">if_</tt></a>&lt;
+                    boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_same.html"
+><tt class="docutils literal">is_same</tt></a>&lt;
+                        typename Tag::qualifier
+                      , boost::parameter::forward_reference
+                    &gt;
+                  , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+                  , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">false_</tt></a>
+                &gt;
+            &gt;
+        &gt;::type
+      , <em>tagged default</em>
+    &gt;::type constexpr
+        <a class="reference internal"
+href="#id9">operator|</a>(T const&amp; x) const;
 
-    static keyword&lt;Tag&gt;&amp; <a class="reference internal" href="#get">get</a>();
+    template &lt;typename T&gt;
+    typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">enable_if</tt></a>&lt;
+        typename boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/eval-if.html"><tt
+class="docutils literal">eval_if</tt></a>&lt;
+            typename boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/eval-if.html"><tt
+class="docutils literal">eval_if</tt></a>&lt;
+                boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_same.html"
+><tt class="docutils literal">is_same</tt></a>&lt;
+                    typename Tag::qualifier
+                  , boost::parameter::out_reference
+                &gt;
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/if.html"><tt
+class="docutils literal">if_</tt></a>&lt;
+                    boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_same.html"
+><tt class="docutils literal">is_same</tt></a>&lt;
+                        typename Tag::qualifier
+                      , boost::parameter::forward_reference
+                    &gt;
+                  , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+                  , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">false_</tt></a>
+                &gt;
+            &gt;
+          , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/if.html"><tt
+class="docutils literal">if_</tt></a>&lt;
+                boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/reference/is_const.html"
+><tt class="docutils literal">is_const</tt></a>&lt;T&gt;
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">false_</tt></a>
+              , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">true_</tt></a>
+            &gt;
+          , boost::mpl::<a class="reference external"
+href="../../../mpl/doc/refmanual/bool.html"><tt
+class="docutils literal">false_</tt></a>
+        &gt;::type
+      , <em>tagged default</em>
+    &gt;::type constexpr
+        <a class="reference internal"
+href="#id9">operator|</a>(T&amp; x) const;
+
+    template &lt;typename F&gt;
+    <em>tagged lazy default</em> <a class="reference internal"
+href="#id10">operator||</a>(F const&amp;) const;
+
+    template &lt;typename F&gt;
+    <em>tagged lazy default</em> <a class="reference internal"
+href="#id10">operator||</a>(F&amp;) const;
+
+    static keyword&lt;Tag&gt; const&amp; <a class="reference internal"
+href="#instance">instance</a>;
+
+    static keyword&lt;Tag&gt;&amp; <a class="reference internal"
+href="#get">get</a>();
 };
 </pre>
 <dl class="docutils" id="operator">
 <dt><tt class="docutils literal">operator=</tt></dt>
-<dd><pre class="first literal-block">
-template &lt;class T&gt; <a class="reference internal" href="#argumentpack"><span class="concept">ArgumentPack</span></a> operator=(T&amp; value) const;
-template &lt;class T&gt; <a class="reference internal" href="#argumentpack"><span class="concept">ArgumentPack</span></a> operator=(T const&amp; value) const;
+<dd>
+<pre class="first literal-block">
+template &lt;typename T&gt; <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a
+> operator=(T const&amp; value) const;
+template &lt;typename T&gt; <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a
+> operator=(T&amp; value) const;
 </pre>
 <table class="last docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">
-<tr class="field"><th class="field-name">Requires:</th><td class="field-body">nothing</td>
+<tr class="field">
+<th class="field-name">Requires:</th>
+<td class="field-body">one of the following:
+<ul>
+<li>The nested <tt class="docutils literal">qualifier</tt> type of
+<tt class="docutils literal">Tag</tt> must be
+<tt class="docutils literal">forward_reference</tt>.</li>
+<li>To use the <tt class="docutils literal">const</tt> lvalue reference
+overload, <tt class="docutils literal">T</tt> must be scalar, or the nested
+<tt class="docutils literal">qualifier</tt> type of
+<tt class="docutils literal">Tag</tt> must be
+<tt class="docutils literal">in_reference</tt>.</li>
+<li>To use the mutable lvalue reference overload, the nested
+<tt class="docutils literal">qualifier</tt> type of
+<tt class="docutils literal">Tag</tt> must be
+<tt class="docutils literal">out_reference</tt> or
+<tt class="docutils literal">in_out_reference</tt>, and
+<tt class="docutils literal">T</tt> must not be
+<tt class="docutils literal">const</tt>-qualified.</li>
+</ul>
+</td>
 </tr>
-<tr class="field"><th class="field-name">Returns:</th><td class="field-body">an <a class="reference internal" href="#argumentpack"><span class="concept">ArgumentPack</span></a>  containing a single <a class="reference internal" href="#tagged-reference">tagged reference</a> to
-<tt class="docutils literal">value</tt> with <a class="reference internal" href="#kw">keyword</a> <tt class="docutils literal">Tag</tt></td>
+<tr class="field">
+<th class="field-name">Returns:</th>
+<td class="field-body">an <a class="reference internal"
+href="#argumentpack"><span class="concept">ArgumentPack</span></a> containing
+a single <a class="reference internal" href="#tagged-reference">tagged
+reference</a> to <tt class="docutils literal">value</tt> with
+<a class="reference internal" href="#kw">keyword</a>
+<tt class="docutils literal">Tag</tt></td>
 </tr>
 </tbody>
 </table>
@@ -351,14 +600,44 @@ template &lt;class T&gt; <a class="reference internal" href="#argumentpack"><spa
 <dl class="docutils" id="id9">
 <dt><tt class="docutils literal">operator|</tt></dt>
 <dd><pre class="first literal-block">
-template &lt;class T&gt; <em>tagged default</em> operator|(T&amp; x) const;
-template &lt;class T&gt; <em>tagged default</em> operator|(T const&amp; x) const;
+template &lt;typename T&gt; <em
+>tagged default</em> operator|(T const&amp; x) const;
+template &lt;typename T&gt; <em
+>tagged default</em> operator|(T&amp; x) const;
 </pre>
 <table class="last docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">
-<tr class="field"><th class="field-name">Returns:</th><td class="field-body">a <a class="reference internal" href="#tagged-default">tagged default</a> with <em>value</em> <tt class="docutils literal">x</tt> and <a class="reference internal" href="#kw">keyword</a> <tt class="docutils literal">Tag</tt>.</td>
+<tr class="field">
+<th class="field-name">Requires:</th>
+<td class="field-body">one of the following:
+<ul>
+<li>The nested <tt class="docutils literal">qualifier</tt> type of
+<tt class="docutils literal">Tag</tt> must be
+<tt class="docutils literal">forward_reference</tt>.</li>
+<li>To use the <tt class="docutils literal">const</tt> lvalue reference
+overload, <tt class="docutils literal">T</tt> must be scalar, or the nested
+<tt class="docutils literal">qualifier</tt> type of
+<tt class="docutils literal">Tag</tt> must be
+<tt class="docutils literal">in_reference</tt>.</li>
+<li>To use the mutable lvalue reference overload, the nested
+<tt class="docutils literal">qualifier</tt> type of
+<tt class="docutils literal">Tag</tt> must be
+<tt class="docutils literal">out_reference</tt> or
+<tt class="docutils literal">in_out_reference</tt>, and
+<tt class="docutils literal">T</tt> must not be
+<tt class="docutils literal">const</tt>-qualified.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name">Returns:</th>
+<td class="field-body">a <a class="reference internal"
+href="#tagged-default">tagged default</a> with <em>value</em>
+<tt class="docutils literal">x</tt> and
+<a class="reference internal" href="#kw">keyword</a>
+<tt class="docutils literal">Tag</tt>.</td>
 </tr>
 </tbody>
 </table>
@@ -366,16 +645,56 @@ template &lt;class T&gt; <em>tagged default</em> operator|(T const&amp; x) const
 </dl>
 <dl class="docutils" id="id10">
 <dt><tt class="docutils literal">operator||</tt></dt>
-<dd><pre class="first literal-block">
-template &lt;class F&gt; <em>tagged lazy default</em> operator||(F const&amp; g) const;
+<dd>
+<pre class="first literal-block">
+template &lt;typename F&gt; <em
+>tagged lazy default</em> operator||(F const&amp; g) const;
+template &lt;typename F&gt; <em
+>tagged lazy default</em> operator||(F&amp; g) const;
 </pre>
 <table class="last docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">
-<tr class="field"><th class="field-name">Requires:</th><td class="field-body"><tt class="docutils literal">g()</tt> is valid, with type <tt class="docutils literal">boost::</tt><a class="reference external" href="../../../utility/utility.htm#result_of"><tt class="docutils literal">result_of</tt></a><tt class="docutils literal"><span class="pre">&lt;F()&gt;::type</span></tt>.<a class="footnote-reference" href="#no-result-of" id="id11"><sup>2</sup></a></td>
+<tr class="field">
+<th class="field-name">Requires:</th>
+<td class="field-body"><tt class="docutils literal">g()</tt> is valid, with
+type <tt class="docutils literal">boost::</tt><a class="reference external"
+href="../../../utility/utility.htm#result_of"><tt class="docutils literal"
+>result_of</tt></a><tt class="docutils literal"><span class="pre"
+>&lt;F()&gt;::type</span></tt>.<a class="footnote-reference"
+href="#no-result-of" id="id11"><sup>2</sup></a></td>
 </tr>
-<tr class="field"><th class="field-name">Returns:</th><td class="field-body">a <a class="reference internal" href="#tagged-lazy-default">tagged lazy default</a> with <em>value</em> <tt class="docutils literal">g</tt> and <a class="reference internal" href="#kw">keyword</a> <tt class="docutils literal">Tag</tt>.</td>
+<tr class="field">
+<th class="field-name">Returns:</th>
+<td class="field-body">a <a class="reference internal"
+href="#tagged-lazy-default">tagged lazy default</a> with <em>value</em>
+<tt class="docutils literal">g</tt> and <a class="reference internal"
+href="#kw">keyword</a> <tt class="docutils literal">Tag</tt>.</td>
+</tr>
+</tbody>
+</table>
+</dd>
+</dl>
+<dl class="docutils" id="instance">
+<dt><tt class="docutils literal">instance</tt></dt>
+<dd><pre class="first literal-block">
+static keyword&lt;Tag&gt; const&amp; instance;
+</pre>
+<table class="last docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Returns:</th>
+<td class="field-body">a “singleton instance”: the same object will be
+returned on each invocation of
+<tt class="docutils literal">instance</tt>.</td>
+</tr>
+<tr class="field">
+<th class="field-name">Thread Safety:</th>
+<td class="field-body"><tt class="docutils literal">instance</tt> can be
+accessed from multiple threads simultaneously.</td>
 </tr>
 </tbody>
 </table>
@@ -386,15 +705,25 @@ template &lt;class F&gt; <em>tagged lazy default</em> operator||(F const&amp; g)
 <dd><pre class="first literal-block">
 static keyword&lt;Tag&gt;&amp; get();
 </pre>
+<div class="admonition-deprecated admonition">
+<p class="first admonition-title">Deprecated</p>
+<p class="last">This macro has been deprecated in favor of
+<tt class="docutils literal">instance</tt>.</p>
+</div>
 <table class="last docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">
-<tr class="field"><th class="field-name">Returns:</th><td class="field-body">a “singleton instance”: the same object will be
-returned on each invocation of <tt class="docutils literal">get()</tt>.</td>
+<tr class="field">
+<th class="field-name">Returns:</th>
+<td class="field-body">a “singleton instance”: the same object will be
+returned on each invocation of
+<tt class="docutils literal">get()</tt>.</td>
 </tr>
-<tr class="field"><th class="field-name">Thread Safety:</th><td class="field-body"><tt class="docutils literal">get()</tt> can be called from multiple threads
-simultaneously.</td>
+<tr class="field">
+<th class="field-name">Thread Safety:</th>
+<td class="field-body"><tt class="docutils literal">get()</tt> can be called
+from multiple threads simultaneously.</td>
 </tr>
 </tbody>
 </table>
@@ -1187,50 +1516,120 @@ methods are <tt class="docutils literal">const</tt>-qualified.</p>
 macro.</p>
 </div>
 <div class="section" id="boost-parameter-name-name">
-<h2><a class="toc-backref" href="#id58">6.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal">BOOST_PARAMETER_NAME(name)</tt></a></h2>
+<h2><a class="toc-backref" href="#id58">6.10&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NAME(name)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/name.hpp">boost/parameter/name.hpp</a></td>
+</tr>
+</tbody>
+</table>
 <p>Declares a tag-type and keyword object.</p>
-<p>Expands to:</p>
 <p><strong>If</strong> <em>name</em> is of the form:</p>
 <pre class="literal-block">
-(<em>tag-name</em>, <em>namespace-name</em>) <em>object-name</em>
+(<em>object-name</em>, <em>namespace-name</em>) <em>qualifier</em>(<em
+>tag-name</em>)
 </pre>
 <p><strong>then</strong></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Requires:</th>
+<td class="field-body">
+<p class="first"><em>qualifier</em> is either <tt class="docutils literal"
+>in</tt>, <tt class="docutils literal">out</tt>, <tt class="docutils literal"
+>in_out</tt>, <tt class="docutils literal">consume</tt>, <tt
+class="docutils literal">move_from</tt>, or <tt class="docutils literal"
+>forward</tt>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<p>Expands to:</p>
 <pre class="literal-block">
-namespace <em>namespace-name</em>
-{
-  struct <em>tag-name</em>
-  {
-      static char const* keyword_name()
-      {
-          return ##<em>tag-name</em>;
-      }
+namespace <em>namespace-name</em> {
 
-      typedef <em>unspecified</em> _;
-      typedef <em>unspecified</em> _1;
-  };
+    struct <em>tag-name</em>
+    {
+        static char const* keyword_name()
+        {
+            return ##<em>tag-name</em>;
+        }
+
+        typedef <em>unspecified</em> _;
+        typedef <em>unspecified</em> _1;
+        typedef boost::parameter::<em>qualifier</em> ## _reference qualifier;
+    };
 }
 
-::boost::parameter::keyword&lt;<em>tag-namespace</em>::<em>tag-name</em>&gt; const&amp; <em>object-name</em>
-    = ::boost::parameter::keyword&lt;<em>tag-namespace</em>::<em>tag-name</em>&gt;::instance;
+::boost::parameter::keyword&lt;<em>tag-namespace</em>::<em
+>tag-name</em>&gt; const&amp;
+    <em>object-name</em> = ::boost::parameter::keyword&lt;
+        <em>tag-namespace</em>::<em>tag-name</em>
+    &gt;::instance;
+</pre>
+<p><strong>Else If</strong> <em>name</em> is of the form:</p>
+<pre class="literal-block">
+(<em>object-name</em>, <em>namespace-name</em>) <em>tag-name</em>
+</pre>
+<p><strong>then</strong></p>
+<p>Treats <em>name</em> as if it were of the form:</p>
+<pre class="literal-block">
+(<em>object-name</em>, <em>namespace-name</em>) forward(<em>tag-name</em>)
+</pre>
+<p><strong>Else If</strong> <em>name</em> is of the form:</p>
+<pre class="literal-block">
+<em>qualifier</em>(<em>tag-name</em>)
+</pre>
+<p><strong>then</strong></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Requires:</th>
+<td class="field-body">
+<p class="first"><em>qualifier</em> is either <tt class="docutils literal"
+>in</tt>, <tt class="docutils literal">out</tt>, <tt class="docutils literal"
+>in_out</tt>, <tt class="docutils literal">consume</tt>, <tt
+class="docutils literal">move_from</tt>, or <tt class="docutils literal"
+>forward</tt>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<p>Expands to:</p>
+<pre class="literal-block">
+namespace tag {
+
+    struct <em>tag-name</em>
+    {
+        static char const* keyword_name()
+        {
+            return ##<em>tag-name</em>;
+        }
+
+        typedef <em>unspecified</em> _;
+        typedef <em>unspecified</em> _1;
+        typedef boost::parameter::<em>qualifier</em> ## _reference qualifier;
+    };
+}
+
+::boost::parameter::keyword&lt;tag::<em>tag-name</em>&gt; const&amp; _ ## <em
+>tag-name</em>
+    = ::boost::parameter::keyword&lt;tag::<em>tag-name</em>&gt;::instance;
 </pre>
 <p><strong>Else</strong></p>
+<p>Treats <em>name</em> as if it were of the form:</p>
 <pre class="literal-block">
-namespace tag
-{
-  struct <em>name</em>
-  {
-      static char const* keyword_name()
-      {
-          return ##<em>name</em>;
-      }
-
-      typedef <em>unspecified</em> _;
-      typedef <em>unspecified</em> _1;
-  };
-}
-
-::boost::parameter::keyword&lt;tag::<em>name</em>&gt; const&amp; _<em>name</em>
-    = ::boost::parameter::keyword&lt;tag::<em>name</em>&gt;::instance;
+forward(<em>tag-name</em>)
 </pre>
 </div>
 <div class="section" id="boost-parameter-template-keyword-name">

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -1,6 +1,6 @@
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- The Boost Parameter Library Reference Documentation 
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+The Boost Parameter Library Reference Documentation 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 :Authors:       David Abrahams, Daniel Wallin
 :Contact:       dave@boost-consulting.com, daniel@boostpro.com
@@ -8,14 +8,14 @@
 :date:          $Date: 2005/07/17 19:53:01 $
 
 :copyright:     Copyright David Abrahams, Daniel Wallin
-                2005-2009. Distributed under the Boost Software License,
-                Version 1.0. (See accompanying file LICENSE_1_0.txt
+                2005-2009.  Distributed under the Boost Software License,
+                Version 1.0.  (See accompanying file LICENSE_1_0.txt
                 or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 |(logo)|__
 
 .. |(logo)| image:: ../../../../boost.png
-   :alt: Boost
+    :alt: Boost
 
 __ ../../../../index.htm
 
@@ -289,71 +289,222 @@ __ ../../../../boost/parameter/keyword.hpp
 
 .. parsed-literal::
 
-    template <class Tag>
+    template <typename Tag>
     struct keyword
     {
-        template <class T> |ArgumentPack|_ `operator=`_\(T& value) const;
-        template <class T> |ArgumentPack|_ `operator=`_\(T const& value) const;
+        template <typename T>
+        typename boost::`enable_if`_<
+            typename boost::mpl::`eval_if_`_<
+                boost::`is_scalar`_<T>
+              , boost::mpl::`true_`_
+              , boost::mpl::`eval_if_`_<
+                    boost::`is_same`_<
+                        typename Tag::qualifier
+                      , boost::parameter::in_reference
+                    >
+                  , boost::mpl::`true_`_
+                  , boost::mpl::`if_`_<
+                        boost::`is_same`_<
+                            typename Tag::qualifier
+                          , boost::parameter::forward_reference
+                        >
+                      , boost::mpl::`true_`_
+                      , boost::mpl::`false_`_
+                    >
+                >
+            >::type
+          , |ArgumentPack|_
+        >::type constexpr
+            `operator=`_\(T const& value) const;
 
-        template <class T> *tagged default* `operator|`_\(T& x) const;
-        template <class T> *tagged default* `operator|`_\(T const& x) const;
+        template <typename T>
+        typename boost::`enable_if`_<
+            typename boost::mpl::`eval_if_`_<
+                typename boost::mpl::`eval_if_`_<
+                    boost::`is_same`_<
+                        typename Tag::qualifier
+                      , boost::parameter::out_reference
+                    >
+                  , boost::mpl::`true_`_
+                  , boost::mpl::`if_`_<
+                        boost::`is_same`_<
+                            typename Tag::qualifier
+                          , boost::parameter::forward_reference
+                        >
+                      , boost::mpl::`true_`_
+                      , boost::mpl::`false_`_
+                    >
+                >::type
+              , boost::mpl::`if_`_<
+                    boost::`is_const`_<T>
+                  , boost::mpl::`false_`_
+                  , boost::mpl::`true_`_
+                >
+              , boost::mpl::`false_`_
+            >::type
+          , |ArgumentPack|_
+        >::type constexpr
+            `operator=`_\(T& value) const;
 
-        template <class F> *tagged lazy default* `operator||`_\(F const&) const;
+        template <typename T>
+        typename boost::`enable_if`_<
+            typename boost::mpl::`eval_if_`_<
+                boost::`is_scalar`_<T>
+              , boost::mpl::`true_`_
+              , boost::mpl::`eval_if_`_<
+                    boost::`is_same`_<
+                        typename Tag::qualifier
+                      , boost::parameter::in_reference
+                    >
+                  , boost::mpl::`true_`_
+                  , boost::mpl::`if_`_<
+                        boost::`is_same`_<
+                            typename Tag::qualifier
+                          , boost::parameter::forward_reference
+                        >
+                      , boost::mpl::`true_`_
+                      , boost::mpl::`false_`_
+                    >
+                >
+            >::type
+          , *tagged default*
+        >::type
+            `operator|`_\(T const& x) const;
+
+        template <typename T>
+        typename boost::`enable_if`_<
+            typename boost::mpl::`eval_if_`_<
+                typename boost::mpl::`eval_if_`_<
+                    boost::`is_same`_<
+                        typename Tag::qualifier
+                      , boost::parameter::out_reference
+                    >
+                  , boost::mpl::`true_`_
+                  , boost::mpl::`if_`_<
+                        boost::`is_same`_<
+                            typename Tag::qualifier
+                          , boost::parameter::forward_reference
+                        >
+                      , boost::mpl::`true_`_
+                      , boost::mpl::`false_`_
+                    >
+                >::type
+              , boost::mpl::`if_`_<
+                    boost::`is_const`_<T>
+                  , boost::mpl::`false_`_
+                  , boost::mpl::`true_`_
+                >
+              , boost::mpl::`false_`_
+            >::type
+          , *tagged default*
+        >::type
+            `operator|`_\(T& x) const;
+
+        template <typename F>
+        *tagged lazy default* `operator||`_\(F const&) const;
+
+        template <typename F>
+        *tagged lazy default* `operator||`_\(F&) const;
+
+        static keyword<Tag> const& instance;
 
         static keyword<Tag>& get_\();
     };
 
+.. _enable_if: ../../../core/doc/html/core/enable_if.html
+.. _eval_if_: ../../../mpl/doc/refmanual/eval-if.html
+.. _false_: ../../../mpl/doc/refmanual/bool.html
+.. _if_: ../../../mpl/doc/refmanual/if.html
+.. _is_const: ../../../type_traits/doc/html/boost_typetraits/reference/is_const.html
+.. _is_same: ../../../type_traits/doc/html/boost_typetraits/reference/is_same.html
+.. _is_scalar: ../../../type_traits/doc/html/boost_typetraits/reference/is_scalar.html
+.. _true_: ../../../mpl/doc/refmanual/bool.html
 
 .. |operator=| replace:: ``operator=``
 .. _operator=:
 
 ``operator=``
-  .. parsed-literal::
+.. parsed-literal::
 
-      template <class T> |ArgumentPack|_ operator=(T& value) const;
-      template <class T> |ArgumentPack|_ operator=(T const& value) const;
+    template <typename T> |ArgumentPack|_ operator=(T const& value) const;
+    template <typename T> |ArgumentPack|_ operator=(T& value) const;
 
-  :Requires: nothing
+:Requires: one of the following:
 
-  :Returns:
-      an |ArgumentPack|_  containing a single |tagged reference| to
-      ``value`` with |kw|_ ``Tag`` 
+\*. The nested ``qualifier`` type of ``Tag`` must be ``forward_reference``.
+
+\*. To use the ``const`` lvalue reference overload, ``T`` must be scalar, or
+the nested ``qualifier`` type of ``Tag`` must be ``in_reference``.
+
+\*. To use the mutable lvalue reference overload, the nested ``qualifier``
+type of ``Tag`` must be ``out_reference`` or ``in_out_reference``, and ``T``
+must not be ``const``-qualified.
+
+:Returns: an |ArgumentPack|_  containing a single |tagged reference| to
+``value`` with |kw|_ ``Tag`` 
 
 .. _operator|:
 
 ``operator|``
-  .. parsed-literal::
+.. parsed-literal::
 
-      template <class T> *tagged default* operator|(T& x) const;
-      template <class T> *tagged default* operator|(T const& x) const;
+    template <typename T> *tagged default* operator|(T const& x) const;
+    template <typename T> *tagged default* operator|(T& x) const;
 
-  :Returns: a |tagged default| with *value* ``x`` and |kw|_ ``Tag``.
+:Requires: one of the following:
+
+\*. The nested ``qualifier`` type of ``Tag`` must be ``forward_reference``.
+
+\*. To use the ``const`` lvalue reference overload, ``T`` must be scalar, or
+the nested ``qualifier`` type of ``Tag`` must be ``in_reference``.
+
+\*. To use the mutable lvalue reference overload, the nested ``qualifier``
+type of ``Tag`` must be ``out_reference`` or ``in_out_reference``, and ``T``
+must not be ``const``-qualified.
+
+:Returns: a |tagged default| with *value* ``x`` and |kw|_ ``Tag``.
 
 .. _operator||:
 
 ``operator||``
-  .. parsed-literal::
+.. parsed-literal::
 
-      template <class F> *tagged lazy default* operator||(F const& g) const;
+    template <typename F> *tagged lazy default* operator||(F const& g) const;
+    template <typename F> *tagged lazy default* operator||(F& g) const;
 
-  :Requires: ``g()`` is valid, with type ``boost::``\ |result_of|_\
-    ``<F()>::type``.  [#no_result_of]_
+:Requires: ``g()`` must be valid, with type ``boost::``\ |result_of|_\
+``<F()>::type``.  [#no_result_of]_
 
+:Returns: a |tagged lazy default| with *value* ``g`` and |kw|_ ``Tag``.
 
-  :Returns: a |tagged lazy default| with *value* ``g`` and |kw|_ ``Tag``.
+.. _instance:
+
+``instance``
+.. parsed-literal::
+
+    static keyword<Tag> const& instance;
+
+:Returns: a “singleton instance”: the same object will be returned on each
+invocation of ``instance``.
+
+:Thread Safety:
+``instance`` can be accessed from multiple threads simultaneously.
 
 .. _get:
 
 ``get``
-  .. parsed-literal::
+.. parsed-literal::
 
-        static keyword<Tag>& get\();
+    static keyword<Tag>& get\();
 
-  :Returns: a “singleton instance”: the same object will be
-    returned on each invocation of ``get()``.
+.. admonition:: Deprecated
 
-  :Thread Safety: ``get()`` can be called from multiple threads
-    simultaneously.
+    This function has been deprecated in favor of ``instance``.
+
+:Returns: a “singleton instance”: the same object will be returned on each
+invocation of ``get()``.
+
+:Thread Safety: ``get()`` can be called from multiple threads simultaneously.
 
 ``parameters``
 --------------
@@ -951,57 +1102,99 @@ The |preprocessor|_ test program demonstrates proper usage of this macro.
 ``BOOST_PARAMETER_NAME(name)``
 ------------------------------
 
-Declares a tag-type and keyword object.
+:Defined in: `boost/parameter/name.hpp`__
 
-Expands to:
+__ ../../../../boost/parameter/name.hpp
+
+Declares a tag-type and keyword object.
 
 **If** *name* is of the form:
 
 .. parsed-literal::
 
-  (*tag-name*, *namespace-name*) *object-name*
+    (*object-name*, *namespace-name*) *qualifier*\ (*tag-name*)
 
 **then**
 
+:Requires: *qualifier* is either ``in``, ``out``, ``in_out``, or ``forward``.
+
+Expands to:
+
 .. parsed-literal::
 
-  namespace *namespace-name* 
-  {
-    struct *tag-name*
-    {
-        static char const* keyword_name()
+    namespace *namespace-name* {
+
+        struct *tag-name*
         {
-            return ##\ *tag-name*;
-        }
+            static char const* keyword_name()
+            {
+                return ## *tag-name*;
+            }
 
-        typedef *unspecified* _;
-        typedef *unspecified* _1;
-    };
-  }
+            typedef *unspecified* _;
+            typedef *unspecified* _1;
+            typedef boost::parameter::*qualifier* ## _reference qualifier;
+        };
+    }
 
-  ::boost::parameter::keyword<*tag-namespace*\ ::\ *tag-name*\ > const& *object-name*
-      = ::boost::parameter::keyword<*tag-namespace*\ ::\ *tag-name*\ >::instance;
+    ::boost::parameter::keyword<*tag-namespace* :: *tag-name* > const&
+        *object-name* = ::boost::parameter::keyword<
+            *tag-namespace* :: *tag-name*
+        >::instance;
+
+**Else If** *name* is of the form:
+
+.. parsed-literal::
+
+    (*tag-name*, *namespace-name*) *object-name*
+
+**then**
+
+Treats *name* as if it were of the form:
+
+.. parsed-literal::
+
+    (forward(*tag-name*), *namespace-name*) *object-name*
+
+**Else If** *name* is of the form:
+
+.. parsed-literal::
+
+    *qualifier*\ (*tag-name*)
+
+**then**
+
+:Requires: *qualifier* is either ``in``, ``out``, ``in_out``, or ``forward``.
+
+Expands to:
+
+.. parsed-literal::
+
+    namespace tag {
+
+        struct *tag-name*
+        {
+            static char const* keyword_name()
+            {
+                return ## *tag-name*;
+            }
+
+            typedef *unspecified* _;
+            typedef *unspecified* _1;
+            typedef boost::parameter::*qualifier* ## _reference qualifier;
+        };
+    }
+
+    ::boost::parameter::keyword<tag:: *tag-name* > const& _ ## *tag-name*
+        = ::boost::parameter::keyword<tag:: *tag-name* >::instance;
 
 **Else**
 
+Treats *name* as if it were of the form:
+
 .. parsed-literal::
 
-  namespace tag
-  {
-    struct *name*
-    {
-        static char const* keyword_name()
-        {
-            return ##\ *name*;
-        }
-
-        typedef *unspecified* _;
-        typedef *unspecified* _1;
-    };
-  }
-
-  ::boost::parameter::keyword<tag::\ *name*\ > const& _\ *name*
-      = ::boost::parameter::keyword<tag::\ *name*\ >::instance;
+    forward(*tag-name*)
 
 
 ``BOOST_PARAMETER_TEMPLATE_KEYWORD(name)``

--- a/include/boost/parameter/aux_/preprocessor/impl/forwarding_overloads.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/forwarding_overloads.hpp
@@ -16,40 +16,32 @@
     template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename p)>
 /**/
 
-#include <boost/preprocessor/punctuation/comma_if.hpp>
 #include <boost/preprocessor/cat.hpp>
-
-#define BOOST_PARAMETER_FUNCTION_ARGUMENT(r, _, i, elem)                     \
-    BOOST_PP_COMMA_IF(i) elem& BOOST_PP_CAT(a, i)
-/**/
-
-#include <boost/parameter/aux_/preprocessor/qualifier.hpp>
-#include <boost/preprocessor/control/if.hpp>
 #include <boost/config.hpp>
 
 #if defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
 // No partial ordering.  This feature doesn't work.
 #define BOOST_PARAMETER_FUNCTION_FORWARD_COMBINATION(r, _, i, elem)          \
-    (BOOST_PP_IF(                                                            \
-        BOOST_PARAMETER_IS_QUALIFIER(                                        \
-            BOOST_PARAMETER_FN_ARG_KEYWORD(elem)                             \
-        )                                                                    \
-      , (BOOST_PP_CAT(ParameterArgumentType, i))                             \
-      , (BOOST_PP_CAT(ParameterArgumentType, i) const)                       \
-    ))
+    ((BOOST_PP_CAT(ParameterArgumentType, i)))
 /**/
 #else
 #define BOOST_PARAMETER_FUNCTION_FORWARD_COMBINATION(r, _, i, elem)          \
-    (BOOST_PP_IF(                                                            \
-        BOOST_PARAMETER_IS_QUALIFIER(                                        \
-            BOOST_PARAMETER_FN_ARG_KEYWORD(elem)                             \
-        )                                                                    \
-      , (BOOST_PP_CAT(ParameterArgumentType, i) const)                       \
+    (                                                                        \
+        (BOOST_PP_CAT(ParameterArgumentType, i) const)                       \
         (BOOST_PP_CAT(ParameterArgumentType, i))                             \
-      , (BOOST_PP_CAT(ParameterArgumentType, i) const)                       \
-    ))
+    )
 /**/
 #endif  // BOOST_NO_FUNCTION_TEMPLATE_ORDERING
+
+#include <boost/preprocessor/punctuation/comma_if.hpp>
+
+// Expands to a definition of a constructor or forwarding function argument
+// passed by lvalue reference.  Used by
+// BOOST_PARAMETER_CONSTRUCTOR_OVERLOAD_IMPL and
+// BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_IMPL.
+#define BOOST_PARAMETER_FUNCTION_ARGUMENT(r, _, i, elem)                     \
+    BOOST_PP_COMMA_IF(i) elem& BOOST_PP_CAT(a, i)
+/**/
 
 #include <boost/preprocessor/seq/for_each_i.hpp>
 
@@ -62,6 +54,7 @@
 #include <boost/parameter/aux_/preprocessor/impl/function_forward_match.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
 #include <boost/preprocessor/control/expr_if.hpp>
+#include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/repetition/enum.hpp>
 #include <boost/preprocessor/tuple/eat.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>

--- a/include/boost/parameter/aux_/preprocessor/qualifier.hpp
+++ b/include/boost/parameter/aux_/preprocessor/qualifier.hpp
@@ -6,13 +6,26 @@
 #ifndef BOOST_PARAMETER_AUX_PREPROCESSOR_QUALIFIER_HPP
 #define BOOST_PARAMETER_AUX_PREPROCESSOR_QUALIFIER_HPP
 
+#define BOOST_PARAMETER_QUALIFIER_EAT_in(x)
 #define BOOST_PARAMETER_QUALIFIER_EAT_out(x)
 #define BOOST_PARAMETER_QUALIFIER_EAT_in_out(x)
+#define BOOST_PARAMETER_QUALIFIER_EAT_forward(x)
 
+#define BOOST_PARAMETER_GET_QUALIFIER_in(x) in_reference
+#define BOOST_PARAMETER_GET_QUALIFIER_out(x) out_reference
+#define BOOST_PARAMETER_GET_QUALIFIER_in_out(x) in_out_reference
+#define BOOST_PARAMETER_GET_QUALIFIER_forward(x) forward_reference
+
+#define BOOST_PARAMETER_STRIP_QUALIFIER_in(x) x
 #define BOOST_PARAMETER_STRIP_QUALIFIER_out(x) x
 #define BOOST_PARAMETER_STRIP_QUALIFIER_in_out(x) x
+#define BOOST_PARAMETER_STRIP_QUALIFIER_forward(x) x
 
 #include <boost/preprocessor/cat.hpp>
+
+#define BOOST_PARAMETER_GET_QUALIFIER_GET(x) \
+    BOOST_PP_CAT(BOOST_PARAMETER_GET_QUALIFIER_, x)
+/**/
 
 #define BOOST_PARAMETER_GET_UNQUALIFIED(x) \
     BOOST_PP_CAT(BOOST_PARAMETER_STRIP_QUALIFIER_, x)
@@ -20,7 +33,7 @@
 
 #include <boost/preprocessor/facilities/is_empty.hpp>
 
-// Expands to 1 if x is either "out(k)" or "in_out(k)";
+// Expands to 1 if x is "in(k)", "out(k)", "in_out(k)", or "forward(k)";
 // expands to 0 otherwise.
 #define BOOST_PARAMETER_IS_QUALIFIER(x) \
     BOOST_PP_IS_EMPTY(BOOST_PP_CAT(BOOST_PARAMETER_QUALIFIER_EAT_, x))
@@ -28,12 +41,30 @@
 
 #include <boost/preprocessor/control/iif.hpp>
 
+// Expands to the qualifier of x,
+// where x is either a keyword qualifier or a keyword.
+//
+//   k => forward_reference
+//   in(k) => in_reference
+//   out(k) => out_reference
+//   in_out(k) => in_out_reference
+//   forward(k) => forward_reference
+#define BOOST_PARAMETER_GET_QUALIFIER(x) \
+    BOOST_PP_IIF( \
+        BOOST_PARAMETER_IS_QUALIFIER(x) \
+      , BOOST_PARAMETER_GET_QUALIFIER_GET(x) \
+      , forward_reference \
+    )
+/**/
+
 // Expands to the unqualified version of x,
 // where x is either a keyword qualifier or a keyword.
 //
 //   k => k
+//   in(k) => k
 //   out(k) => k
 //   in_out(k) => k
+//   forward(k) => k
 #define BOOST_PARAMETER_UNQUALIFIED(x) \
     BOOST_PP_IIF( \
         BOOST_PARAMETER_IS_QUALIFIER(x) \

--- a/include/boost/parameter/keyword.hpp
+++ b/include/boost/parameter/keyword.hpp
@@ -1,123 +1,239 @@
-// Copyright Daniel Wallin, David Abrahams 2005. Use, modification and
-// distribution is subject to the Boost Software License, Version 1.0. (See
-// accompanying file LICENSE_1_0.txt or copy at
+// Copyright Daniel Wallin, David Abrahams 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef KEYWORD_050328_HPP
 #define KEYWORD_050328_HPP
 
-#include <boost/parameter/keyword_fwd.hpp>
-#include <boost/parameter/aux_/unwrap_cv_reference.hpp>
 #include <boost/parameter/aux_/tag.hpp>
 #include <boost/parameter/aux_/default.hpp>
+#include <boost/parameter/keyword_fwd.hpp>
+#include <boost/config.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/type_traits/is_scalar.hpp>
+#endif  // BOOST_NO_SFINAE
 
 namespace boost { namespace parameter {
 
-// Instances of unique specializations of keyword<...> serve to
-// associate arguments with parameter names.  For example:
-//
-//    struct rate_;           // parameter names
-//    struct skew_;
-//    namespace
-//    {
-//      keyword<rate_> rate;  // keywords
-//      keyword<skew_> skew;
-//    }
-//
-//    ...
-//
-//    f(rate = 1, skew = 2.4);
-//
-template <class Tag>
-struct keyword
-{
-    template <class T>
-    typename aux::tag<Tag, T>::type const
-    operator=(T& x) const
+    // Instances of unique specializations of keyword<...> serve to
+    // associate arguments with parameter names.  For example:
+    //
+    //     struct rate_;             // parameter names
+    //     struct skew_;
+    //
+    //     namespace
+    //     {
+    //         keyword<rate_> rate;  // keywords
+    //         keyword<skew_> skew;
+    //     }
+    //
+    //     ...
+    //
+    //     f(rate = 1, skew = 2.4);
+    template <typename Tag>
+    struct keyword
     {
-        typedef typename aux::tag<Tag, T>::type result;
-        return result(x);
-    }
+        template <typename T>
+#if defined(BOOST_NO_SFINAE)
+        inline typename ::boost::parameter::aux::tag<Tag,T const>::type
+#else
+        inline typename ::boost::lazy_enable_if<
+            typename ::boost::mpl::eval_if<
+                ::boost::is_scalar<T>
+              , ::boost::mpl::true_
+              , ::boost::mpl::eval_if<
+                    ::boost::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::in_reference
+                    >
+                  , ::boost::mpl::true_
+                  , ::boost::mpl::if_<
+                        ::boost::is_same<
+                            typename Tag::qualifier
+                          , ::boost::parameter::forward_reference
+                        >
+                      , ::boost::mpl::true_
+                      , ::boost::mpl::false_
+                    >
+                >
+            >::type
+          , ::boost::parameter::aux::tag<Tag,T const>
+        >::type BOOST_CONSTEXPR
+#endif  // BOOST_NO_SFINAE
+            operator=(T const& x) const
+        {
+            typedef typename ::boost::parameter::aux
+            ::tag<Tag,T const>::type result;
+            return result(x);
+        }
 
-    template <class Default>
-    aux::default_<Tag, Default>
-    operator|(Default& default_) const
-    {
-        return aux::default_<Tag, Default>(default_);
-    }
+        template <typename Default>
+#if defined(BOOST_NO_SFINAE)
+        inline ::boost::parameter::aux::default_<Tag,Default const>
+#else
+        inline typename ::boost::enable_if<
+            typename ::boost::mpl::eval_if<
+                ::boost::is_scalar<Default>
+              , ::boost::mpl::true_
+              , ::boost::mpl::eval_if<
+                    ::boost::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::in_reference
+                    >
+                  , ::boost::mpl::true_
+                  , ::boost::mpl::if_<
+                        ::boost::is_same<
+                            typename Tag::qualifier
+                          , ::boost::parameter::forward_reference
+                        >
+                      , ::boost::mpl::true_
+                      , ::boost::mpl::false_
+                    >
+                >
+            >::type
+          , ::boost::parameter::aux::default_<Tag,Default const>
+        >::type
+#endif  // BOOST_NO_SFINAE
+            operator|(Default const& d) const
+        {
+            return ::boost::parameter::aux::default_<Tag,Default const>(d);
+        }
 
-    template <class Default>
-    aux::lazy_default<Tag, Default>
-    operator||(Default& default_) const
-    {
-        return aux::lazy_default<Tag, Default>(default_);
-    }
+        template <typename T>
+#if defined(BOOST_NO_SFINAE)
+        inline typename ::boost::parameter::aux::tag<Tag,T>::type
+#else
+        inline typename ::boost::lazy_enable_if<
+            typename ::boost::mpl::eval_if<
+                typename ::boost::mpl::if_<
+                    ::boost::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::out_reference
+                    >
+                  , ::boost::mpl::true_
+                  , ::boost::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >::type
+              , ::boost::mpl::if_<
+                    ::boost::is_const<T>
+                  , ::boost::mpl::false_
+                  , ::boost::mpl::true_
+                >
+              , ::boost::mpl::false_
+            >::type
+          , ::boost::parameter::aux::tag<Tag,T>
+        >::type BOOST_CONSTEXPR
+#endif  // BOOST_NO_SFINAE
+            operator=(T& x) const
+        {
+            typedef typename ::boost::parameter::aux
+            ::tag<Tag,T>::type result;
+            return result(x);
+        }
 
-    template <class T>
-    typename aux::tag<Tag, T const>::type const
-    operator=(T const& x) const
-    {
-        typedef typename aux::tag<Tag, T const>::type result;
-        return result(x);
-    }
+        template <typename Default>
+#if defined(BOOST_NO_SFINAE)
+        inline ::boost::parameter::aux::default_<Tag,Default>
+#else
+        inline typename ::boost::enable_if<
+            typename ::boost::mpl::eval_if<
+                typename ::boost::mpl::if_<
+                    ::boost::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::out_reference
+                    >
+                  , ::boost::mpl::true_
+                  , ::boost::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >::type
+              , ::boost::mpl::if_<
+                    ::boost::is_const<Default>
+                  , ::boost::mpl::false_
+                  , ::boost::mpl::true_
+                >
+              , ::boost::mpl::false_
+            >::type
+          , ::boost::parameter::aux::default_<Tag,Default>
+        >::type
+#endif  // BOOST_NO_SFINAE
+            operator|(Default& d) const
+        {
+            return ::boost::parameter::aux::default_<Tag,Default>(d);
+        }
 
-    template <class Default>
-    aux::default_<Tag, const Default>
-    operator|(const Default& default_) const
-    {
-        return aux::default_<Tag, const Default>(default_);
-    }
+        template <typename Default>
+        inline ::boost::parameter::aux::lazy_default<Tag,Default const>
+            operator||(Default const& d) const
+        {
+            return ::boost::parameter::aux
+            ::lazy_default<Tag,Default const>(d);
+        }
 
-    template <class Default>
-    aux::lazy_default<Tag, Default>
-    operator||(Default const& default_) const
-    {
-        return aux::lazy_default<Tag, Default>(default_);
-    }
+        template <typename Default>
+        inline ::boost::parameter::aux::lazy_default<Tag,Default>
+            operator||(Default& d) const
+        {
+            return ::boost::parameter::aux::lazy_default<Tag,Default>(d);
+        }
 
- public: // Insurance against ODR violations
-    
-    // People will need to define these keywords in header files.  To
-    // prevent ODR violations, it's important that the keyword used in
-    // every instantiation of a function template is the same object.
-    // We provide a reference to a common instance of each keyword
-    // object and prevent construction by users.
-    static keyword<Tag> const instance;
+     public: // Insurance against ODR violations
+        // Users will need to define their keywords in header files.  To
+        // prevent ODR violations, it's important that the keyword used in
+        // every instantiation of a function template is the same object.
+        // We provide a reference to a common instance of each keyword
+        // object and prevent construction by users.
+        static ::boost::parameter::keyword<Tag> const instance;
 
-    // This interface is deprecated
-    static keyword<Tag>& get()
-    {
-        return const_cast<keyword<Tag>&>(instance);
-    }
-};
+        // This interface is deprecated.
+        static ::boost::parameter::keyword<Tag>& get()
+        {
+            return const_cast< ::boost::parameter::keyword<Tag>&>(instance);
+        }
+    };
 
-template <class Tag>
-keyword<Tag> const keyword<Tag>::instance = {};
-
-// Reduces boilerplate required to declare and initialize keywords
-// without violating ODR.  Declares a keyword tag type with the given
-// name in namespace tag_namespace, and declares and initializes a
-// reference in an anonymous namespace to a singleton instance of that
-// type.
-
-#define BOOST_PARAMETER_KEYWORD(tag_namespace,name)                 \
-    namespace tag_namespace                                         \
-    {                                                               \
-      struct name                                                   \
-      {                                                             \
-          static char const* keyword_name()                         \
-          {                                                         \
-              return #name;                                         \
-          }                                                         \
-      };                                                            \
-    }                                                               \
-    namespace                                                       \
-    {                                                               \
-       ::boost::parameter::keyword<tag_namespace::name> const& name \
-       = ::boost::parameter::keyword<tag_namespace::name>::instance;\
-    }
-
+    template <typename Tag>
+    ::boost::parameter::keyword<Tag> const ::boost::parameter
+    ::keyword<Tag>::instance = ::boost::parameter::keyword<Tag>();
 }} // namespace boost::parameter
 
-#endif // KEYWORD_050328_HPP
+#include <boost/parameter/aux_/name.hpp>
+
+// Reduces boilerplate required to declare and initialize keywords without
+// violating ODR.  Declares a keyword tag type with the given name in
+// namespace tag_namespace, and declares and initializes a reference in an
+// anonymous namespace to a singleton instance of that type.
+#define BOOST_PARAMETER_KEYWORD(tag_namespace, name)                         \
+    namespace tag_namespace                                                  \
+    {                                                                        \
+        struct name                                                          \
+        {                                                                    \
+            static char const* keyword_name()                                \
+            {                                                                \
+                return #name;                                                \
+            }                                                                \
+            typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(name) _;            \
+            typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(name) _1;           \
+            typedef ::boost::parameter::forward_reference qualifier;         \
+        };                                                                   \
+    }                                                                        \
+    namespace                                                                \
+    {                                                                        \
+        ::boost::parameter::keyword<tag_namespace::name> const& name         \
+            = ::boost::parameter::keyword<tag_namespace::name>::instance;    \
+    }
+/**/
+
+#endif  // include guard
 

--- a/include/boost/parameter/keyword_fwd.hpp
+++ b/include/boost/parameter/keyword_fwd.hpp
@@ -8,7 +8,12 @@
 
 namespace boost { namespace parameter {
 
-    template <class Tag>
+    struct in_reference;
+    struct out_reference;
+    typedef ::boost::parameter::out_reference in_out_reference;
+    struct forward_reference;
+
+    template <typename Tag>
     struct keyword;
 }} // namespace boost::parameter
 

--- a/include/boost/parameter/name.hpp
+++ b/include/boost/parameter/name.hpp
@@ -7,83 +7,103 @@
 #define BOOST_PARAMETER_NAME_060806_HPP
 
 #include <boost/parameter/aux_/name.hpp>
-#include <boost/parameter/aux_/void.hpp>
-#include <boost/parameter/keyword.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
-# define BOOST_PARAMETER_BASIC_NAME(tag_namespace, tag, name)       \
-    namespace tag_namespace                                         \
-    {                                                               \
-      struct tag                                                    \
-      {                                                             \
-          static char const* keyword_name()                         \
-          {                                                         \
-              return BOOST_PP_STRINGIZE(tag);                       \
-          }                                                         \
-                                                                    \
-          typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(tag) _;      \
-                                                                    \
-          typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(tag) _1;     \
-      };                                                            \
-    }                                                               \
-    namespace                                                       \
-    {                                                               \
-       ::boost::parameter::keyword<tag_namespace::tag> const& name  \
-       = ::boost::parameter::keyword<tag_namespace::tag>::instance; \
+#define BOOST_PARAMETER_NAME_TAG(tag_namespace, tag, q)                      \
+    namespace tag_namespace                                                  \
+    {                                                                        \
+        struct tag                                                           \
+        {                                                                    \
+            static char const* keyword_name()                                \
+            {                                                                \
+                return BOOST_PP_STRINGIZE(tag);                              \
+            }                                                                \
+            typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(tag) _;             \
+            typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(tag) _1;            \
+            typedef ::boost::parameter::q qualifier;                         \
+        };                                                                   \
     }
+/**/
 
-# define BOOST_PARAMETER_COMPLEX_NAME_TUPLE1(tag,namespace)         \
-    (tag, namespace), ~
+#include <boost/parameter/keyword.hpp>
+
+#define BOOST_PARAMETER_NAME_KEYWORD(tag_namespace, tag, name)               \
+    namespace                                                                \
+    {                                                                        \
+        ::boost::parameter::keyword<tag_namespace::tag> const& name          \
+            = ::boost::parameter::keyword<tag_namespace::tag>::instance;     \
+    }
+/**/
+
+#define BOOST_PARAMETER_BASIC_NAME(tag_namespace, tag, qualifier, name)      \
+    BOOST_PARAMETER_NAME_TAG(tag_namespace, tag, qualifier)                  \
+    BOOST_PARAMETER_NAME_KEYWORD(tag_namespace, tag, name)
+/**/
+
+#define BOOST_PARAMETER_COMPLEX_NAME_TUPLE1(object, namespace)               \
+    (object, namespace), ~
+/**/
 
 #include <boost/preprocessor/tuple/elem.hpp>
 
-# define BOOST_PARAMETER_COMPLEX_NAME_TUPLE(name)                   \
+#define BOOST_PARAMETER_COMPLEX_NAME_TUPLE(name)                             \
     BOOST_PP_TUPLE_ELEM(2, 0, (BOOST_PARAMETER_COMPLEX_NAME_TUPLE1 name))
+/**/
 
-# define BOOST_PARAMETER_COMPLEX_NAME_TAG(name)                     \
+#define BOOST_PARAMETER_COMPLEX_NAME_OBJECT(name)                            \
     BOOST_PP_TUPLE_ELEM(2, 0, BOOST_PARAMETER_COMPLEX_NAME_TUPLE(name))
+/**/
 
-# define BOOST_PARAMETER_COMPLEX_NAME_NAMESPACE(name)               \
+#define BOOST_PARAMETER_COMPLEX_NAME_NAMESPACE(name)                         \
     BOOST_PP_TUPLE_ELEM(2, 1, BOOST_PARAMETER_COMPLEX_NAME_TUPLE(name))
+/**/
 
+#include <boost/parameter/aux_/preprocessor/qualifier.hpp>
 #include <boost/preprocessor/tuple/eat.hpp>
 
-# define BOOST_PARAMETER_COMPLEX_NAME(name)                         \
-    BOOST_PARAMETER_BASIC_NAME(                                     \
-        BOOST_PARAMETER_COMPLEX_NAME_NAMESPACE(name)                \
-      , BOOST_PP_TUPLE_EAT(2) name                                  \
-      , BOOST_PARAMETER_COMPLEX_NAME_TAG(name)                      \
-    )                                                               \
+#define BOOST_PARAMETER_COMPLEX_NAME(name)                                   \
+    BOOST_PARAMETER_BASIC_NAME(                                              \
+        BOOST_PARAMETER_COMPLEX_NAME_NAMESPACE(name)                         \
+      , BOOST_PARAMETER_UNQUALIFIED(BOOST_PP_TUPLE_EAT(2) name)              \
+      , BOOST_PARAMETER_GET_QUALIFIER(BOOST_PP_TUPLE_EAT(2) name)            \
+      , BOOST_PARAMETER_COMPLEX_NAME_OBJECT(name)                            \
+    )
 /**/
 
 #include <boost/preprocessor/cat.hpp>
 
-# define BOOST_PARAMETER_SIMPLE_NAME(name)                          \
-    BOOST_PARAMETER_BASIC_NAME(tag, name, BOOST_PP_CAT(_, name))
+#define BOOST_PARAMETER_SIMPLE_NAME(name)                                    \
+    BOOST_PARAMETER_BASIC_NAME(                                              \
+        tag                                                                  \
+      , BOOST_PARAMETER_UNQUALIFIED(name)                                    \
+      , BOOST_PARAMETER_GET_QUALIFIER(name)                                  \
+      , BOOST_PP_CAT(_, BOOST_PARAMETER_UNQUALIFIED(name))                   \
+    )
+/**/
 
 #include <boost/parameter/aux_/preprocessor/is_binary.hpp>
 #include <boost/preprocessor/control/iif.hpp>
 
-# define BOOST_PARAMETER_NAME(name)                                 \
-    BOOST_PP_IIF(                                                   \
-        BOOST_PARAMETER_IS_BINARY(name)                             \
-      , BOOST_PARAMETER_COMPLEX_NAME                                \
-      , BOOST_PARAMETER_SIMPLE_NAME                                 \
-    )(name)                                                         \
+#define BOOST_PARAMETER_NAME(name)                                           \
+    BOOST_PP_IIF(                                                            \
+        BOOST_PARAMETER_IS_BINARY(name)                                      \
+      , BOOST_PARAMETER_COMPLEX_NAME                                         \
+      , BOOST_PARAMETER_SIMPLE_NAME                                          \
+    )(name)
 /**/
 
 #include <boost/parameter/aux_/template_keyword.hpp>
 
-# define BOOST_PARAMETER_TEMPLATE_KEYWORD(name)                     \
-    namespace tag                                                   \
-    {                                                               \
-      struct name;                                                  \
-    }                                                               \
-    template <class T>                                              \
-    struct name                                                     \
-      : boost::parameter::template_keyword<tag::name, T>            \
-    {};                                                             \
+#define BOOST_PARAMETER_TEMPLATE_KEYWORD(name)                               \
+    namespace tag                                                            \
+    {                                                                        \
+        struct name;                                                         \
+    }                                                                        \
+    template <typename T>                                                    \
+    struct name : ::boost::parameter::template_keyword<tag::name,T>          \
+    {                                                                        \
+    };
 /**/
 
-#endif // BOOST_PARAMETER_NAME_060806_HPP
+#endif  // include guard
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -32,6 +32,7 @@ alias parameter
      [ compile ntp.cpp ]
      [ compile function_type_tpl_param.cpp ]
      [ compile unwrap_cv_reference.cpp ]
+     [ compile-fail compose.cpp : <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_0 : compose_fail_0 ]
      [ compile-fail duplicates.cpp ]
      [ compile-fail deduced_unmatched_arg.cpp ]
      [ bpl-test python_test ]

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -12,8 +12,8 @@ namespace param {
     BOOST_PARAMETER_NAME(a1)
     BOOST_PARAMETER_NAME(a2)
     BOOST_PARAMETER_NAME(a3)
-    BOOST_PARAMETER_NAME(lrc)
-    BOOST_PARAMETER_NAME(lr)
+    BOOST_PARAMETER_NAME(in(lrc))
+    BOOST_PARAMETER_NAME(out(lr))
     BOOST_PARAMETER_NAME(rr)
 }
 
@@ -155,7 +155,11 @@ int main()
     BOOST_TEST_EQ(198.9, b1.l());
     int x = 7;
     int const y = 9;
+#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_0)
+    test::G g((param::_lr = 8, param::_rr = y, param::_lrc = x));
+#else
     test::G g((param::_lr = x, param::_rr = 8, param::_lrc = y));
+#endif
     BOOST_TEST_EQ(7, g.j);
     BOOST_TEST_EQ(8, g.i);
     BOOST_TEST_EQ(9, g.k);

--- a/test/literate/handling-out-parameters0.cpp
+++ b/test/literate/handling-out-parameters0.cpp
@@ -15,7 +15,7 @@ BOOST_PARAMETER_NAME(graph)
 BOOST_PARAMETER_NAME(visitor)
 BOOST_PARAMETER_NAME(root_vertex)
 BOOST_PARAMETER_NAME(index_map)
-BOOST_PARAMETER_NAME(color_map)
+BOOST_PARAMETER_NAME(in_out(color_map))
 
 BOOST_PARAMETER_FUNCTION((void), f, tag,
   (required (graph, *))
@@ -23,7 +23,7 @@ BOOST_PARAMETER_FUNCTION((void), f, tag,
     (visitor,            *, boost::dfs_visitor<>())
     (root_vertex,        *, *vertices(graph).first)
     (index_map,          *, get(boost::vertex_index,graph))
-    (in_out(color_map), *,
+    (color_map,          *,
       default_color_map(num_vertices(graph), index_map) )
 )
 ) {}

--- a/test/literate/optional-parameters0.cpp
+++ b/test/literate/optional-parameters0.cpp
@@ -14,14 +14,14 @@ BOOST_PARAMETER_NAME(graph)
 BOOST_PARAMETER_NAME(visitor)
 BOOST_PARAMETER_NAME(root_vertex)
 BOOST_PARAMETER_NAME(index_map)
-BOOST_PARAMETER_NAME(color_map)
+BOOST_PARAMETER_NAME(in_out(color_map))
 
 BOOST_PARAMETER_FUNCTION((void), f, tag,
   (required (graph, *))
 (optional     (visitor,           *, boost::dfs_visitor<>())
     (root_vertex,       *, *vertices(graph).first)
     (index_map,         *, get(boost::vertex_index,graph))
-    (in_out(color_map), *,
+    (color_map,         *,
       default_color_map(num_vertices(graph), index_map) )
 )
 ) {}

--- a/test/literate/predicate-requirements0.cpp
+++ b/test/literate/predicate-requirements0.cpp
@@ -7,7 +7,7 @@ BOOST_PARAMETER_NAME((_graph, graphs) graph)
 BOOST_PARAMETER_NAME((_visitor, graphs) visitor)
 BOOST_PARAMETER_NAME((_root_vertex, graphs) root_vertex)
 BOOST_PARAMETER_NAME((_index_map, graphs) index_map)
-BOOST_PARAMETER_NAME((_color_map, graphs) color_map)
+BOOST_PARAMETER_NAME((_color_map, graphs) in_out(color_map))
 
 using boost::mpl::_;
 // We first need to define a few metafunction that we use in the
@@ -78,7 +78,7 @@ BOOST_PARAMETER_FUNCTION(
           >)
         , get(boost::vertex_index,graph))
 
-      (in_out(color_map)
+      (color_map
         , *(boost::is_same<
               vertex_descriptor<graphs::graph::_>, key_type<_>
           >)

--- a/test/literate/writing-the-function0.cpp
+++ b/test/literate/writing-the-function0.cpp
@@ -5,7 +5,7 @@ BOOST_PARAMETER_NAME(graph)
 BOOST_PARAMETER_NAME(visitor)
 BOOST_PARAMETER_NAME(root_vertex)
 BOOST_PARAMETER_NAME(index_map)
-BOOST_PARAMETER_NAME(color_map)
+BOOST_PARAMETER_NAME(in_out(color_map))
 
 namespace boost {
 
@@ -32,7 +32,7 @@ namespace graphs
         (visitor,           *, boost::dfs_visitor<>())
         (root_vertex,       *, *vertices(graph).first)
         (index_map,         *, get(boost::vertex_index,graph))
-        (in_out(color_map), *,
+        (color_map,         *,
           default_color_map(num_vertices(graph), index_map) )
       )
   )


### PR DESCRIPTION
Add parameter category qualifier "forward" (current qualifiers are "in", "out", and "in_out") based on http://www.modernescpp.com/index.php/c-core-guidelines-how-to-pass-function-parameters.  Add new usage syntax BOOST_PARAMETER_NAME((object-name), namespace-name) qualifier(tag-name)) and BOOST_PARAMETER_NAME(qualifier(name)).  (Existing code that uses qualifiers directly and correctly with BOOST_PARAMETER_FUNCTION and other code generation macros should remain unaffected for now, so no breaking changes.)  The reason for the change in usage is to enable applying of parameter category constraints to Boost.Parameter-enabled functions and constructors invoked through argument composition.  (Otherwise, it is currently possible to use argument composition to bypass parameter category constraints applied in BOOST_PARAMETER_FUNCTION et. al.) See "test/compose.cpp" for example usage.