### PR TITLE
Restructure tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Copyright 2016 Edward Diener
+# Copyright 2017 Cromwell D. Enage
 # Distributed under the Boost Software License, Version 1.0.
-# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://boost.org/LICENSE_1_0.txt)
 
 language: cpp
 
@@ -25,12 +27,18 @@ matrix:
 
   include:
     - os: linux
-      compiler: g++
-      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03,11 TEST_SUITE=parameter
+      compiler: g++-4.4
+      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=98 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.4
+          sources:
+            - ubuntu-toolchain-r-test
 
     - os: linux
       compiler: g++-4.4
-      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=98,0x TEST_SUITE=parameter
+      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=0x TEST_SUITE=parameter_slp_tests
       addons:
         apt:
           packages:
@@ -40,7 +48,7 @@ matrix:
 
     - os: linux
       compiler: g++-4.6
-      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03,0x TEST_SUITE=parameter
+      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03 TEST_SUITE=parameter_slp_tests
       addons:
         apt:
           packages:
@@ -49,8 +57,71 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
-      compiler: g++-5
-      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=03,11,14,1z TEST_SUITE=parameter
+      compiler: g++-4.6
+      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=0x TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-4.7 CXXSTD=03 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-4.7 CXXSTD=11 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-4.8 CXXSTD=03 TEST_SUITE=parameter_standard_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.8
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-4.8 CXXSTD=11 TEST_SUITE=parameter_standard_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.8
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-4.9 CXXSTD=03 TEST_SUITE=parameter_standard_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-4.9 CXXSTD=11 TEST_SUITE=parameter_standard_tests
+      addons:
+        apt:
+          packages:
+            - g++-4.9
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=03 TEST_SUITE=parameter_standard_tests
       addons:
         apt:
           packages:
@@ -59,8 +130,88 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
-      compiler: g++-6
-      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=03,11,14,1z TEST_SUITE=parameter
+      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=11 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-5
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=14 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-5
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=03 TEST_SUITE=parameter_sp_tests
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=11 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=14 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=1z TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=03 CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=parameter_sp_tests
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=11 CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=14 CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=1z CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=parameter_slp_tests
       addons:
         apt:
           packages:
@@ -71,7 +222,84 @@ matrix:
     - os: linux
       dist: trusty
       compiler: g++-7
-      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03,11,14,17 TEST_SUITE=parameter
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03 TEST_SUITE=parameter_sp_tests
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: trusty
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=11 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: trusty
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=14 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: trusty
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=17 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: trusty
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03 CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=parameter_sp_tests
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: trusty
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=11 CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: trusty
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=14 CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: trusty
+      compiler: g++-7
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=17 CXXSTD_DIALECT=cxxstd-dialect=gnu TEST_SUITE=parameter_slp_tests
       addons:
         apt:
           packages:
@@ -81,7 +309,7 @@ matrix:
 
     - os: linux
       compiler: g++-8
-      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=03,11,14,17 TEST_SUITE=parameter
+      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=03 TEST_SUITE=parameter_slp_tests
       addons:
         apt:
           packages:
@@ -90,8 +318,296 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
+      compiler: g++-8
+      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=11 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-8
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: g++-8
+      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=14 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-8
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: g++-8
+      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=17 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - g++-8
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.5 CXXSTD=03 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.5
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.5 CXXSTD=11 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.5
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.6 CXXSTD=03 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.6
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.6 CXXSTD=11 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.6
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.7 CXXSTD=03 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.7
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.7 CXXSTD=11 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.7
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=03 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.8
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=11 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.8
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=14 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.8
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=1z TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.8
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.9 CXXSTD=03 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.9
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.9
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.9 CXXSTD=11 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.9
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.9
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.9 CXXSTD=14 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.9
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.9
+
+    - os: linux
+      env: TOOLSET=clang COMPILER=clang++-3.9 CXXSTD=1z TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-3.9
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.9
+
+    - os: linux
+      compiler: clang++-4.0
+      env: TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=03 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+
+    - os: linux
+      compiler: clang++-4.0
+      env: TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=11 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+
+    - os: linux
+      compiler: clang++-4.0
+      env: TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=14 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+
+    - os: linux
+      compiler: clang++-4.0
+      env: TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=1z TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+
+    - os: linux
+      compiler: clang++-5.0
+      env: TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=03 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+
+    - os: linux
+      compiler: clang++-5.0
+      env: TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=11 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+
+    - os: linux
+      compiler: clang++-5.0
+      env: TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=14 TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+
+    - os: linux
+      compiler: clang++-5.0
+      env: TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=1z TEST_SUITE=parameter_sl_tests
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+
+    - os: linux
       compiler: clang++
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z TEST_SUITE=parameter
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - libstdc++-5-dev
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=11 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - libstdc++-5-dev
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=14 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - libstdc++-5-dev
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=1z TEST_SUITE=parameter_slp_tests
       addons:
         apt:
           packages:
@@ -101,7 +617,31 @@ matrix:
 
     - os: linux
       compiler: clang++-libc++
-      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=03,11,14,1z TEST_SUITE=parameter
+      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=03 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - libc++-dev
+
+    - os: linux
+      compiler: clang++-libc++
+      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=11 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - libc++-dev
+
+    - os: linux
+      compiler: clang++-libc++
+      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=14 TEST_SUITE=parameter_slp_tests
+      addons:
+        apt:
+          packages:
+            - libc++-dev
+
+    - os: linux
+      compiler: clang++-libc++
+      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=1z TEST_SUITE=parameter_slp_tests
       addons:
         apt:
           packages:
@@ -109,12 +649,56 @@ matrix:
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z TEST_SUITE=parameter
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03 TEST_SUITE=parameter_all_tests
+
+    - os: osx
+      compiler: clang++
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=11 TEST_SUITE=parameter_all_tests
+
+    - os: osx
+      compiler: clang++
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=14 TEST_SUITE=parameter_all_tests
+
+    - os: osx
+      compiler: clang++
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=1z TEST_SUITE=parameter_all_tests
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03 TEST_SUITE=parameter_slp_tests
+      osx_image: xcode7.3
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=11 TEST_SUITE=parameter_all_tests
+      osx_image: xcode7.3
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=14 TEST_SUITE=parameter_all_tests
+      osx_image: xcode7.3
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=1z TEST_SUITE=parameter_all_tests
+      osx_image: xcode7.3
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03 TEST_SUITE=parameter_sl_tests
+      osx_image: xcode8.3
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=11 TEST_SUITE=parameter_all_but_python_tests
+      osx_image: xcode8.3
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=14 TEST_SUITE=parameter_all_but_python_tests
+      osx_image: xcode8.3
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=1z TEST_SUITE=parameter_all_but_python_tests
+      osx_image: xcode8.3
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
   - cd ..
-  - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+  - git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
   - git submodule update --init tools/build
   - git submodule update --init libs/config

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 # Copyright 2017 Edward Diener
+# Copyright 2017 Cromwell D. Enage
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://boost.org/LICENSE_1_0.txt)
@@ -15,29 +16,50 @@ branches:
 environment:
   matrix:
     - ARGS: --toolset=gcc address-model=32
-      TEST_SUITE: parameter
+      TEST_SUITE: parameter_slp_tests
       PATH: C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin;%PATH%
     - ARGS: --toolset=gcc address-model=32 linkflags=-Wl,-allow-multiple-definition
-      TEST_SUITE: parameter
+      TEST_SUITE: parameter_slp_tests
       PATH: C:\MinGW\bin;%PATH%
+    - ARGS: --toolset=gcc address-model=64
+      TEST_SUITE: parameter_sl_tests
+      PATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
+    - ARGS: --toolset=gcc address-model=64 cxxflags=-std=gnu++1z
+      TEST_SUITE: parameter_sl_tests
+      PATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       ARGS: --toolset=msvc-9.0  address-model=32
-      TEST_SUITE: parameter
+      TEST_SUITE: parameter_all_tests
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       ARGS: --toolset=msvc-10.0 address-model=32
-      TEST_SUITE: parameter
+      TEST_SUITE: parameter_all_tests
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       ARGS: --toolset=msvc-11.0 address-model=32
       TEST_SUITE: parameter_msvc11_tests
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       ARGS: --toolset=msvc-12.0 address-model=32
-      TEST_SUITE: parameter
+      TEST_SUITE: parameter_all_tests
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      ARGS: --toolset=msvc-12.0 address-model=64
+      TEST_SUITE: parameter_all_but_python_tests
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       ARGS: --toolset=msvc-14.0 address-model=32
-      TEST_SUITE: parameter
+      TEST_SUITE: parameter_all_tests
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ARGS: --toolset=msvc-14.0 address-model=64
+      TEST_SUITE: parameter_all_but_python_tests
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ARGS: --toolset=msvc-14.0 address-model=64 cxxflags=-std:c++latest
+      TEST_SUITE: parameter_all_but_python_tests
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ARGS: --toolset=msvc-14.1 address-model=32
-      TEST_SUITE: parameter
+      TEST_SUITE: parameter_msvc14_tests
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARGS: --toolset=msvc-14.1 address-model=64
+      TEST_SUITE: parameter_msvc14_no_python_tests
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARGS: --toolset=msvc-14.1 address-model=64 cxxflags=-std:c++latest
+      TEST_SUITE: parameter_msvc14_no_python_tests
 
 install:
   - cd ..

--- a/include/boost/parameter.hpp
+++ b/include/boost/parameter.hpp
@@ -1,6 +1,6 @@
-// Copyright David Abrahams, Daniel Wallin 2005. Use, modification and 
-// distribution is subject to the Boost Software License, Version 1.0. 
-// (See accompanying file LICENSE_1_0.txt or copy at 
+// Copyright David Abrahams, Daniel Wallin 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 //  See www.boost.org/libs/parameter for documentation.
@@ -17,5 +17,5 @@
 #include <boost/parameter/name.hpp>
 #include <boost/parameter/preprocessor.hpp>
 
-#endif // BOOST_PARAMETER_050401_HPP
+#endif  // include guard
 

--- a/include/boost/parameter/parameters.hpp
+++ b/include/boost/parameter/parameters.hpp
@@ -273,6 +273,7 @@ namespace boost { namespace parameter {
             );
         }
 
+#if (2 < BOOST_PARAMETER_MAX_ARITY)
         // Higher arities are handled by the preprocessor
 #define BOOST_PP_ITERATION_PARAMS_1 \
     (3,( \
@@ -281,6 +282,7 @@ namespace boost { namespace parameter {
       , <boost/parameter/aux_/preprocessor/overloads.hpp> \
     ))
 #include BOOST_PP_ITERATE()
+#endif
     };
 }} // namespace boost::parameter
 

--- a/include/boost/parameter/preprocessor.hpp
+++ b/include/boost/parameter/preprocessor.hpp
@@ -1,4 +1,5 @@
 // Copyright Daniel Wallin 2006.
+// Copyright Cromwell D. Enage 2017.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,49 +1,259 @@
-# Copyright David Abrahams, Daniel Wallin 2006. Distributed under the
-# Boost Software License, Version 1.0. (See accompanying file
-# LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+# Copyright David Abrahams, Daniel Wallin 2006.
+# Copyright Cromwell D. Enage 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
 
 # Boost Parameter Library test Jamfile
 
 import python ;
 
 project boost/parameter
-  : default-build <warnings>off
-  ;
+    :
+        default-build
+        <warnings>off
+    ;
 
 build-project literate ;
 
-alias parameter
-  :  [ run basics.cpp ]
-     [ run compose.cpp ]
-     [ run sfinae.cpp ]
-     [ run macros.cpp ]
-     [ run earwicker.cpp ]
-     [ run tutorial.cpp ]
-     [ run singular.cpp ]
-     [ run mpl.cpp ]
-     [ run preprocessor.cpp ]
-     [ run preprocessor_deduced.cpp ]
-     [ run efficiency.cpp : : : : : <variant>release ]
-     [ run maybe.cpp ]
-     [ run deduced.cpp ]
-     [ run optional_deduced_sfinae.cpp ]
-     [ run deduced_dependent_predicate.cpp ]
-     [ run normalized_argument_types.cpp ]
-     [ compile ntp.cpp ]
-     [ compile function_type_tpl_param.cpp ]
-     [ compile unwrap_cv_reference.cpp ]
-     [ compile-fail compose.cpp : <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_0 : compose_fail_0 ]
-     [ compile-fail duplicates.cpp ]
-     [ compile-fail deduced_unmatched_arg.cpp ]
-     [ bpl-test python_test ]
-  ;
+alias parameter_standard_tests
+    :
+    [ run maybe.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run singular.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run tutorial.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run compose.cpp
+        :
+        :
+        :
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run sfinae.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=2
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run optional_deduced_sfinae.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run efficiency.cpp
+        :
+        :
+        :
+        :
+        :
+            <variant>release
+            <preserve-target-tests>off
+    ]
+    [ run normalized_argument_types.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=2
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run basics.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run mpl.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run earwicker.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run macros.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run preprocessor.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run preprocessor_deduced.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run deduced.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run deduced_dependent_predicate.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ compile unwrap_cv_reference.cpp ]
+    [ compile ntp.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+    ]
+    [ compile function_type_tpl_param.cpp ]
+    [ compile-fail duplicates.cpp
+        :
+        :
+            duplicates_fail
+    ]
+    [ compile-fail deduced_unmatched_arg.cpp
+        :
+        :
+            deduced_unmatched_arg_fail
+    ]
+    [ compile-fail basics.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE
+        :
+            basics_fail
+    ]
+    [ compile-fail compose.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_0
+        :
+            compose_fail_0
+    ]
+    [ compile-fail deduced.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE
+        :
+            deduced_fail
+    ]
+    ;
 
-alias parameter_msvc11_fail
-  :  [ run-fail compose.cpp : : : <define>LIBS_PARAMETER_TEST_RUN_FAILURE : compose_fail_0 : <preserve-target-tests>off ]
-  ;
+alias parameter_python_test
+    :
+    [ bpl-test python_test ]
+    ;
+
+alias parameter_sl_tests
+    :
+        parameter_standard_tests
+    ;
+
+alias parameter_sp_tests
+    :
+        parameter_standard_tests
+        parameter_python_test
+    ;
+
+alias parameter_slp_tests
+    :
+        parameter_sl_tests
+        parameter_python_test
+    ;
+
+alias parameter_all_but_python_tests
+    :
+        parameter_sl_tests
+    ;
+
+alias parameter_all_tests
+    :
+        parameter_slp_tests
+    ;
+
+alias parameter_msvc11_fail_tests
+    :
+    [ run-fail compose.cpp
+        :
+        :
+        :
+            <define>LIBS_PARAMETER_TEST_RUN_FAILURE_MSVC
+        :
+            compose_fail_msvc11
+        :
+            <preserve-target-tests>off
+    ]
+    ;
 
 alias parameter_msvc11_tests
-  :  parameter
-     parameter_msvc11_fail
-  ;
+    :
+        parameter_all_tests
+        parameter_msvc11_fail_tests
+    ;
+
+alias parameter_msvc14_no_python_tests
+    :
+        parameter_all_but_python_tests
+    ;
+
+alias parameter_msvc14_tests
+    :
+        parameter_all_tests
+    ;
 

--- a/test/basics.cpp
+++ b/test/basics.cpp
@@ -1,112 +1,111 @@
-// Copyright David Abrahams, Daniel Wallin 2003. Use, modification and 
-// distribution is subject to the Boost Software License, Version 1.0. 
-// (See accompanying file LICENSE_1_0.txt or copy at 
+// Copyright David Abrahams, Daniel Wallin 2003.
+// Copyright Cromwell D. Enage 2017.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/parameter.hpp>
-#include <cassert>
-#include <string.h>
 #include <boost/bind.hpp>
-#include <boost/ref.hpp>
-
 #include "basics.hpp"
 
-namespace test
-{
-  // A separate function for getting the "value" key, so we can deduce
-  // F and use lazy_binding on it.
-  template <class Params, class F>
-  typename boost::parameter::lazy_binding<Params,tag::value,F>::type
-  extract_value(Params const& p, F const& f)
-  {
-      typename boost::parameter::lazy_binding<
-        Params, tag::value, F
-      >::type v = p[value || f ];
-      return v;
-  }
-  
-  template<class Params>
-  int f_impl(Params const& p)
-  {
-      typename boost::parameter::binding<Params, tag::name>::type
-          n = p[name];
+namespace test {
 
-      typename boost::parameter::binding<
-        Params, tag::value, double
-      >::type v = extract_value(p, boost::bind(&value_default));
-          
-      typename boost::parameter::binding<
-        Params, tag::index, int
-      >::type i =
-#if BOOST_WORKAROUND(__DECCXX_VER, BOOST_TESTED_AT(60590042))
-        p[test::index | 999];
-#else
-        p[index | 999];
-#endif
+    // A separate function for getting the "value" key, so we can deduce F
+    // and use lazy_binding on it.
+    template <typename Params, typename F>
+    typename boost::parameter::lazy_binding<Params,tag::value,F>::type
+        extract_value(Params const& p, F const& f)
+    {
+        typename boost::parameter::lazy_binding<
+            Params,test::tag::value,F
+        >::type v = p[test::_value || f];
+        return v;
+    }
 
-      p[tester](n,v,i);
+    template <typename Params>
+    int f_impl(Params const& p)
+    {
+        typename boost::parameter::binding<Params,test::tag::name>::type
+            n = p[test::_name];
 
-      return 1;
-  }
+        typename boost::parameter::binding<
+            Params,test::tag::value,double
+        >::type v = test::extract_value(p, boost::bind(&test::value_default));
 
-  template<class Tester, class Name, class Value, class Index>
-  int f(Tester const& t, const Name& name_, 
-      const Value& value_, const Index& index_)
-  {
-      return f_impl(f_parameters()(t, name_, value_, index_));
-  }
+        typename boost::parameter::binding<Params,test::tag::index,int>::type
+            i = p[test::_index | 999];
 
-  template<class Tester, class Name, class Value>
-  int f(Tester const& t, const Name& name_, const Value& value_)
-  {
-      return f_impl(f_parameters()(t, name_, value_));
-  }
+        p[test::_tester](n, v, i);
 
-  template<class Tester, class Name>
-  int f(Tester const& t, const Name& name_)
-  {
-      return f_impl(f_parameters()(t, name_));
-  }
+        return 1;
+    }
 
-  template<class Params>
-  int f_list(Params const& params)
-  {
-      return f_impl(params);
-  }
+    template <typename A0, typename A1, typename A2, typename A3>
+    int f(A0 const& a0, A1 const& a1, A2 const& a2, A3 const& a3)
+    {
+        return test::f_impl(test::f_parameters()(a0, a1, a2, a3));
+    }
 
+    template <typename A0, typename A1, typename A2>
+    int f(A0 const& a0, A1 const& a1, A2 const& a2)
+    {
+        return test::f_impl(test::f_parameters()(a0, a1, a2));
+    }
+
+    template <typename A0, typename A1>
+    int f(A0 const& a0, A1 const& a1)
+    {
+        return test::f_impl(test::f_parameters()(a0, a1));
+    }
+
+    template <class Params>
+    int f_list(Params const& params)
+    {
+        return test::f_impl(params);
+    }
 }
+
+#include <boost/container/string.hpp>
+#include <boost/ref.hpp>
+#include <boost/config/workaround.hpp>
 
 int main()
 {
-   using test::f;
-   using test::f_list;
-   using test::name;
-   using test::value;
-   using test::index;
-   using test::tester;
+    test::f(
+        test::values(
+            boost::container::string("foo")
+          , boost::container::string("bar")
+          , boost::container::string("baz")
+        )
+      , boost::container::string("foo")
+      , boost::container::string("bar")
+      , boost::container::string("baz")
+    );
 
-   f(
-       test::values(S("foo"), S("bar"), S("baz"))
-     , S("foo"), S("bar"), S("baz")
-   );
-
-   int x = 56;
-   f(
-       test::values("foo", 666.222, 56)
-     , index = boost::ref(x), name = "foo"
-   );
+    int x = 56;
+    test::f(
+        test::values(boost::container::string("foo"), 666.222, 56)
+      , test::_index = boost::ref(x)
+      , test::_name = boost::container::string("foo")
+    );
 
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-   // No comma operator available on Borland
-   f_list((
-       tester = test::values("foo", 666.222, 56)
-     , index = boost::ref(x)
-     , name = "foo"
-   ));
-#endif
-   
-   //f(index = 56, name = 55); // won't compile
+    x = 56;
+    test::f_list((
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 666.222
+          , 56
+        )
+      , test::_index = boost::ref(x)
+      , test::_name = boost::container::string("foo")
+    ));
+#endif  // No comma operator available on Borland.
 
-   return boost::report_errors();
+#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE)
+    test::f(test::_index = 56, test::_name = 55); // won't compile
+#endif
+
+    return boost::report_errors();
 }
 

--- a/test/basics.hpp
+++ b/test/basics.hpp
@@ -1,112 +1,107 @@
-// Copyright David Abrahams, Daniel Wallin 2005. Use, modification and 
-// distribution is subject to the Boost Software License, Version 1.0. 
-// (See accompanying file LICENSE_1_0.txt or copy at 
+// Copyright David Abrahams, Daniel Wallin 2005.
+// Copyright Cromwell D. Enage 2017.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BASICS_050424_HPP
 #define BASICS_050424_HPP
 
-#include <boost/parameter/keyword.hpp>
-#include <boost/parameter/parameters.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/assert.hpp>
+#include <boost/parameter.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 4)
+#error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
+#endif
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/mpl/assert.hpp>
-#include <cstring>
-#include <boost/detail/lightweight_test.hpp>
+#include <boost/assert.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 namespace test {
 
-BOOST_PARAMETER_KEYWORD(tag, name)
-BOOST_PARAMETER_KEYWORD(tag, value)
-BOOST_PARAMETER_KEYWORD(tag, index)
-BOOST_PARAMETER_KEYWORD(tag, tester)
+    BOOST_PARAMETER_NAME(name)
+    BOOST_PARAMETER_NAME(value)
+    BOOST_PARAMETER_NAME(index)
+    BOOST_PARAMETER_NAME(tester)
 
-using namespace boost::parameter;
-
-struct f_parameters // vc6 is happier with inheritance than with a typedef
-  : parameters<
-        tag::tester
-      , tag::name
-      , tag::value
-      , tag::index
-    >
-{};
-
-inline double value_default()
-{
-    return 666.222;
-}
-
-template <class T>
-inline bool equal(T const& x, T const& y)
-{
-    return x == y;
-}
-
-inline bool equal(char const* s1, char const* s2)
-{
-    using namespace std;
-    return !strcmp(s1,s2);
-}
-
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-inline bool equal(char* s1, char* s2)
-{
-    using namespace std;
-    return !strcmp(s1,s2);
-}
-#endif 
-
-template <class Name, class Value, class Index>
-struct values_t
-{
-    values_t(Name const& n, Value const& v, Index const& i)
-      : n(n), v(v), i(i)
-    {}
-
-    template <class Name_, class Value_, class Index_>
-    void operator()(Name_ const& n_, Value_ const& v_, Index_ const& i_) const
+    struct f_parameters // vc6 is happier with inheritance than with a typedef
+      : boost::parameter::parameters<
+            test::tag::tester
+          , test::tag::name
+          , test::tag::value
+          , test::tag::index
+        >
     {
+    };
 
-        // Only VC and its emulators fail this; they seem to have
-        // problems with deducing the constness of string literal
-        // arrays.
-#if defined(_MSC_VER)                                                   \
-        && (BOOST_WORKAROUND(BOOST_INTEL_CXX_VERSION, <= 700)           \
-            || BOOST_WORKAROUND(BOOST_MSVC, < 1310))                    \
-            || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-# else 
-        BOOST_MPL_ASSERT((boost::is_same<Index,Index_>));
-        BOOST_MPL_ASSERT((boost::is_same<Value,Value_>));
-        BOOST_MPL_ASSERT((boost::is_same<Name,Name_>));
-#endif
-        BOOST_TEST(equal(n, n_));
-        BOOST_TEST(equal(v, v_));
-        BOOST_TEST(equal(i, i_));
+    inline double value_default()
+    {
+        return 666.222;
     }
 
-    Name const& n;
-    Value const& v;
-    Index const& i;
-};
+    template <typename T>
+    inline bool equal(T const& x, T const& y)
+    {
+        return x == y;
+    }
 
-template <class Name, class Value, class Index>
-inline values_t<Name,Value,Index>
-values(Name const& n, Value const& v, Index const& i)
-{
-    return values_t<Name,Value,Index>(n,v,i);
-}
+    template <typename Name, typename Value, typename Index>
+    struct values_t
+    {
+        values_t(Name const& n_, Value const& v_, Index const& i_)
+          : n(n_), v(v_), i(i_)
+        {
+        }
 
+        template <typename Name_, typename Value_, typename Index_>
+        void
+            operator()(
+                Name_ const& n_
+              , Value_ const& v_
+              , Index_ const& i_
+            ) const
+        {
+            BOOST_MPL_ASSERT((
+                typename boost::mpl::if_<
+                    boost::is_same<Index,Index_>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >::type
+            ));
+            BOOST_MPL_ASSERT((
+                typename boost::mpl::if_<
+                    boost::is_same<Value,Value_>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >::type
+            ));
+            BOOST_MPL_ASSERT((
+                typename boost::mpl::if_<
+                    boost::is_same<Name,Name_>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >::type
+            ));
+            BOOST_TEST(test::equal(n, n_));
+            BOOST_TEST(test::equal(v, v_));
+            BOOST_TEST(test::equal(i, i_));
+        }
+
+        Name const& n;
+        Value const& v;
+        Index const& i;
+    };
+
+    template <typename Name, typename Value, typename Index>
+    inline test::values_t<Name,Value,Index>
+        values(Name const& n, Value const& v, Index const& i)
+    {
+        return test::values_t<Name,Value,Index>(n, v, i);
+    }
 } // namespace test
 
-// GCC2 has a problem with char (&)[] deduction, so we'll cast string
-// literals there.
-#undef S
-#if BOOST_WORKAROUND(__GNUC__, == 2) || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-# define S(s) (char const*)s
-#else
-# define S(s) s
-#endif
-
-#endif // BASICS_050424_HPP
+#endif  // include guard
 

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -109,7 +109,7 @@ namespace test {
 
 int main()
 {
-#if !defined(LIBS_PARAMETER_TEST_RUN_FAILURE) && \
+#if !defined(LIBS_PARAMETER_TEST_RUN_FAILURE_MSVC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails at runtime without this workaround.
@@ -123,7 +123,7 @@ int main()
 #endif
     BOOST_TEST_EQ(1, a.i);
     BOOST_TEST_EQ(13, a.j);
-#if !defined(LIBS_PARAMETER_TEST_RUN_FAILURE) && \
+#if !defined(LIBS_PARAMETER_TEST_RUN_FAILURE_MSVC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails at runtime without this workaround.
@@ -138,7 +138,7 @@ int main()
     BOOST_TEST_EQ(13, b0.j);
     BOOST_TEST_EQ(4.0f, b0.k());
     BOOST_TEST_EQ(2.5, b0.l());
-#if !defined(LIBS_PARAMETER_TEST_RUN_FAILURE) && \
+#if !defined(LIBS_PARAMETER_TEST_RUN_FAILURE_MSVC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails at runtime without this workaround.

--- a/test/deduced.cpp
+++ b/test/deduced.cpp
@@ -1,114 +1,192 @@
-// Copyright Daniel Wallin 2006. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2006.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/parameter/parameters.hpp>
 #include <boost/parameter/name.hpp>
 #include <boost/parameter/binding.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 #include "deduced.hpp"
 
-namespace parameter = boost::parameter;
-namespace mpl = boost::mpl;
+#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE)
+#include <boost/tti/detail/dnullptr.hpp>
+#endif
 
-BOOST_PARAMETER_NAME(x)
-BOOST_PARAMETER_NAME(y)
-BOOST_PARAMETER_NAME(z)
+namespace test {
+
+    BOOST_PARAMETER_NAME(x)
+    BOOST_PARAMETER_NAME(y)
+    BOOST_PARAMETER_NAME(z)
+
+    template <typename To>
+    struct predicate
+    {
+        template <typename From, typename Args>
+        struct apply
+          : boost::mpl::if_<
+                boost::is_convertible<From,To>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+        {
+        };
+    };
+} // namespace test
+
+#include <boost/container/string.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-    using namespace parameter;
+    test::check<
+        boost::parameter::parameters<test::tag::x,test::tag::y>
+    >((test::_x = 0, test::_y = 1), 0, 1);
 
-    check<
-        parameters<
-            tag::x
-          , tag::y
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::required<
+                boost::parameter::deduced<test::tag::y>
+              , test::predicate<int>
+            >
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::z>
+              , test::predicate<boost::container::string>
+            >
         >
     >(
-        (_x = 0, _y = 1)
+        (
+            test::_x = 0
+          , test::_y = test::not_present
+          , test::_z = boost::container::string("foo")
+        )
+      , test::_x = 0
+      , boost::container::string("foo")
+    );
+
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::required<
+                boost::parameter::deduced<test::tag::y>
+              , test::predicate<int>
+            >
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::z>
+              , test::predicate<boost::container::string>
+            >
+        >
+    >(
+        (
+            test::_x = 0
+          , test::_y = 1
+          , test::_z = boost::container::string("foo")
+        )
+      , 0
+      , boost::container::string("foo")
+      , 1
+    );
+
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::required<
+                boost::parameter::deduced<test::tag::y>
+              , test::predicate<int>
+            >
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::z>
+              , test::predicate<boost::container::string>
+            >
+        >
+    >(
+        (
+            test::_x = 0
+          , test::_y = 1
+          , test::_z = boost::container::string("foo")
+        )
       , 0
       , 1
+      , boost::container::string("foo")
     );
 
-    check<
-        parameters<
-            tag::x
-          , required<deduced<tag::y>, boost::is_convertible<mpl::_, int> >
-          , optional<deduced<tag::z>, boost::is_convertible<mpl::_, char const*> >
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::required<
+                boost::parameter::deduced<test::tag::y>
+              , test::predicate<int>
+            >
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::z>
+              , test::predicate<boost::container::string>
+            >
         >
     >(
-        (_x = 0, _y = not_present, _z = "foo")
-      , _x = 0
-      , "foo"
-    );
-
-    check<
-        parameters<
-            tag::x
-          , required<deduced<tag::y>, boost::is_convertible<mpl::_, int> >
-          , optional<deduced<tag::z>, boost::is_convertible<mpl::_, char const*> >
-        >
-    >(
-        (_x = 0, _y = 1, _z = "foo")
+        (
+            test::_x = 0
+          , test::_y = 1
+          , test::_z = boost::container::string("foo")
+        )
       , 0
-      , "foo"
+      , test::_y = 1
+      , boost::container::string("foo")
+    );
+
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::required<
+                boost::parameter::deduced<test::tag::y>
+              , test::predicate<int>
+            >
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::z>
+              , test::predicate<boost::container::string>
+            >
+        >
+    >(
+        (
+            test::_x = 0
+          , test::_y = 1
+          , test::_z = boost::container::string("foo")
+        )
+      , test::_z = boost::container::string("foo")
+      , test::_x = 0
       , 1
     );
 
-    check<
-        parameters<
-            tag::x
-          , required<deduced<tag::y>, boost::is_convertible<mpl::_, int> >
-          , optional<deduced<tag::z>, boost::is_convertible<mpl::_, char const*> >
+#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE)
+    // Fails because boost::parameter::aux::make_arg_list<> evaluates
+    // boost::parameter::aux::is_named_argument<> to boost::mpl::false_
+    // for static_cast<long*>(BOOST_TTI_DETAIL_NULLPTR).
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::required<
+                boost::parameter::deduced<test::tag::y>
+              , test::predicate<int>
+            >
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::z>
+              , test::predicate<boost::container::string>
+            >
         >
     >(
-        (_x = 0, _y = 1, _z = "foo")
-      , 0
-      , 1
-      , "foo"
-    );
-
-    check<
-        parameters<
-            tag::x
-          , required<deduced<tag::y>, boost::is_convertible<mpl::_, int> >
-          , optional<deduced<tag::z>, boost::is_convertible<mpl::_, char const*> >
-        >
-    >(
-        (_x = 0, _y = 1, _z = "foo")
-      , 0
-      , _y = 1
-      , "foo"
-    );
-
-    check<
-        parameters<
-            tag::x
-          , required<deduced<tag::y>, boost::is_convertible<mpl::_, int> >
-          , optional<deduced<tag::z>, boost::is_convertible<mpl::_, char const*> >
-        >
-    >(
-        (_x = 0, _y = 1, _z = "foo")
-      , _z = "foo"
-      , _x = 0
+        (
+            test::_x = 0
+          , test::_y = 1
+          , test::_z = boost::container::string("foo")
+        )
+      , test::_x = 0
+      , static_cast<long*>(BOOST_TTI_DETAIL_NULLPTR)
       , 1
     );
+#endif
 
-    // Fails becasue of parameters.hpp:428
-/*
-    check<
-        parameters<
-            tag::x
-          , required<deduced<tag::y>, boost::is_convertible<mpl::_, int> >
-          , optional<deduced<tag::z>, boost::is_convertible<mpl::_, char const*> >
-        >
-    >(
-        (_x = 0, _y = 1, _z = "foo")
-      , _x = 0
-      , (long*)0
-      , 1
-    );
-*/
-
-    return 0;
-};
+    return boost::report_errors();
+}
 

--- a/test/deduced.hpp
+++ b/test/deduced.hpp
@@ -1,77 +1,92 @@
-// Copyright Daniel Wallin 2006. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2006.
+// Copyright Cromwell D. Enage 2017.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_DEDUCED_060920_HPP
-# define BOOST_DEDUCED_060920_HPP
+#define BOOST_DEDUCED_060920_HPP
 
-# include <boost/mpl/for_each.hpp>
-# include "basics.hpp"
+#include <boost/mpl/for_each.hpp>
+#include "basics.hpp"
 
-struct not_present_tag {};
-not_present_tag not_present;
+namespace test {
 
-template <class E, class ArgPack>
-struct assert_expected
-{
-    assert_expected(E const& e, ArgPack const& args)
-      : expected(e)
-      , args(args)
-    {}
-
-    template <class T>
-    bool check_not_present(T const&) const
+    struct not_present_tag
     {
-        BOOST_MPL_ASSERT((boost::is_same<T,not_present_tag>));
-        return true;
+    };
+
+    not_present_tag not_present;
+
+    template <typename E, typename ArgPack>
+    struct assert_expected
+    {
+        assert_expected(E const& e, ArgPack const& args_)
+          : expected(e), args(args_)
+        {
+        }
+
+        template <typename T>
+        bool check_not_present(T const&) const
+        {
+            BOOST_MPL_ASSERT((
+                typename boost::mpl::if_<
+                    boost::is_same<T,test::not_present_tag>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >::type
+            ));
+            return true;
+        }
+
+        template <typename K>
+        bool check1(K const& k, test::not_present_tag const& t, long) const
+        {
+            return check_not_present(args[k | t]);
+        }
+
+        template <typename K, typename Expected>
+        bool check1(K const& k, Expected const& expected, int) const
+        {
+            return test::equal(args[k], expected);
+        }
+
+        template <typename K>
+        void operator()(K) const
+        {
+            boost::parameter::keyword<K> const&
+                k = boost::parameter::keyword<K>::instance;
+            BOOST_TEST(check1(k, expected[k], 0L));
+        }
+
+        E const& expected;
+        ArgPack const& args;
+    };
+
+    template <typename E, typename ArgPack>
+    void check0(E const& e, ArgPack const& args)
+    {
+        boost::mpl::for_each<E>(test::assert_expected<E,ArgPack>(e, args));
     }
 
-    template <class K>
-    bool check1(K const& k, not_present_tag const&, long) const
+    template <typename P, typename E, typename A0>
+    void check(E const& e, A0 const& a0)
     {
-        return check_not_present(args[k | not_present]);
+        test::check0(e, P()(a0));
     }
 
-    template <class K, class Expected>
-    bool check1(K const& k, Expected const& expected, int) const
+    template <typename P, typename E, typename A0, typename A1>
+    void check(E const& e, A0 const& a0, A1 const& a1)
     {
-        return test::equal(args[k], expected);
+        test::check0(e, P()(a0, a1));
     }
 
-    template <class K>
-    void operator()(K) const
+    template <typename P, typename E, typename A0, typename A1, typename A2>
+    void check(E const& e, A0 const& a0, A1 const& a1, A2 const& a2)
     {
-        boost::parameter::keyword<K> const& k = boost::parameter::keyword<K>::get();
-        assert(check1(k, expected[k], 0L));
+        test::check0(e, P()(a0, a1, a2));
     }
+} // namespace test
 
-    E const& expected;
-    ArgPack const& args;
-};
-
-template <class E, class ArgPack>
-void check0(E const& e, ArgPack const& args)
-{
-    boost::mpl::for_each<E>(assert_expected<E,ArgPack>(e, args));
-}
-
-template <class P, class E, class A0>
-void check(E const& e, A0 const& a0)
-{
-    check0(e, P()(a0));
-}
-
-template <class P, class E, class A0, class A1>
-void check(E const& e, A0 const& a0, A1 const& a1)
-{
-    check0(e, P()(a0,a1));
-}
-
-template <class P, class E, class A0, class A1, class A2>
-void check(E const& e, A0 const& a0, A1 const& a1, A2 const& a2)
-{
-    check0(e, P()(a0,a1,a2));
-}
-
-#endif // BOOST_DEDUCED_060920_HPP
+#endif  // include guard
 

--- a/test/deduced_dependent_predicate.cpp
+++ b/test/deduced_dependent_predicate.cpp
@@ -1,109 +1,117 @@
-// Copyright Daniel Wallin 2006. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2006.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/parameter/config.hpp>
 #include <boost/parameter/parameters.hpp>
 #include <boost/parameter/name.hpp>
 #include <boost/parameter/binding.hpp>
-#include <boost/type_traits.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/type_traits/is_convertible.hpp>
+#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#include <boost/type_traits/remove_reference.hpp>
+#else
+#include <boost/type_traits/add_lvalue_reference.hpp>
+#endif  // Borland workarounds needed.
 #include "deduced.hpp"
 
-namespace parameter = boost::parameter;
-namespace mpl = boost::mpl;
+namespace test {
 
-BOOST_PARAMETER_NAME(x)
-BOOST_PARAMETER_NAME(y)
-BOOST_PARAMETER_NAME(z)
+    BOOST_PARAMETER_NAME(x)
+    BOOST_PARAMETER_NAME(y)
+    BOOST_PARAMETER_NAME(z)
+} // namespace test
+
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-    using namespace parameter;
-    using boost::is_same;
-    using boost::remove_reference;
-    using boost::add_reference;
-
-    check<
-        parameters<
-            tag::x
-          , optional<
-                deduced<tag::y>
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))    
-              , is_same<
-                    mpl::_1
-                  , remove_reference<binding<mpl::_2,tag::x> >
-                > 
-#else
-              , is_same<
-                    add_reference<mpl::_1>
-                  , binding<mpl::_2,tag::x>
-                > 
-#endif
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::y>
+              , boost::mpl::if_<
+                    boost::is_same<
+#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+                        boost::mpl::_1
+                      , boost::remove_reference<
+                            boost::parameter::binding<
+                                boost::mpl::_2
+                              , test::tag::x
+                            >
+                        >
+#else   // !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+                        boost::add_lvalue_reference<boost::mpl::_1>
+                      , boost::parameter::binding<boost::mpl::_2,test::tag::x>
+#endif  // Borland workarounds needed.
+                    >
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >
             >
         >
-    >(
-        (_x = 0, _y = 1)
-      , 0
-      , 1
-    );
+    >((test::_x = 0, test::_y = 1), 0, 1);
 
-    check<
-        parameters<
-            tag::x
-          , optional<
-                deduced<tag::y>
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))    
-              , is_same<
-                    mpl::_1
-                  , remove_reference<binding<mpl::_2,tag::x> >
-                > 
-#else
-              , is_same<
-                    add_reference<mpl::_1>
-                  , binding<mpl::_2,tag::x>
-                > 
-#endif
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::y>
+              , boost::mpl::if_<
+                    boost::is_same<
+#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+                        boost::mpl::_1
+                      , boost::remove_reference<
+                            boost::parameter::binding<
+                                boost::mpl::_2
+                              , test::tag::x
+                            >
+                        >
+#else   // !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+                        boost::add_lvalue_reference<boost::mpl::_1>
+                      , boost::parameter::binding<boost::mpl::_2,test::tag::x>
+#endif  // Borland workarounds needed.
+                    >
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >
             >
         >
-    >(
-        (_x = 0U, _y = 1U)
-      , 0U
-      , 1U
-    );
+    >((test::_x = 0U, test::_y = 1U), 0U, 1U);
 
-    check<
-        parameters<
-            tag::x
-          , optional<
-                deduced<tag::y>
-              , is_same<
-                    mpl::_1
-                  , tag::x::_
-                > 
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::y>
+              , boost::mpl::if_<
+                    boost::is_convertible<boost::mpl::_1,test::tag::x::_>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >
             >
         >
-    >(
-        (_x = 0U, _y = 1U)
-      , 0U
-      , 1U
-    );
+    >((test::_x = 0U, test::_y = 1U), 0U, 1U);
 
-    check<
-        parameters<
-            tag::x
-          , optional<
-                deduced<tag::y>
-              , is_same<
-                    mpl::_1
-                  , tag::x::_1
-                > 
+    test::check<
+        boost::parameter::parameters<
+            test::tag::x
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::tag::y>
+              , boost::mpl::if_<
+                    boost::is_convertible<boost::mpl::_1,test::tag::x::_1>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >
             >
         >
-    >(
-        (_x = 0U, _y = 1U)
-      , 0U
-      , 1U
-    );
+    >((test::_x = 0U, test::_y = 1U), 0U, 1U);
 
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/duplicates.cpp
+++ b/test/duplicates.cpp
@@ -1,24 +1,28 @@
-// Copyright Daniel Wallin 2005. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/parameter.hpp>
-#include <string.h>
 #include "basics.hpp"
 
-namespace test
-{
-  template <class Params>
-  void f(Params const &) {}
+namespace test {
+
+    template <typename Params>
+    void f(Params const &)
+    {
+    }
 }
 
 int main()
 {
-   using namespace test;
-
-   f((name = 1, value = 1, test::index = 1, tester = 1,
-      value = 1 // repeated keyword: should not compile
-   ));
-   return 0;
+    test::f((
+        test::_name = 1
+      , test::_value = 1
+      , test::_index = 1
+      , test::_tester = 1
+      , test::_value = 1 // repeated keyword: should not compile
+    ));
+    return 0;
 }
 

--- a/test/earwicker.cpp
+++ b/test/earwicker.cpp
@@ -1,56 +1,97 @@
-// Copyright David Abrahams, Daniel Wallin 2005. Use, modification and 
-// distribution is subject to the Boost Software License, Version 1.0. 
-// (See accompanying file LICENSE_1_0.txt or copy at 
+// Copyright David Abrahams, Daniel Wallin 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/parameter.hpp>
-#include <boost/type_traits/is_convertible.hpp>
-#include <boost/mpl/placeholders.hpp>
-#include <iostream>
+#include <boost/parameter/config.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 4)
+#error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
+#endif
+
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
-BOOST_PARAMETER_KEYWORD(tag, x)
-BOOST_PARAMETER_KEYWORD(tag, y)
-BOOST_PARAMETER_KEYWORD(tag, z)
+    BOOST_PARAMETER_NAME(w)
+    BOOST_PARAMETER_NAME(x)
+    BOOST_PARAMETER_NAME(y)
+    BOOST_PARAMETER_NAME(z)
+} // namespace test
 
-using namespace boost::parameter;
-using namespace boost::mpl::placeholders;
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 
-struct f_parameters // vc6 is happier with inheritance than with a typedef
-  : parameters<
-        optional<tag::x,boost::is_convertible<_,int> >
-      , optional<tag::y,boost::is_convertible<_,int> >
-      , optional<tag::z,boost::is_convertible<_,int> >
-    >
-{};
+namespace test {
 
-#ifdef BOOST_NO_VOID_RETURNS
-BOOST_PARAMETER_FUN(int, f, 0, 3, f_parameters)
-#else 
-BOOST_PARAMETER_FUN(void, f, 0, 3, f_parameters)
+    struct f_predicate
+    {
+        template <typename T, typename Args>
+        struct apply
+          : boost::mpl::if_<
+                boost::is_convertible<T,int>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+        {
+        };
+    };
+} // namespace test
+
+#include <boost/parameter/parameters.hpp>
+
+namespace test {
+
+    struct f_parameters // vc6 is happier with inheritance than with a typedef
+      : boost::parameter::parameters<
+            boost::parameter::required<test::tag::w>
+          , boost::parameter::optional<test::tag::x,test::f_predicate>
+          , boost::parameter::optional<test::tag::y,test::f_predicate>
+          , boost::parameter::optional<test::tag::z,test::f_predicate>
+        >
+    {
+    };
+} // namespace test
+
+#include <boost/parameter/macros.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+namespace test {
+
+#if defined(BOOST_NO_VOID_RETURNS)
+    BOOST_PARAMETER_FUN(int, f, 1, 4, f_parameters)
+#else
+    BOOST_PARAMETER_FUN(void, f, 1, 4, f_parameters)
 #endif 
-{
-    std::cout << "x = " << p[x | -1] << std::endl;
-    std::cout << "y = " << p[y | -2] << std::endl;
-    std::cout << "z = " << p[z | -3] << std::endl;
-    std::cout <<  "================" << std::endl;
-#ifdef BOOST_NO_VOID_RETURNS
-    return 0;
+    {
+        BOOST_TEST_EQ(p[test::_w][0], p[test::_x | -1]);
+        BOOST_TEST_EQ(p[test::_w][1], p[test::_y | -2]);
+        BOOST_TEST_EQ(p[test::_w][2], p[test::_z | -3]);
+#if defined(BOOST_NO_VOID_RETURNS)
+        return 0;
 #endif 
-}
-
-}
-
+    }
+} // namespace test
 
 int main()
 {
-    using namespace test;
-    f(x = 1, y = 2, z = 3);
-    f(x = 1);
-    f(y = 2);
-    f(z = 3);
-    f(z = 3, x = 1);
+    int a[3];
+    a[0] = 1;
+    a[1] = 2;
+    a[2] = 3;
+    test::f(test::_x = 1, test::_y = 2, test::_z = 3, test::_w = a);
+    a[1] = -2;
+    a[2] = -3;
+    test::f(test::_x = 1, test::_w = a);
+    a[0] = -1;
+    a[1] = 2;
+    test::f(test::_y = 2, test::_w = a);
+    a[1] = -2;
+    a[2] = 3;
+    test::f(test::_z = 3, test::_w = a);
+    a[0] = 1;
+    test::f(test::_z = 3, test::_x = 1, test::_w = a);
+    return boost::report_errors();
 }
-
 

--- a/test/efficiency.cpp
+++ b/test/efficiency.cpp
@@ -1,195 +1,195 @@
-// Copyright David Abrahams, Matthias Troyer, Michael Gauckler
-// 2005. Distributed under the Boost Software License, Version
-// 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// Copyright David Abrahams, Matthias Troyer, Michael Gauckler 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/parameter.hpp>
+#include <boost/config/workaround.hpp>
 #include <boost/timer.hpp>
 #include <iostream>
 
-namespace test
-{
-  //
-  // This test measures the abstraction overhead of using the named
-  // parameter interface.  Some actual test results have been recorded
-  // in timings.txt in this source file's directory, or
-  // http://www.boost.org/libs/parameter/test/timings.txt.
-  //
-  // Caveats:
-  //
-  //   1. This test penalizes the named parameter library slightly, by
-  //      passing two arguments through the named interface, while
-  //      only passing one through the plain C++ interface.
-  //
-  //   2. This test does not measure the case where an ArgumentPack is
-  //      so large that it doesn't fit in the L1 cache.
-  //
-  //   3. Although we've tried to make this test as general as
-  //      possible, we are targeting it at a specific application.
-  //      Where that affects design decisions, we've noted it below in
-  //      ***...***.
-  //
-  //   4. The first time you run this program, the time may not be
-  //      representative because of disk and memory cache effects, so
-  //      always run it multiple times and ignore the first
-  //      measurement.  This approach will also allow you to estimate
-  //      the statistical error of your test by observing the
-  //      variation in the valid times.
-  //
-  //   5. Try to run this program on a machine that's otherwise idle,
-  //      or other processes and even device hardware interrupts may
-  //      interfere by causing caches to be flushed.
-  
-  // Accumulator function object with plain C++ interface 
-  template <class T>
-  struct plain_weight_running_total
-  {
-      plain_weight_running_total()
+namespace test {
+
+    //
+    // This test measures the abstraction overhead of using the named
+    // parameter interface.  Some actual test results have been recorded
+    // in timings.txt in this source file's directory, or
+    // http://www.boost.org/libs/parameter/test/timings.txt.
+    //
+    // Caveats:
+    //
+    //   1. This test penalizes the named parameter library slightly, by
+    //      passing two arguments through the named interface, while
+    //      only passing one through the plain C++ interface.
+    //
+    //   2. This test does not measure the case where an ArgumentPack is
+    //      so large that it doesn't fit in the L1 cache.
+    //
+    //   3. Although we've tried to make this test as general as possible,
+    //      we are targeting it at a specific application.  Where that
+    //      affects design decisions, we've noted it below in ***...***.
+    //
+    //   4. The first time you run this program, the time may not be
+    //      representative because of disk and memory cache effects, so
+    //      always run it multiple times and ignore the first
+    //      measurement.  This approach will also allow you to estimate
+    //      the statistical error of your test by observing the
+    //      variation in the valid times.
+    //
+    //   5. Try to run this program on a machine that's otherwise idle,
+    //      or other processes and even device hardware interrupts may
+    //      interfere by causing caches to be flushed.
+
+    // Accumulator function object with plain C++ interface 
+    template <typename T>
+    struct plain_weight_running_total
+    {
+        plain_weight_running_total()
 #if BOOST_WORKAROUND(BOOST_MSVC, < 1300)
-        : sum(T())
+          : sum(T())
 #else
-        : sum()
-#endif 
-      {}
-      
-      void operator()(T w)
-      {
-          this->sum += w;
-      }
+          : sum()
+#endif
+        {
+        }
 
-      T sum;
-  };
+        void operator()(T w)
+        {
+            this->sum += w;
+        }
 
-  BOOST_PARAMETER_KEYWORD(tag, weight)
-  BOOST_PARAMETER_KEYWORD(tag, value)
-      
-  // Accumulator function object with named parameter interface
-  template <class T>
-  struct named_param_weight_running_total
-  {
-      named_param_weight_running_total()
+        T sum;
+    };
+
+    BOOST_PARAMETER_NAME(weight)
+    BOOST_PARAMETER_NAME(value)
+
+    // Accumulator function object with named parameter interface
+    template <typename T>
+    struct named_param_weight_running_total
+    {
+        named_param_weight_running_total()
 #if BOOST_WORKAROUND(BOOST_MSVC, < 1300)
-        : sum(T())
+          : sum(T())
 #else
-        : sum()
-#endif 
-      {}
+          : sum()
+#endif
+        {
+        }
 
-      template <class ArgumentPack>
-      void operator()(ArgumentPack const& variates)
-      {
-          this->sum += variates[weight];
-      }
+        template <typename ArgumentPack>
+        void operator()(ArgumentPack const& variates)
+        {
+            this->sum += variates[test::_weight];
+        }
 
-      T sum;
-  };
+        T sum;
+    };
 
-  // This value is required to ensure that a smart compiler's dead
-  // code elimination doesn't optimize away anything we're testing.
-  // We'll use it to compute the return code of the executable to make
-  // sure it's needed.
-  double live_code;
+    // This value is required to ensure that a smart compiler's dead code
+    // elimination doesn't optimize away anything we're testing.  We'll use it
+    // to compute the return code of the executable to make sure it's needed.
+    double live_code;
 
-  // Call objects of the given Accumulator type repeatedly with x as
-  // an argument.
-  template <class Accumulator, class Arg>
-  void hammer(Arg const& x, long const repeats)
-  {
-      // Strategy: because the sum in an accumulator after each call
-      // depends on the previous value of the sum, the CPU's pipeline
-      // might be stalled while waiting for the previous addition to
-      // complete.  Therefore, we allocate an array of accumulators,
-      // and update them in sequence, so that there's no dependency
-      // between adjacent addition operations.
-      //
-      // Additionally, if there were only one accumulator, the
-      // compiler or CPU might decide to update the value in a
-      // register rather that writing it back to memory.  we want each
-      // operation to at least update the L1 cache.  *** Note: This
-      // concern is specific to the particular application at which
-      // we're targeting the test. ***
+    // Call objects of the given Accumulator type repeatedly
+    // with x an argument.
+    template <typename Accumulator, typename Arg>
+    void hammer(Arg const& x, long const repeats)
+    {
+        // Strategy: because the sum in an accumulator after each call
+        // depends on the previous value of the sum, the CPU's pipeline
+        // might be stalled while waiting for the previous addition to
+        // complete.  Therefore, we allocate an array of accumulators,
+        // and update them in sequence, so that there's no dependency
+        // between adjacent addition operations.
+        //
+        // Additionally, if there were only one accumulator, the compiler or
+        // CPU might decide to update the value in a register rather than
+        // writing it back to memory.  We want each operation to at least
+        // update the L1 cache.  *** Note: This concern is specific to the
+        // particular application at which we're targeting the test. ***
 
-      // This has to be at least as large as the number of
-      // simultaneous accumulations that can be executing in the
-      // compiler pipeline.  A safe number here is larger than the
-      // machine's maximum pipeline depth. If you want to test the L2
-      // or L3 cache, or main memory, you can increase the size of
-      // this array.  1024 is an upper limit on the pipeline depth of
-      // current vector machines.
-      const std::size_t number_of_accumulators = 1024;
-      
-      Accumulator a[number_of_accumulators];
-      
-      for (long iteration = 0; iteration < repeats; ++iteration)
-      {
-          for (Accumulator* ap = a;  ap < a + number_of_accumulators; ++ap)
-          {
-              (*ap)(x);
-          }
-      }
+        // This has to be at least as large as the number of simultaneous
+        // accumulations that can be executing in the compiler pipeline.  A
+        // safe number here is larger than the machine's maximum pipeline
+        // depth.  If you want to test the L2 or L3 cache, or main memory,
+        // you can increase the size of this array.  1024 is an upper limit
+        // on the pipeline depth of current vector machines.
+        std::size_t const number_of_accumulators = 1024;
 
-      // Accumulate all the partial sums to avoid dead code
-      // elimination.
-      for (Accumulator* ap = a;  ap < a + number_of_accumulators; ++ap)
-      {
-          live_code += ap->sum;
-      }
-  }
+        Accumulator a[number_of_accumulators];
 
-  // Measure the time required to hammer accumulators of the given
-  // type with the argument x.
-  template <class Accumulator, class T>
-  double measure(T const& x, long const repeats)
-  {
-      // Hammer accumulators a couple of times to ensure the
-      // instruction cache is full of our test code, and that we don't
-      // measure the cost of a page fault for accessing the data page
-      // containing the memory where the accumulators will be
-      // allocated
-      hammer<Accumulator>(x, repeats);
-      hammer<Accumulator>(x, repeats);
+        for (long iteration = 0; iteration < repeats; ++iteration)
+        {
+            for (Accumulator* ap = a; ap < a + number_of_accumulators; ++ap)
+            {
+                (*ap)(x);
+            }
+        }
 
-      // Now start a timer
-      boost::timer time;
-      hammer<Accumulator>(x, repeats);  // This time, we'll measure
-      return time.elapsed();
-  }
+        // Accumulate all the partial sums to avoid dead code elimination.
+        for (Accumulator* ap = a; ap < a + number_of_accumulators; ++ap)
+        {
+            test::live_code += ap->sum;
+        }
+    }
+
+    // Measure the time required to hammer accumulators of the given
+    // type with the argument x.
+    template <typename Accumulator, typename T>
+    double measure(T const& x, long const repeats)
+    {
+        // Hammer accumulators a couple of times to ensure the instruction
+        // cache is full of our test code, and that we don't measure the cost
+        // of a page fault for accessing the data page containing the memory
+        // where the accumulators will be allocated.
+        test::hammer<Accumulator>(x, repeats);
+        test::hammer<Accumulator>(x, repeats);
+
+        // Now start a timer.
+        boost::timer time;
+        test::hammer<Accumulator>(x, repeats);  // This time, we'll measure.
+        return time.elapsed();
+    }
 }
 
 int main()
 {
-    using namespace test;
-
-    // first decide how many repetitions to measure
+    // First decide how many repetitions to measure.
     long repeats = 100;
     double measured = 0;
+
     while (measured < 1.0 && repeats <= 10000000)
     {
         repeats *= 10;
-        
+
         boost::timer time;
 
-        hammer<plain_weight_running_total<double> >(.1, repeats);
-        hammer<named_param_weight_running_total<double> >(
-            (weight = .1, value = .2), repeats);
+        test::hammer<test::plain_weight_running_total<double> >(.1, repeats);
+        test::hammer<test::named_param_weight_running_total<double> >(
+            (test::_weight = .1, test::_value = .2), repeats
+        );
 
         measured = time.elapsed();
     }
     
     std::cout
         << "plain time:           "
-        << measure<plain_weight_running_total<double> >(.1, repeats)
+        << test::measure<test::plain_weight_running_total<double> >(
+            .1, repeats
+        )
         << std::endl;
-    
+
     std::cout
         << "named parameter time: "
-        << measure<named_param_weight_running_total<double> >(
-            (weight = .1, value = .2), repeats
+        << test::measure<test::named_param_weight_running_total<double> >(
+            (test::_weight = .1, test::_value = .2), repeats
         )
         << std::endl;
 
     // This is ultimately responsible for preventing all the test code
     // from being optimized away.  Change this to return 0 and you
     // unplug the whole test's life support system.
-    return live_code < 0.;
+    return test::live_code < 0.;
 }
+

--- a/test/literate/Jamfile.v2
+++ b/test/literate/Jamfile.v2
@@ -5,7 +5,7 @@ run extracting-parameter-types0.cpp ;
 run extracting-parameter-types1.cpp ;
 compile template-keywords0.cpp ;
 compile template-keywords1.cpp ;
-compile top-level0.cpp ;
+run top-level0.cpp ;
 compile headers-and-namespaces0.cpp ;
 compile predicate-requirements0.cpp ;
 compile handling-out-parameters0.cpp ;

--- a/test/literate/building-argumentpacks0.cpp
+++ b/test/literate/building-argumentpacks0.cpp
@@ -1,47 +1,61 @@
 
 #include <boost/parameter.hpp>
 #include <iostream>
+
 BOOST_PARAMETER_NAME(index)
 
-template <class ArgumentPack>
+template <typename ArgumentPack>
 int print_index(ArgumentPack const& args)
 {
     std::cout << "index = " << args[_index] << std::endl;
     return 0;
 }
 
-int x = print_index(_index = 3);  // prints "index = 3"
-
 BOOST_PARAMETER_NAME(name)
 
-template <class ArgumentPack>
+template <typename ArgumentPack>
 int print_name_and_index(ArgumentPack const& args)
 {
     std::cout << "name = " << args[_name] << "; ";
     return print_index(args);
 }
 
-int y = print_name_and_index((_index = 3, _name = "jones"));
+#include <boost/core/lightweight_test.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 
-
-namespace parameter = boost::parameter;
-using parameter::required;
-using parameter::optional;
-using boost::is_convertible;
-using boost::mpl::_;
-parameter::parameters<
-    required<tag::name, is_convertible<_,char const*> >
-  , optional<tag::index, is_convertible<_,int> >
-> spec;
-
-char const sam[] = "sam";
-int twelve = 12;
-
-int z0 = print_name_and_index( spec(sam, twelve) );
-
-int z1 = print_name_and_index(
-   spec(_index=12, _name="sam")
-);
 int main()
-{}
+{
+    int x = print_index(_index = 3);  // prints "index = 3"
+    int y = print_name_and_index((_index = 3, _name = "jones"));
+    boost::parameter::parameters<
+        boost::parameter::required<
+            tag::name
+          , boost::mpl::if_<
+                boost::is_convertible<boost::mpl::_,char const*>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+        >
+      , boost::parameter::optional<
+            tag::index
+          , boost::mpl::if_<
+                boost::is_convertible<boost::mpl::_,int>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+        >
+    > spec;
+    char const sam[] = "sam";
+    int twelve = 12;
+    int z0 = print_name_and_index(spec(sam, twelve));
+    int z1 = print_name_and_index(spec(_index=12, _name="sam"));
+    BOOST_TEST(!x);
+    BOOST_TEST(!y);
+    BOOST_TEST(!z0);
+    BOOST_TEST(!z1);
+    return boost::report_errors();
+}
 

--- a/test/literate/deduced-parameters0.cpp
+++ b/test/literate/deduced-parameters0.cpp
@@ -8,67 +8,84 @@ BOOST_PARAMETER_NAME(keywords)
 BOOST_PARAMETER_NAME(policies)
 
 struct default_call_policies
-{};
+{
+};
 
 struct no_keywords
-{};
+{
+};
 
 struct keywords
-{};
+{
+};
 
-template <class T>
+#include <boost/mpl/bool.hpp>
+
+template <typename T>
 struct is_keyword_expression
   : boost::mpl::false_
-{};
+{
+};
 
 template <>
 struct is_keyword_expression<keywords>
   : boost::mpl::true_
-{};
+{
+};
 
 default_call_policies some_policies;
 
 void f()
-{}
-namespace mpl = boost::mpl;
+{
+}
+
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 
 BOOST_PARAMETER_FUNCTION(
     (void), def, tag,
-
-    (required (name,(char const*)) (func,*) )   // nondeduced
-
+    (required (name,(char const*)) (func,*) )  // nondeduced
     (deduced
-      (optional
-        (docstring, (char const*), "")
+        (optional
+            (docstring, (char const*), "")
+            (keywords
+              , *(is_keyword_expression<boost::mpl::_>) // see 5
+              , no_keywords()
+            )
+            (policies
+              , *(
+                    boost::mpl::eval_if<
+                        boost::is_convertible<boost::mpl::_,char const*>
+                      , boost::mpl::false_
+                      , boost::mpl::if_<
+                            is_keyword_expression<boost::mpl::_> // see 5
+                          , boost::mpl::false_
+                          , boost::mpl::true_
+                        >
+                    >
+                )
+              , default_call_policies()
+            )
+        )
+    )
+)
+{
+}
 
-        (keywords
-           , *(is_keyword_expression<mpl::_>) // see 5
-           , no_keywords())
-
-        (policies
-           , *(mpl::not_<
-                 mpl::or_<
-                     boost::is_convertible<mpl::_, char const*>
-                   , is_keyword_expression<mpl::_> // see 5
-                 >
-             >)
-           , default_call_policies()
-         )
-       )
-     )
- )
- {
-    
- }
-
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-def("f", &f, some_policies, "Documentation for f");
-def("f", &f, "Documentation for f", some_policies);
-
-def(
-    "f", &f
-   , _policies = some_policies, "Documentation for f");
+    def("f", &f, some_policies, "Documentation for f");
+    def("f", &f, "Documentation for f", some_policies);
+    def(
+        "f"
+      , &f
+      , _policies = some_policies
+      , "Documentation for f"
+    );
+    return boost::report_errors();
 }
 

--- a/test/literate/deduced-template-parameters0.cpp
+++ b/test/literate/deduced-template-parameters0.cpp
@@ -1,124 +1,214 @@
 
 #include <boost/parameter.hpp>
-#include <boost/mpl/is_sequence.hpp>
+
+namespace boost { namespace python {
+
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(class_type)
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(base_list)
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(held_type)
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(copyable)
+}}
+
+namespace boost { namespace python {
+    namespace detail {
+
+        struct bases_base
+        {
+        };
+    }
+
+    template <typename A0 = void, typename A1 = void, typename A2 = void>
+    struct bases : detail::bases_base
+    {
+    };
+}}
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/eval_if.hpp>
 #include <boost/noncopyable.hpp>
-#include <memory>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+#include <boost/type_traits/is_class.hpp>
 #include <boost/config.hpp>
 
-using namespace boost::parameter;
-using boost::mpl::_;
+#if !defined(BOOST_TT_HAS_CONFORMING_IS_CLASS_IMPLEMENTATION) || \
+    !(1 == BOOST_TT_HAS_CONFORMING_IS_CLASS_IMPLEMENTATION)
+#include <boost/type_traits/is_scalar.hpp>
+#endif
 
 namespace boost { namespace python {
 
-BOOST_PARAMETER_TEMPLATE_KEYWORD(class_type)
-BOOST_PARAMETER_TEMPLATE_KEYWORD(base_list)
-BOOST_PARAMETER_TEMPLATE_KEYWORD(held_type)
-BOOST_PARAMETER_TEMPLATE_KEYWORD(copyable)
-
-}}
-namespace boost { namespace python {
-
-namespace detail { struct bases_base {}; }
-
-template <class A0 = void, class A1 = void, class A2 = void  >
-struct bases : detail::bases_base
-{};
-
-}}
-
-
-#include <boost/type_traits/is_class.hpp>
-namespace boost { namespace python {
-typedef parameter::parameters<
-    required<tag::class_type, is_class<_> >
-
-  , parameter::optional<
-        deduced<tag::base_list>
-      , is_base_and_derived<detail::bases_base,_>
-    >
-
-  , parameter::optional<
-        deduced<tag::held_type>
-      , mpl::not_<
-            mpl::or_<
-                is_base_and_derived<detail::bases_base,_>
-              , is_same<noncopyable,_>
+    typedef boost::parameter::parameters<
+        boost::parameter::required<
+            tag::class_type
+#if defined(BOOST_TT_HAS_CONFORMING_IS_CLASS_IMPLEMENTATION) && \
+    (1 == BOOST_TT_HAS_CONFORMING_IS_CLASS_IMPLEMENTATION)
+          , boost::mpl::if_<
+                boost::is_class<boost::mpl::_>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+#else
+          , boost::mpl::if_<
+                boost::is_scalar<boost::mpl::_>
+              , boost::mpl::false_
+              , boost::mpl::true_
+            >
+#endif
+        >
+      , boost::parameter::optional<
+            boost::parameter::deduced<tag::base_list>
+          , boost::mpl::if_<
+                boost::is_base_of<detail::bases_base,boost::mpl::_>
+              , boost::mpl::true_
+              , boost::mpl::false_
             >
         >
+      , boost::parameter::optional<
+            boost::parameter::deduced<tag::held_type>
+          , boost::mpl::eval_if<
+                boost::is_base_of<detail::bases_base,boost::mpl::_>
+              , boost::mpl::false_
+              , boost::mpl::if_<
+                    boost::is_same<boost::noncopyable,boost::mpl::_>
+                  , boost::mpl::false_
+                  , boost::mpl::true_
+                >
+            >
+        >
+      , boost::parameter::optional<
+            boost::parameter::deduced<tag::copyable>
+          , boost::mpl::if_<
+                boost::is_same<boost::noncopyable,boost::mpl::_>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+        >
+    > class_signature;
+
+    template <
+        typename A0
+      , typename A1 = boost::parameter::void_
+      , typename A2 = boost::parameter::void_
+      , typename A3 = boost::parameter::void_
     >
+    struct class_
+    {
+        // Create ArgumentPack
+        typedef typename boost::python::class_signature::BOOST_NESTED_TEMPLATE
+        bind<A0,A1,A2,A3>::type args;
 
-  , parameter::optional<deduced<tag::copyable>, is_same<noncopyable,_> >
+        // Extract first logical parameter.
+        typedef typename boost::parameter::value_type<
+            args,boost::python::tag::class_type
+        >::type class_type;
 
-> class_signature;
-template <
-    class A0
-  , class A1 = parameter::void_
-  , class A2 = parameter::void_
-  , class A3 = parameter::void_
->
-struct class_
-{
-    // Create ArgumentPack
-    typedef typename
-      class_signature::bind<A0,A1,A2,A3>::type
-    args;
+        typedef typename boost::parameter::value_type<
+            args,boost::python::tag::base_list,boost::python::bases<>
+        >::type base_list;
 
-    // Extract first logical parameter.
-    typedef typename parameter::value_type<
-      args, tag::class_type>::type class_type;
+        typedef typename boost::parameter::value_type<
+            args,boost::python::tag::held_type,class_type
+        >::type held_type;
 
-    typedef typename parameter::value_type<
-      args, tag::base_list, bases<> >::type base_list;
-
-    typedef typename parameter::value_type<
-      args, tag::held_type, class_type>::type held_type;
-
-    typedef typename parameter::value_type<
-      args, tag::copyable, void>::type copyable;
-};
-
+        typedef typename boost::parameter::value_type<
+            args,boost::python::tag::copyable,void
+        >::type copyable;
+    };
 }}
 
+struct B
+{
+};
 
+struct D
+{
+};
 
-struct B {};
-struct D {};
+typedef boost::python::class_<B,boost::noncopyable> c1;
 
-using boost::python::bases;
-typedef boost::python::class_<B, boost::noncopyable> c1;
-
-#if defined(BOOST_NO_CXX11_SMART_PTR)
-
-typedef boost::python::class_<D, std::auto_ptr<D>, bases<B> > c2;
-
-#else
-
-typedef boost::python::class_<D, std::unique_ptr<D>, bases<B> > c2;
-
-#endif
-
-BOOST_MPL_ASSERT((boost::is_same<c1::class_type, B>));
-BOOST_MPL_ASSERT((boost::is_same<c1::base_list, bases<> >));
-BOOST_MPL_ASSERT((boost::is_same<c1::held_type, B>));
-BOOST_MPL_ASSERT((
-     boost::is_same<c1::copyable, boost::noncopyable>
-));
-
-BOOST_MPL_ASSERT((boost::is_same<c2::class_type, D>));
-BOOST_MPL_ASSERT((boost::is_same<c2::base_list, bases<B> >));
+#include <memory>
 
 #if defined(BOOST_NO_CXX11_SMART_PTR)
-
-BOOST_MPL_ASSERT((
-    boost::is_same<c2::held_type, std::auto_ptr<D> >
-));
-
+typedef boost::python::class_<D,std::auto_ptr<D>,boost::python::bases<B> > c2;
 #else
-
-BOOST_MPL_ASSERT((
-    boost::is_same<c2::held_type, std::unique_ptr<D> >
-));
-
+typedef boost::python::class_<
+    D,std::unique_ptr<D>,boost::python::bases<B>
+> c2;
 #endif
 
-BOOST_MPL_ASSERT((boost::is_same<c2::copyable, void>));
+#include <boost/mpl/assert.hpp>
+#include <boost/mpl/aux_/test.hpp>
+
+MPL_TEST_CASE()
+{
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c1::class_type,B>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c1::base_list,boost::python::bases<> >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c1::held_type,B>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c1::copyable,boost::noncopyable>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::class_type,D>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::base_list,boost::python::bases<B> >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+#if defined(BOOST_NO_CXX11_SMART_PTR)
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::held_type,std::auto_ptr<D> >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+#else
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::held_type,std::unique_ptr<D> >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+#endif  // BOOST_NO_CXX11_SMART_PTR
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::copyable,void>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+}
+

--- a/test/literate/default-expression-evaluation0.cpp
+++ b/test/literate/default-expression-evaluation0.cpp
@@ -7,33 +7,35 @@ BOOST_PARAMETER_NAME(visitor)
 BOOST_PARAMETER_NAME(root_vertex)
 BOOST_PARAMETER_NAME(index_map)
 BOOST_PARAMETER_NAME(color_map)
+
 #include <boost/graph/depth_first_search.hpp> // for dfs_visitor
 
-BOOST_PARAMETER_FUNCTION(
-    (void), depth_first_search, tag
-    
-, (required
-    (graph, *)
-    (visitor, *)
-    (root_vertex, *)
-    (index_map, *)
-    (color_map, *)
-  )
-
+BOOST_PARAMETER_FUNCTION((void), depth_first_search, tag,
+    (required
+        (graph, *)
+        (visitor, *)
+        (root_vertex, *)
+        (index_map, *)
+        (color_map, *)
+    )
 )
 {
-   std::cout << "graph=" << graph << std::endl;
-   std::cout << "visitor=" << visitor << std::endl;
-   std::cout << "root_vertex=" << root_vertex << std::endl;
-   std::cout << "index_map=" << index_map << std::endl;
-   std::cout << "color_map=" << color_map << std::endl;
+    std::cout << "graph=" << graph << std::endl;
+    std::cout << "visitor=" << visitor << std::endl;
+    std::cout << "root_vertex=" << root_vertex << std::endl;
+    std::cout << "index_map=" << index_map << std::endl;
+    std::cout << "color_map=" << color_map << std::endl;
 }
+
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
     depth_first_search(1, 2, 3, 4, 5);
-
     depth_first_search(
-        "1", '2', _color_map = '5',
-        _index_map = "4", _root_vertex = "3");
+        "1", '2', _color_map = '5'
+      , _index_map = "4", _root_vertex = "3"
+    );
+    return boost::report_errors();
 }
+

--- a/test/literate/defining-the-keywords1.cpp
+++ b/test/literate/defining-the-keywords1.cpp
@@ -1,13 +1,21 @@
 
 #include <boost/parameter/keyword.hpp>
-namespace graphs
-{
-  namespace tag { struct graph; } // keyword tag type
 
-  namespace // unnamed
-  {
-    // A reference to the keyword object
-    boost::parameter::keyword<tag::graph>& _graph
-    = boost::parameter::keyword<tag::graph>::get();
-  }
+namespace graphs {
+    namespace tag {
+
+        // keyword tag type
+        struct graph
+        {
+            typedef boost::parameter::forward_reference qualifier;
+        };
+    }
+
+    namespace // unnamed
+    {
+        // A reference to the keyword object
+        boost::parameter::keyword<tag::graph> const& _graph
+            = boost::parameter::keyword<tag::graph>::instance;
+    }
 }
+

--- a/test/literate/exercising-the-code-so-far0.cpp
+++ b/test/literate/exercising-the-code-so-far0.cpp
@@ -1,118 +1,193 @@
 
 #include <boost/parameter.hpp>
+
+namespace boost { namespace python {
+
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(class_type)
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(base_list)
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(held_type)
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(copyable)
+
+    template <typename B = int>
+    struct bases
+    {
+    };
+}}
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/mpl/is_sequence.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/type_traits/is_class.hpp>
-#include <memory>
 #include <boost/config.hpp>
 
-using namespace boost::parameter;
+#if !defined(BOOST_TT_HAS_CONFORMING_IS_CLASS_IMPLEMENTATION) || \
+    !(1 == BOOST_TT_HAS_CONFORMING_IS_CLASS_IMPLEMENTATION)
+#include <boost/type_traits/is_scalar.hpp>
+#endif
 
 namespace boost { namespace python {
 
-BOOST_PARAMETER_TEMPLATE_KEYWORD(class_type)
-BOOST_PARAMETER_TEMPLATE_KEYWORD(base_list)
-BOOST_PARAMETER_TEMPLATE_KEYWORD(held_type)
-BOOST_PARAMETER_TEMPLATE_KEYWORD(copyable)
+    typedef boost::parameter::parameters<
+        boost::parameter::required<
+            tag::class_type
+#if defined(BOOST_TT_HAS_CONFORMING_IS_CLASS_IMPLEMENTATION) && \
+    (1 == BOOST_TT_HAS_CONFORMING_IS_CLASS_IMPLEMENTATION)
+          , boost::mpl::if_<
+                boost::is_class<boost::mpl::_>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+#else
+          , boost::mpl::if_<
+                boost::is_scalar<boost::mpl::_>
+              , boost::mpl::false_
+              , boost::mpl::true_
+            >
+#endif
+        >
+      , boost::parameter::optional<
+            tag::base_list
+          , boost::mpl::is_sequence<boost::mpl::_>
+        >
+      , boost::parameter::optional<tag::held_type>
+      , boost::parameter::optional<tag::copyable>
+    > class_signature;
+}} // namespace boost::python
 
-template <class B = int>
-struct bases
-{};
-
-}}
 namespace boost { namespace python {
 
-using boost::mpl::_;
+    template <
+        typename A0
+      , typename A1 = boost::parameter::void_
+      , typename A2 = boost::parameter::void_
+      , typename A3 = boost::parameter::void_
+    >
+    struct class_
+    {
+        // Create ArgumentPack
+        typedef typename class_signature::BOOST_NESTED_TEMPLATE bind<
+            A0, A1, A2, A3
+        >::type args;
 
-typedef parameter::parameters<
-    required<tag::class_type, boost::is_class<_> >
-  , parameter::optional<tag::base_list, mpl::is_sequence<_> >
-  , parameter::optional<tag::held_type>
-  , parameter::optional<tag::copyable>
-> class_signature;
+        // Extract first logical parameter.
+        typedef typename boost::parameter::value_type<
+            args, tag::class_type
+        >::type class_type;
 
-}}
+        typedef typename boost::parameter::value_type<
+            args, tag::base_list, boost::python::bases<>
+        >::type base_list;
 
-namespace boost { namespace python {
+        typedef typename boost::parameter::value_type<
+            args, tag::held_type, class_type
+        >::type held_type;
 
-template <
-    class A0
-  , class A1 = parameter::void_
-  , class A2 = parameter::void_
-  , class A3 = parameter::void_
->
-struct class_
+        typedef typename boost::parameter::value_type<
+            args, tag::copyable, void
+        >::type copyable;
+    };
+}} // namespace boost::python
+
+struct B
 {
-    // Create ArgumentPack
-    typedef typename
-      class_signature::bind<A0,A1,A2,A3>::type
-    args;
-
-    // Extract first logical parameter.
-    typedef typename parameter::value_type<
-      args, tag::class_type>::type class_type;
-
-    typedef typename parameter::value_type<
-      args, tag::base_list, bases<> >::type base_list;
-
-    typedef typename parameter::value_type<
-      args, tag::held_type, class_type>::type held_type;
-
-    typedef typename parameter::value_type<
-      args, tag::copyable, void>::type copyable;
 };
 
-}}
+struct D
+{
+};
 
+#include <boost/noncopyable.hpp>
+#include <memory>
 
-using boost::python::class_type;
-using boost::python::copyable;
-using boost::python::held_type;
-using boost::python::base_list;
-using boost::python::bases;
-
-struct B {};
-struct D {};
 typedef boost::python::class_<
-    class_type<B>, copyable<boost::noncopyable>
+    boost::python::class_type<B>
+  , boost::python::copyable<boost::noncopyable>
 > c1;
 
 typedef boost::python::class_<
-
+    D
+  , boost::python::held_type<
 #if defined(BOOST_NO_CXX11_SMART_PTR)
-
-    D, held_type<std::auto_ptr<D> >, base_list<bases<B> >
-    
+        std::auto_ptr<D>
 #else
-
-    D, held_type<std::unique_ptr<D> >, base_list<bases<B> >
-    
+        std::unique_ptr<D>
 #endif
-
+    >
+  , boost::python::base_list<boost::python::bases<B> >
 > c2;
 
-BOOST_MPL_ASSERT((boost::is_same<c1::class_type, B>));
-BOOST_MPL_ASSERT((boost::is_same<c1::base_list, bases<> >));
-BOOST_MPL_ASSERT((boost::is_same<c1::held_type, B>));
-BOOST_MPL_ASSERT((
-     boost::is_same<c1::copyable, boost::noncopyable>
-));
+#include <boost/type_traits/is_same.hpp>
+#include <boost/mpl/aux_/test.hpp>
+#include <boost/mpl/assert.hpp>
 
-BOOST_MPL_ASSERT((boost::is_same<c2::class_type, D>));
-BOOST_MPL_ASSERT((boost::is_same<c2::base_list, bases<B> >));
-
+MPL_TEST_CASE()
+{
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c1::class_type,B>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c1::base_list,boost::python::bases<> >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c1::held_type,B>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c1::copyable,boost::noncopyable>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::class_type,D>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::base_list,boost::python::bases<B> >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
 #if defined(BOOST_NO_CXX11_SMART_PTR)
-
-BOOST_MPL_ASSERT((
-    boost::is_same<c2::held_type, std::auto_ptr<D> >
-));
-
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::held_type,std::auto_ptr<D> >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
 #else
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::held_type,std::unique_ptr<D> >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+#endif  // BOOST_NO_CXX11_SMART_PTR
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<c2::copyable,void>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+}
 
-BOOST_MPL_ASSERT((
-    boost::is_same<c2::held_type, std::unique_ptr<D> >
-));
-
-#endif
-
-BOOST_MPL_ASSERT((boost::is_same<c2::copyable, void>));

--- a/test/literate/extracting-parameter-types0.cpp
+++ b/test/literate/extracting-parameter-types0.cpp
@@ -1,28 +1,38 @@
 
 #include <boost/parameter.hpp>
-#include <cassert>
+
 BOOST_PARAMETER_NAME(name)
 BOOST_PARAMETER_NAME(index)
 
-template <class Name, class Index>
+template <typename T>
+void noop(T&)
+{
+}
+
+template <typename Name, typename Index>
 int deduce_arg_types_impl(Name& name, Index& index)
 {
     Name& n2 = name;  // we know the types
     Index& i2 = index;
+    noop(n2);
+    noop(i2);
     return index;
 }
 
-template <class ArgumentPack>
+template <typename ArgumentPack>
 int deduce_arg_types(ArgumentPack const& args)
 {
     return deduce_arg_types_impl(args[_name], args[_index|42]);
 }
-int a1 = deduce_arg_types((_name = "foo"));
-int a2 = deduce_arg_types((_name = "foo", _index = 3));
+
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-    assert(a1 == 42);
-    assert(a2 == 3);
+    int a1 = deduce_arg_types((_name = "foo"));
+    int a2 = deduce_arg_types((_name = "foo", _index = 3));
+    BOOST_TEST_EQ(a1, 42);
+    BOOST_TEST_EQ(a2, 3);
+    return boost::report_errors();
 }
 

--- a/test/literate/extracting-parameter-types1.cpp
+++ b/test/literate/extracting-parameter-types1.cpp
@@ -1,21 +1,21 @@
 
 #include <boost/parameter.hpp>
-#include <boost/type_traits/remove_reference.hpp>
-#include <cassert>
 
-namespace parameter = boost::parameter;
 BOOST_PARAMETER_NAME(index)
 
-template <class ArgumentPack>
-typename parameter::value_type<ArgumentPack, tag::index, int>::type
-twice_index(ArgumentPack const& args)
+template <typename ArgumentPack>
+typename boost::parameter::value_type<ArgumentPack,tag::index,int>::type
+    twice_index(ArgumentPack const& args)
 {
     return 2 * args[_index|42];
 }
 
-int six = twice_index(_index = 3);
+#include <boost/core/lightweight_test.hpp>
+
 int main()
 {
-    assert(six == 6);
+    int six = twice_index(_index = 3);
+    BOOST_TEST_EQ(six, 6);
+    return boost::report_errors();
 }
 

--- a/test/literate/fine-grained-name-control0.cpp
+++ b/test/literate/fine-grained-name-control0.cpp
@@ -1,15 +1,21 @@
 
 #include <boost/parameter.hpp>
+
 BOOST_PARAMETER_NAME((pass_foo, keywords) foo)
 
 BOOST_PARAMETER_FUNCTION(
-  (int), f,
-  keywords, (required (foo, *)))
+    (int), f, keywords, (required (foo, *))
+)
 {
     return foo + 1;
 }
 
-int x = f(pass_foo = 41);
+#include <boost/core/lightweight_test.hpp>
+
 int main()
-{}
+{
+    int x = f(pass_foo = 41);
+    BOOST_TEST_EQ(x, 42);
+    return boost::report_errors();
+}
 

--- a/test/literate/lazy-default-computation0.cpp
+++ b/test/literate/lazy-default-computation0.cpp
@@ -2,23 +2,27 @@
 #include <boost/parameter.hpp>
 #include <string>
 
-namespace parameter = boost::parameter;
 BOOST_PARAMETER_NAME(s1)
 BOOST_PARAMETER_NAME(s2)
 BOOST_PARAMETER_NAME(s3)
 
-template <class ArgumentPack>
+template <typename ArgumentPack>
 std::string f(ArgumentPack const& args)
 {
     std::string const& s1 = args[_s1];
     std::string const& s2 = args[_s2];
-    typename parameter::binding<
+    typename boost::parameter::binding<
         ArgumentPack,tag::s3,std::string
     >::type s3 = args[_s3|(s1+s2)]; // always constructs s1+s2
     return s3;
 }
 
-std::string x = f((_s1="hello,", _s2=" world", _s3="hi world"));
+#include <boost/core/lightweight_test.hpp>
+
 int main()
-{}
+{
+    std::string x = f((_s1="hello,", _s2=" world", _s3="hi world"));
+    BOOST_TEST_EQ(x, std::string("hi world"));
+    return boost::report_errors();
+}
 

--- a/test/literate/lazy-default-computation1.cpp
+++ b/test/literate/lazy-default-computation1.cpp
@@ -5,26 +5,33 @@
 #include <string>
 #include <functional>
 
-namespace parameter = boost::parameter;
-
 BOOST_PARAMETER_NAME(s1)
 BOOST_PARAMETER_NAME(s2)
 BOOST_PARAMETER_NAME(s3)
 
-template <class ArgumentPack>
+template <typename ArgumentPack>
 std::string f(ArgumentPack const& args)
 {
     std::string const& s1 = args[_s1];
     std::string const& s2 = args[_s2];
-typename parameter::binding<
-    ArgumentPack, tag::s3, std::string
->::type s3 = args[_s3
-    || boost::bind(std::plus<std::string>(), boost::ref(s1), boost::ref(s2)) ];
+    typename boost::parameter::binding<
+        ArgumentPack, tag::s3, std::string
+    >::type s3 = args[
+        _s3 || boost::bind(
+            std::plus<std::string>()
+          , boost::ref(s1)
+          , boost::ref(s2)
+        )
+    ];
     return s3;
 }
 
-std::string x = f((_s1="hello,", _s2=" world", _s3="hi world"));
+#include <boost/core/lightweight_test.hpp>
 
 int main()
-{}
+{
+    std::string x = f((_s1="hello,", _s2=" world", _s3="hi world"));
+    BOOST_TEST_EQ(x, std::string("hi world"));
+    return boost::report_errors();
+}
 

--- a/test/literate/namespaces0.cpp
+++ b/test/literate/namespaces0.cpp
@@ -1,20 +1,27 @@
 
 #include <boost/parameter.hpp>
 #include <iostream>
-namespace lib
-{
-  BOOST_PARAMETER_NAME(name)
-  BOOST_PARAMETER_NAME(index)
 
-  BOOST_PARAMETER_FUNCTION(
-    (int), f, tag,
-    (optional (name,*,"bob")(index,(int),1))
-  )
-  {
-      std::cout << name << ":" << index << std::endl;
-      return index;
-  }
+namespace lib {
+
+    BOOST_PARAMETER_NAME(name)
+    BOOST_PARAMETER_NAME(index)
+
+    BOOST_PARAMETER_FUNCTION(
+        (int), f, tag, (optional (name,*,"bob")(index,(int),1))
+    )
+    {
+        std::cout << name << ":" << index << std::endl;
+        return index;
+    }
 }
-int x = lib::f(lib::_name = "jill", lib::_index = 1);
-int main() {}
+
+#include <boost/core/lightweight_test.hpp>
+
+int main()
+{
+    int x = lib::f(lib::_name = "jill", lib::_index = 1);
+    BOOST_TEST_EQ(x, 1);
+    return boost::report_errors();
+}
 

--- a/test/literate/namespaces1.cpp
+++ b/test/literate/namespaces1.cpp
@@ -1,23 +1,30 @@
 
 #include <boost/parameter.hpp>
 #include <iostream>
-namespace lib
-{
-  BOOST_PARAMETER_NAME(name)
-  BOOST_PARAMETER_NAME(index)
 
-  BOOST_PARAMETER_FUNCTION(
-    (int), f, tag,
-    (optional (name,*,"bob")(index,(int),1))
-  )
-  {
-      std::cout << name << ":" << index << std::endl;
-      return index;
-  }
+namespace lib {
+
+    BOOST_PARAMETER_NAME(name)
+    BOOST_PARAMETER_NAME(index)
+
+    BOOST_PARAMETER_FUNCTION(
+        (int), f, tag, (optional (name,*,"bob")(index,(int),1))
+    )
+    {
+        std::cout << name << ":" << index << std::endl;
+        return index;
+    }
 }
+
+#include <boost/core/lightweight_test.hpp>
+
 using lib::_name;
 using lib::_index;
 
-int x = lib::f(_name = "jill", _index = 1);
-int main() {}
+int main()
+{
+    int x = lib::f(_name = "jill", _index = 1);
+    BOOST_TEST_EQ(x, 1);
+    return boost::report_errors();
+}
 

--- a/test/literate/namespaces2.cpp
+++ b/test/literate/namespaces2.cpp
@@ -1,21 +1,29 @@
 
 #include <boost/parameter.hpp>
 #include <iostream>
-namespace lib
-{
-  BOOST_PARAMETER_NAME(name)
-  BOOST_PARAMETER_NAME(index)
 
-  BOOST_PARAMETER_FUNCTION(
-    (int), f, tag,
-    (optional (name,*,"bob")(index,(int),1))
-  )
-  {
-      std::cout << name << ":" << index << std::endl;
-      return index;
-  }
+namespace lib {
+
+    BOOST_PARAMETER_NAME(name)
+    BOOST_PARAMETER_NAME(index)
+
+    BOOST_PARAMETER_FUNCTION(
+        (int), f, tag, (optional (name,*,"bob")(index,(int),1))
+    )
+    {
+        std::cout << name << ":" << index << std::endl;
+        return index;
+    }
 }
+
+#include <boost/core/lightweight_test.hpp>
+
 using namespace lib;
-int x = f(_name = "jill", _index = 3);
-int main() {}
+
+int main()
+{
+    int x = f(_name = "jill", _index = 3);
+    BOOST_TEST_EQ(x, 3);
+    return boost::report_errors();
+}
 

--- a/test/literate/namespaces3.cpp
+++ b/test/literate/namespaces3.cpp
@@ -1,25 +1,31 @@
 
 #include <boost/parameter.hpp>
 #include <iostream>
-namespace lib
-{
-  namespace keywords
-  {
-     BOOST_PARAMETER_NAME(name)
-     BOOST_PARAMETER_NAME(index)
-  }
 
-  BOOST_PARAMETER_FUNCTION(
-    (int), f, keywords::tag,
-    (optional (name,*,"bob")(index,(int),1))
-  )
-  {
-      std::cout << name << ":" << index << std::endl;
-      return index;
-  }
+namespace lib {
+    namespace keywords {
+
+        BOOST_PARAMETER_NAME(name)
+        BOOST_PARAMETER_NAME(index)
+    }
+
+    BOOST_PARAMETER_FUNCTION(
+        (int), f, keywords::tag, (optional (name,*,"bob")(index,(int),1))
+    )
+    {
+        std::cout << name << ":" << index << std::endl;
+        return index;
+    }
 }
 
+#include <boost/core/lightweight_test.hpp>
+
 using namespace lib::keywords;
-int y = lib::f(_name = "bob", _index = 2);
-int main() {}
+
+int main()
+{
+    int x = lib::f(_name = "bob", _index = 2);
+    BOOST_TEST_EQ(x, 2);
+    return boost::report_errors();
+}
 

--- a/test/literate/parameter-enabled-constructors0.cpp
+++ b/test/literate/parameter-enabled-constructors0.cpp
@@ -1,17 +1,18 @@
 
 #include <boost/parameter.hpp>
 #include <iostream>
+
 BOOST_PARAMETER_NAME(name)
 BOOST_PARAMETER_NAME(index)
 
 struct myclass_impl
 {
-    template <class ArgumentPack>
+    template <typename ArgumentPack>
     myclass_impl(ArgumentPack const& args)
     {
-        std::cout << "name = " << args[_name]
-                  << "; index = " << args[_index | 42]
-                  << std::endl;
+        std::cout << "name = " << args[_name];
+        std::cout << "; index = " << args[_index | 42];
+        std::cout << std::endl;
     }
 };
 
@@ -19,13 +20,17 @@ struct myclass : myclass_impl
 {
     BOOST_PARAMETER_CONSTRUCTOR(
         myclass, (myclass_impl), tag
-      , (required (name,*)) (optional (index,*))) // no semicolon
+      , (required (name,*)) (optional (index,*))
+    ) // no semicolon
 };
 
+#include <boost/core/lightweight_test.hpp>
 
-int main() {
-myclass x("bob", 3);                     // positional
-myclass y(_index = 12, _name = "sally"); // named
-myclass z("june");                       // positional/defaulted
+int main()
+{
+    myclass x("bob", 3);                     // positional
+    myclass y(_index = 12, _name = "sally"); // named
+    myclass z("june");                       // positional/defaulted
+    return boost::report_errors();
 }
 

--- a/test/literate/predicate-requirements0.cpp
+++ b/test/literate/predicate-requirements0.cpp
@@ -1,103 +1,189 @@
 
 #include <boost/parameter.hpp>
-#include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/depth_first_search.hpp>
 
 BOOST_PARAMETER_NAME((_graph, graphs) graph)
 BOOST_PARAMETER_NAME((_visitor, graphs) visitor)
-BOOST_PARAMETER_NAME((_root_vertex, graphs) root_vertex)
-BOOST_PARAMETER_NAME((_index_map, graphs) index_map)
+BOOST_PARAMETER_NAME((_root_vertex, graphs) in(root_vertex))
+BOOST_PARAMETER_NAME((_index_map, graphs) in(index_map))
 BOOST_PARAMETER_NAME((_color_map, graphs) in_out(color_map))
 
-using boost::mpl::_;
-// We first need to define a few metafunction that we use in the
-// predicates below.
+#include <boost/graph/graph_traits.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_convertible.hpp>
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/type_traits/is_same.hpp>
 
-template <class G>
-struct traversal_category
+struct vertex_descriptor_predicate
 {
-    typedef typename boost::graph_traits<G>::traversal_category type;
+    template <typename T, typename Args>
+    struct apply
+      : boost::mpl::if_<
+            boost::is_convertible<
+                T
+              , typename boost::graph_traits<
+                    typename boost::parameter::value_type<
+                        Args
+                      , graphs::graph
+                    >::type
+                >::vertex_descriptor
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >
+    {
+    };
 };
 
-template <class G>
-struct vertex_descriptor
+#include <boost/mpl/eval_if.hpp>
+
+struct graph_predicate
 {
-    typedef typename boost::graph_traits<G>::vertex_descriptor type;
+    template <typename T, typename Args>
+    struct apply
+      : boost::mpl::eval_if<
+            boost::is_convertible<
+                typename boost::graph_traits<T>::traversal_category
+              , boost::incidence_graph_tag
+            >
+          , boost::mpl::if_<
+                boost::is_convertible<
+                    typename boost::graph_traits<T>::traversal_category
+                  , boost::vertex_list_graph_tag
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+          , boost::mpl::false_
+        >
+    {
+    };
 };
 
-template <class G>
-struct value_type
+#include <boost/property_map/property_map.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+struct color_map_predicate
 {
-    typedef typename boost::property_traits<G>::value_type type;
+    template <typename T, typename Args>
+    struct apply
+      : boost::mpl::if_<
+            boost::is_same<
+                typename boost::property_traits<T>::key_type
+              , typename boost::graph_traits<
+                    typename boost::parameter::value_type<
+                        Args
+                      , graphs::graph
+                    >::type
+                >::vertex_descriptor
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >
+    {
+    };
 };
 
-template <class G>
-struct key_type
+#include <boost/type_traits/is_integral.hpp>
+
+struct index_map_predicate
 {
-    typedef typename boost::property_traits<G>::key_type type;
+    template <typename T, typename Args>
+    struct apply
+      : boost::mpl::eval_if<
+            boost::is_integral<
+                typename boost::property_traits<T>::value_type
+            >
+          , boost::mpl::if_<
+                boost::is_same<
+                    typename boost::property_traits<T>::key_type
+                  , typename boost::graph_traits<
+                        typename boost::parameter::value_type<
+                            Args
+                          , graphs::graph
+                        >::type
+                    >::vertex_descriptor
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+          , boost::mpl::false_
+        >
+    {
+    };
 };
 
-template<class Size, class IndexMap>
+#include <boost/graph/properties.hpp>
+#include <vector>
+
+template <typename Size, typename IndexMap>
 boost::iterator_property_map<
-    boost::default_color_type*, IndexMap
-  , boost::default_color_type, boost::default_color_type&
->
-default_color_map(Size num_vertices, IndexMap const& index_map)
+    std::vector<boost::default_color_type>::iterator
+  , IndexMap
+  , boost::default_color_type
+  , boost::default_color_type&
+>&
+    default_color_map(Size num_vertices, IndexMap const& index_map)
 {
-   std::vector<boost::default_color_type> colors(num_vertices);
-   return &colors[0];
+    static std::vector<boost::default_color_type> colors(num_vertices);
+    static boost::iterator_property_map<
+        std::vector<boost::default_color_type>::iterator
+      , IndexMap
+      , boost::default_color_type
+      , boost::default_color_type&
+    > m(colors.begin(), index_map);
+    return m;
 }
 
-BOOST_PARAMETER_FUNCTION(
-    (void), depth_first_search, graphs
+#include <boost/graph/depth_first_search.hpp>
 
-  , (required
-      (graph
-       , *(boost::mpl::and_<
-               boost::is_convertible<
-                   traversal_category<_>, boost::incidence_graph_tag
-               >
-             , boost::is_convertible<
-                   traversal_category<_>, boost::vertex_list_graph_tag
-               >
-           >) ))
-
+BOOST_PARAMETER_FUNCTION((void), depth_first_search, graphs,
+    (required
+        (graph, *(graph_predicate))
+    )
     (optional
-      (visitor, *, boost::dfs_visitor<>()) // not checkable
-
-      (root_vertex
-        , (vertex_descriptor<graphs::graph::_>)
-        , *vertices(graph).first)
-
-      (index_map
-        , *(boost::mpl::and_<
-              boost::is_integral<value_type<_> >
-            , boost::is_same<
-                  vertex_descriptor<graphs::graph::_>, key_type<_>
-              >
-          >)
-        , get(boost::vertex_index,graph))
-
-      (color_map
-        , *(boost::is_same<
-              vertex_descriptor<graphs::graph::_>, key_type<_>
-          >)
-       , default_color_map(num_vertices(graph), index_map) )
+        (visitor
+          , *  // not easily checkable
+          , boost::dfs_visitor<>()
+        )
+        (root_vertex
+          , *(vertex_descriptor_predicate)
+          , *vertices(graph).first
+        )
+        (index_map
+          , *(index_map_predicate)
+          , get(boost::vertex_index, graph)
+        )
+        (color_map
+          , *(color_map_predicate)
+          , default_color_map(num_vertices(graph), index_map)
+        )
     )
 )
-{}
+{
+}
+
+#include <boost/core/lightweight_test.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <utility>
 
 int main()
 {
-    typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS> G;
-
+    typedef boost::adjacency_list<
+        boost::vecS
+      , boost::vecS
+      , boost::directedS
+    > G;
     enum {u, v, w, x, y, z, N};
-    typedef std::pair<int, int> E;
-    E edges[] = {E(u, v), E(u, x), E(x, v), E(y, x), E(v, y), E(w, y),
-                 E(w,z), E(z, z)};
+    typedef std::pair<std::size_t,std::size_t> E;
+    E edges[] = {
+        E(u, v), E(u, x), E(x, v), E(y, x),
+        E(v, y), E(w, y), E(w, z), E(z, z)
+    };
     G g(edges, edges + sizeof(edges) / sizeof(E), N);
 
     ::depth_first_search(g);
-    ::depth_first_search(g, _root_vertex = (int)x);
+    ::depth_first_search(g, _root_vertex = static_cast<std::size_t>(x));
+    return boost::report_errors();
 }
 

--- a/test/literate/top-level0.cpp
+++ b/test/literate/top-level0.cpp
@@ -1,38 +1,56 @@
 
 #include <boost/parameter.hpp>
 
-namespace test
-{
-  BOOST_PARAMETER_NAME(title)
-  BOOST_PARAMETER_NAME(width)
-  BOOST_PARAMETER_NAME(titlebar)
+namespace test {
 
-  BOOST_PARAMETER_FUNCTION(
-     (int), new_window, tag, (required (title,*)(width,*)(titlebar,*)))
-  {
-     return 0;
-  }
+    BOOST_PARAMETER_NAME(title)
+    BOOST_PARAMETER_NAME(width)
+    BOOST_PARAMETER_NAME(titlebar)
 
-  BOOST_PARAMETER_TEMPLATE_KEYWORD(deleter)
-  BOOST_PARAMETER_TEMPLATE_KEYWORD(copy_policy)
+    BOOST_PARAMETER_FUNCTION((int), new_window, tag,
+        (required (title,*)(width,*)(titlebar,*))
+    )
+    {
+        return 0;
+    }
 
-  template <class T> struct Deallocate {};
-  struct DeepCopy {};
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(deleter)
+    BOOST_PARAMETER_TEMPLATE_KEYWORD(copy_policy)
 
-  namespace parameter = boost::parameter;
+    template <typename T>
+    struct Deallocate
+    {
+    };
 
-  struct Foo {};
-  template <class T, class A0, class A1>
-  struct smart_ptr
-  {
-      smart_ptr(Foo*);
-  };
+    struct DeepCopy
+    {
+    };
+
+    struct Foo
+    {
+    };
+
+    template <typename T, typename A0, typename A1>
+    struct smart_ptr
+    {
+        smart_ptr(test::Foo*)
+        {
+        }
+    };
 }
-using namespace test;
-int x = 
-new_window("alert", _width=10, _titlebar=false);
 
-smart_ptr<
-   Foo
- , deleter<Deallocate<Foo> >
- , copy_policy<DeepCopy> > p(new Foo);
+#include <boost/core/lightweight_test.hpp>
+
+int main()
+{
+    int x = test::new_window("alert", test::_width=10, test::_titlebar=false);
+    test::Foo* foo = new test::Foo();
+    test::smart_ptr<
+        test::Foo
+      , test::deleter<test::Deallocate<test::Foo> >
+      , test::copy_policy<test::DeepCopy>
+    > p(foo);
+    delete foo;
+    return boost::report_errors();
+}
+

--- a/test/macros.cpp
+++ b/test/macros.cpp
@@ -1,57 +1,68 @@
-// Copyright David Abrahams, Daniel Wallin 2003. Use, modification and 
-// distribution is subject to the Boost Software License, Version 1.0. 
-// (See accompanying file LICENSE_1_0.txt or copy at 
+// Copyright David Abrahams, Daniel Wallin 2003.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/parameter.hpp>
 #include <boost/parameter/macros.hpp>
 #include <boost/bind.hpp>
-#include <boost/static_assert.hpp>
-#include <boost/ref.hpp>
-#include <cassert>
-#include <string.h>
-
 #include "basics.hpp"
 
-namespace test
-{
+namespace test {
 
-  BOOST_PARAMETER_FUN(int, f, 2, 4, f_parameters)
-  {
-      p[tester](
-          p[name]
-        , p[value || boost::bind(&value_default) ]
-#if BOOST_WORKAROUND(__DECCXX_VER, BOOST_TESTED_AT(60590042))
-        , p[test::index | 999 ]
-#else
-        , p[index | 999 ]
-#endif
-      );
+    BOOST_PARAMETER_FUN(int, f, 2, 4, f_parameters)
+    {
+        p[test::_tester](
+            p[test::_name]
+          , p[test::_value || boost::bind(&test::value_default)]
+          , p[test::_index | 999]
+        );
 
-      return 1;
-  }
-  
+        return 1;
+    }
+
+    BOOST_PARAMETER_NAME(foo)
+    BOOST_PARAMETER_NAME(bar)
+
+    struct baz_parameters
+      : boost::parameter::parameters<
+            boost::parameter::optional<test::tag::foo>
+          , boost::parameter::optional<test::tag::bar>
+        >
+    {
+    };
+
+    BOOST_PARAMETER_FUN(int, baz, 0, 2, baz_parameters)
+    {
+        return 1;
+    }
 } // namespace test
+
+#include <boost/container/string.hpp>
+#include <boost/ref.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-    using test::f;
-    using test::name;
-    using test::value;
-    using test::index;
-    using test::tester;
+    test::f(
+        test::values(
+            boost::container::string("foo")
+          , boost::container::string("bar")
+          , boost::container::string("baz")
+        )
+      , boost::container::string("foo")
+      , boost::container::string("bar")
+      , boost::container::string("baz")
+    );
+    BOOST_TEST_EQ(1, test::baz());
 
-    f(
-       test::values(S("foo"), S("bar"), S("baz"))
-     , S("foo"), S("bar"), S("baz")
-   );
+    int x = 56;
+    test::f(
+        test::values(boost::container::string("foo"), 666.222, 56)
+      , test::_index = boost::ref(x)
+      , test::_name = boost::container::string("foo")
+    );
 
-   int x = 56;
-   f(
-       test::values("foo", 666.222, 56)
-     , index = boost::ref(x), name = "foo"
-   );
-
-   return boost::report_errors();
+    return boost::report_errors();
 }
 

--- a/test/maybe.cpp
+++ b/test/maybe.cpp
@@ -1,35 +1,43 @@
-// Copyright Daniel Wallin 2006. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2006.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/parameter/keyword.hpp>
-#include <boost/parameter/aux_/maybe.hpp>
-#include <cassert>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
-BOOST_PARAMETER_KEYWORD(tag, kw)
-BOOST_PARAMETER_KEYWORD(tag, unused)
-    
-template <class Args>
-int f(Args const& args)
-{
-    return args[kw | 1.f];
-}
+    BOOST_PARAMETER_NAME(kw)
+    BOOST_PARAMETER_NAME(unused)
 
+    template <typename Args>
+    int f(Args const& args)
+    {
+        return args[test::_kw | 1.f];
+    }
 } // namespace test
+
+#include <boost/parameter/aux_/maybe.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-    using test::kw;
-    using test::unused;
-    using test::f;
-    using boost::parameter::aux::maybe;
-
-    assert(f((kw = 0, unused = 0)) == 0);
-    assert(f(unused = 0) == 1);
-    assert(f((kw = maybe<int>(), unused = 0)) == 1);
-    assert(f((kw = maybe<int>(2), unused = 0)) == 2);
-    return 0;
+    BOOST_TEST_EQ(0, test::f((test::_kw = 0, test::_unused = 0)));
+    BOOST_TEST_EQ(1, test::f(test::_unused = 0));
+    BOOST_TEST_EQ(
+        1
+      , test::f((
+            test::_kw = boost::parameter::aux::maybe<int>()
+          , test::_unused = 0
+        ))
+    );
+    BOOST_TEST_EQ(
+        2
+      , test::f((
+            test::_kw = boost::parameter::aux::maybe<int>(2)
+          , test::_unused = 0
+        ))
+    );
+    return boost::report_errors();
 }
 

--- a/test/mpl.cpp
+++ b/test/mpl.cpp
@@ -1,80 +1,118 @@
-// Copyright David Abrahams 2006. Distributed under the Boost
-// Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright David Abrahams 2006.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
-#include "basics.hpp"
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/for_each.hpp>
-#include <boost/mpl/assert.hpp>
 #include <boost/mpl/size.hpp>
+#include <boost/mpl/contains.hpp>
+#include <boost/mpl/assert.hpp>
 #include <boost/type_traits/add_pointer.hpp>
+#include <boost/parameter/config.hpp>
+#include "basics.hpp"
 
-# include <boost/mpl/contains.hpp>
+namespace test {
 
-namespace test
-{
-  namespace mpl = boost::mpl;
+    template <typename Set>
+    struct assert_in_set
+    {
+        template <typename T>
+        void operator()(T*)
+        {
+            BOOST_MPL_ASSERT((boost::mpl::contains<Set,T>));
+        }
+    };
 
-  template <class Set>
-  struct assert_in_set
-  {
-      template <class T>
-      void operator()(T*)
-      {
-          BOOST_MPL_ASSERT((mpl::contains<Set,T>));
-      }
-  };
+    template <typename Expected, typename Params>
+    void f_impl(Params const& p BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Expected))
+    {
+        BOOST_MPL_ASSERT_RELATION(
+            boost::mpl::size<Expected>::value
+          , ==
+          , boost::mpl::size<Params>::value
+        );
 
-  
-  template<class Expected, class Params>
-  void f_impl(Params const& p BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Expected))
-  {
-      BOOST_MPL_ASSERT_RELATION(
-          mpl::size<Expected>::value
-        , ==
-        , mpl::size<Params>::value
-      );
+        boost::mpl::for_each<
+            Params
+          , boost::add_pointer<boost::mpl::_1>
+        >(
+            test::assert_in_set<Expected>()
+        );
+    }
 
-      mpl::for_each<Params, boost::add_pointer<mpl::_1> >(assert_in_set<Expected>());
-  }
+    template <
+        typename Expected
+      , typename Tester
+      , typename Name
+      , typename Value
+      , typename Index
+    >
+    void f(
+        Tester const& t
+      , Name const& name_
+      , Value const& value_
+      , Index const& index_
+        BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Expected)
+    )
+    {
+        test::f_impl<Expected>(
+            test::f_parameters()(t, name_, value_, index_)
+        );
+    }
 
-  template<class Expected, class Tester, class Name, class Value, class Index>
-  void f(Tester const& t, const Name& name_, 
-      const Value& value_, const Index& index_ BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Expected))
-  {
-      f_impl<Expected>(f_parameters()(t, name_, value_, index_));
-  }
+    template <
+        typename Expected
+      , typename Tester
+      , typename Name
+      , typename Value
+    >
+    void f(
+        Tester const& t
+      , Name const& name_
+      , Value const& value_
+        BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Expected)
+    )
+    {
+        test::f_impl<Expected>(test::f_parameters()(t, name_, value_));
+    }
 
-  template<class Expected, class Tester, class Name, class Value>
-  void f(Tester const& t, const Name& name_, const Value& value_ BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Expected))
-  {
-      f_impl<Expected>(f_parameters()(t, name_, value_));
-  }
+    template <typename Expected, typename Tester, typename Name>
+    void f(
+        Tester const& t
+      , Name const& name_
+        BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Expected)
+    )
+    {
+        test::f_impl<Expected>(test::f_parameters()(t, name_));
+    }
 
-  template<class Expected, class Tester, class Name>
-  void f(Tester const& t, const Name& name_ BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(Expected))
-  {
-      f_impl<Expected>(f_parameters()(t, name_));
-  }
+    void run()
+    {
+        typedef test::tag::tester tester_;
+        typedef test::tag::name name_;
+        typedef test::tag::value value_;
+        typedef test::tag::index index_;
 
-  void run()
-  {
-      typedef test::tag::tester tester_;
-      typedef test::tag::name name_;
-      typedef test::tag::value value_;
-      typedef test::tag::index index_;
-
-      f<mpl::list4<tester_,name_,value_,index_> >(1, 2, 3, 4);
-      f<mpl::list3<tester_,name_,index_> >(1, 2, index = 3);
-      f<mpl::list3<tester_,name_,index_> >(1, index = 2, name = 3);
-      f<mpl::list2<name_,value_> >(name = 3, value = 4);
-      f_impl<mpl::list1<value_> >(value = 4);
-  }
+        test::f<boost::mpl::list4<tester_,name_,value_,index_> >(1, 2, 3, 4);
+        test::f<boost::mpl::list3<tester_,name_,index_> >(
+            1, 2, test::_index = 3
+        );
+        test::f<boost::mpl::list3<tester_,name_,index_> >(
+            1, test::_index = 2, test::_name = 3
+        );
+        test::f<boost::mpl::list2<name_,value_> >(
+            test::_name = 3, test::_value = 4
+        );
+        test::f_impl<boost::mpl::list1<value_> >(test::_value = 4);
+    }
 }
+
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
     test::run();
-    return 0;
+    return boost::report_errors();
 }
 

--- a/test/normalized_argument_types.cpp
+++ b/test/normalized_argument_types.cpp
@@ -1,85 +1,136 @@
-// Copyright Daniel Wallin 2006. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2006.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/parameter/config.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 2)
+#error Define BOOST_PARAMETER_MAX_ARITY as 2 or greater.
+#endif
 
 #include <boost/parameter.hpp>
+
+namespace test {
+
+    struct count_instances
+    {
+        count_instances()
+        {
+            ++count_instances::count;
+        }
+
+        count_instances(count_instances const&)
+        {
+            ++count_instances::count;
+        }
+
+        template <typename T>
+        count_instances(T const&)
+        {
+            ++count_instances::count;
+        }
+
+        ~count_instances()
+        {
+            --count_instances::count;
+        }
+
+        static std::size_t count;
+
+        void noop() const
+        {
+        }
+    };
+
+    std::size_t count_instances::count = 0;
+
+    BOOST_PARAMETER_NAME(x)
+    BOOST_PARAMETER_NAME(y)
+} // namespace test
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/mpl/assert.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <cassert>
+#include <boost/type_traits/is_convertible.hpp>
 
-struct count_instances
-{
-    count_instances()
-    {
-        ++count;
-    }
+namespace test {
 
-    count_instances(count_instances const&)
-    {
-        ++count;
-    }
-
-    template <class T>
-    count_instances(T const&)
-    {
-        ++count;
-    }
-
-    ~count_instances()
-    {
-        --count;
-    }
-
-    static std::size_t count;
-};
-
-std::size_t count_instances::count = 0;
-
-BOOST_PARAMETER_NAME(x)
-BOOST_PARAMETER_NAME(y)
-
-BOOST_PARAMETER_FUNCTION((int), f, tag,
-    (required
-       (x, (int))
-       (y, (int))
+    BOOST_PARAMETER_FUNCTION((int), f, tag,
+        (required
+            (x, (long))
+        )
+        (optional
+            (y, (long), 2L)
+        )
     )
-)
-{
-    BOOST_MPL_ASSERT((boost::is_same<x_type,int>));
-    BOOST_MPL_ASSERT((boost::is_same<y_type,int>));
-    return 0;
-}
+    {
+        BOOST_MPL_ASSERT((
+            typename boost::mpl::if_<
+                boost::is_convertible<x_type,long>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >::type
+        ));
+        BOOST_MPL_ASSERT((
+            typename boost::mpl::if_<
+                boost::is_convertible<y_type,long>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >::type
+        ));
+        return 0;
+    }
+} // namespace test
 
-BOOST_PARAMETER_FUNCTION((int), g, tag,
-    (required
-       (x, (count_instances))
-    )
-)
-{
-    BOOST_MPL_ASSERT((boost::is_same<x_type,count_instances>));
-    assert(count_instances::count > 0);
-    return 0;
-}
+#include <boost/core/lightweight_test.hpp>
 
-BOOST_PARAMETER_FUNCTION((int), h, tag,
-    (required
-       (x, (count_instances const&))
+namespace test {
+
+    BOOST_PARAMETER_FUNCTION((int), g, tag,
+        (required
+            (x, (test::count_instances))
+        )
     )
-)
-{
-    BOOST_MPL_ASSERT((boost::is_same<x_type,count_instances const>));
-    assert(count_instances::count == 1);
-    return 0;
-}
+    {
+        BOOST_MPL_ASSERT((
+            typename boost::mpl::if_<
+                boost::is_convertible<x_type,test::count_instances>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >::type
+        ));
+        x.noop();
+        BOOST_TEST_LT(0, test::count_instances::count);
+        return 0;
+    }
+
+    BOOST_PARAMETER_FUNCTION((int), h, tag,
+        (required
+            (x, (test::count_instances const&))
+        )
+    )
+    {
+        BOOST_MPL_ASSERT((
+            typename boost::mpl::if_<
+                boost::is_convertible<x_type,test::count_instances const>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >::type
+        ));
+        x.noop();
+        BOOST_TEST_EQ(1, test::count_instances::count);
+        return 0;
+    }
+} // namespace test
 
 int main()
 {
-    f(1, 2);
-    f(1., 2.f);
-    f(1U, 2L);
-
-    g(0);
-
-    h(0);
+    test::f(1, 2);
+    test::f(1., 2.f);
+    test::f(1U);
+    test::g(0);
+    test::h(0);
+    return boost::report_errors();
 }
 

--- a/test/ntp.cpp
+++ b/test/ntp.cpp
@@ -1,110 +1,223 @@
-// Copyright Daniel Wallin 2006. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2006.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/parameter/config.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 4)
+#error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
+#endif
+
+namespace test {
+
+    struct X
+    {
+    };
+
+    struct Y : X
+    {
+    };
+} // namespace test
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+
+namespace test {
+
+    struct Z
+    {
+        template <typename T, typename Args>
+        struct apply
+          : boost::mpl::if_<
+                boost::is_base_of<
+                    X
+                  , typename boost::remove_const<
+                        typename boost::remove_reference<T>::type
+                    >::type
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >::type
+        {
+        };
+    };
+} // namespace test
 
 #include <boost/parameter.hpp>
-#include <boost/mpl/assert.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/is_base_and_derived.hpp>
 
-namespace mpl = boost::mpl;
-namespace parameter = boost::parameter;
+namespace test {
 
-template <class T = int>
-struct a0_is
-  : parameter::template_keyword<a0_is<>, T>
-{};
+    template <typename T = int>
+    struct a0_is : boost::parameter::template_keyword<test::a0_is<>,T>
+    {
+    };
 
-template <class T = int>
-struct a1_is
-  : parameter::template_keyword<a1_is<>, T>
-{};
+    template <typename T = int>
+    struct a1_is : boost::parameter::template_keyword<test::a1_is<>,T>
+    {
+    };
 
-template <class T = int>
-struct a2_is
-  : parameter::template_keyword<a2_is<>, T>
-{};
+    template <typename T = int>
+    struct a2_is : boost::parameter::template_keyword<test::a2_is<>,T>
+    {
+    };
 
-template <class T = int>
-struct a3_is
-  : parameter::template_keyword<a3_is<>, T>
-{};
+    template <typename T = int>
+    struct a3_is : boost::parameter::template_keyword<test::a3_is<>,T>
+    {
+    };
 
-struct X {};
-struct Y : X {};
-
-template <
-    class A0 = parameter::void_
-  , class A1 = parameter::void_
-  , class A2 = parameter::void_
-  , class A3 = parameter::void_
->
-struct with_ntp
-{
-    typedef typename parameter::parameters<
-        a0_is<>, a1_is<>, a2_is<>
-      , parameter::optional<
-            parameter::deduced<a3_is<> >
-          , boost::is_base_and_derived<X, mpl::_>
-        >
-    >::bind<A0,A1,A2,A3
+    template <
+        typename A0 = boost::parameter::void_
+      , typename A1 = boost::parameter::void_
+      , typename A2 = boost::parameter::void_
+      , typename A3 = boost::parameter::void_
+    >
+    struct with_ntp
+    {
+        typedef typename boost::parameter::parameters<
+            test::a0_is<>
+          , test::a1_is<>
+          , test::a2_is<>
+          , boost::parameter::optional<
+                boost::parameter::deduced<test::a3_is<> >
+              , Z
+            >
+        >::BOOST_NESTED_TEMPLATE bind<
+            A0
+          , A1
+          , A2
+          , A3
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-          , parameter::void_
-#endif 
-            >::type args;
+          , boost::parameter::void_
+#endif
+        >::type args;
+        typedef typename boost::parameter::binding<
+            args
+          , test::a0_is<>
+          , void*
+        >::type a0;
+        typedef typename boost::parameter::binding<
+            args
+          , test::a1_is<>
+          , void*
+        >::type a1;
+        typedef typename boost::parameter::binding<
+            args
+          , test::a2_is<>
+          , void*
+        >::type a2;
+        typedef typename boost::parameter::binding<
+            args
+          , test::a3_is<>
+          , void*
+        >::type a3;
+        typedef void(*type)(a0, a1, a2, a3);
+    };
+} // namespace test
 
-    typedef typename parameter::binding<
-        args, a0_is<>, void*
-    >::type a0;
+#include <boost/type_traits/is_same.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/mpl/aux_/test.hpp>
 
-    typedef typename parameter::binding<
-        args, a1_is<>, void*
-    >::type a1;
-
-    typedef typename parameter::binding<
-        args, a2_is<>, void*
-    >::type a2;
-
-    typedef typename parameter::binding<
-        args, a3_is<>, void*
-    >::type a3;
-
-    typedef void(*type)(a0,a1,a2,a3);
-};
-
-BOOST_MPL_ASSERT((boost::is_same<
-    with_ntp<>::type, void(*)(void*,void*,void*,void*)
->));
-
-BOOST_MPL_ASSERT((boost::is_same<
-    with_ntp<a2_is<int> >::type, void(*)(void*,void*,int,void*)
->));
-
-BOOST_MPL_ASSERT((boost::is_same<
-    with_ntp<a1_is<int> >::type, void(*)(void*,int,void*,void*)
->));
-
-BOOST_MPL_ASSERT((boost::is_same<
-    with_ntp<a2_is<int const>, a1_is<float> >::type, void(*)(void*,float,int const,void*)
->));
-
-BOOST_MPL_ASSERT((boost::is_same<
-    with_ntp<int const>::type, void(*)(int const, void*, void*,void*)
->));
-
-BOOST_MPL_ASSERT((boost::is_same<
-    with_ntp<int, float>::type, void(*)(int, float, void*,void*)
->));
-
-BOOST_MPL_ASSERT((boost::is_same<
-    with_ntp<int, float, char>::type, void(*)(int, float, char,void*)
->));
-
-BOOST_MPL_ASSERT((boost::is_same<
-    with_ntp<a0_is<int>, Y>::type, void(*)(int,void*,void*, Y)
->));
-
-BOOST_MPL_ASSERT((boost::is_same<
-    with_ntp<int&, a2_is<char>, Y>::type, void(*)(int&,void*,char, Y)
->));
+MPL_TEST_CASE()
+{
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<
+                test::with_ntp<>::type
+              , void(*)(void*, void*, void*, void*)
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<
+                test::with_ntp<test::a2_is<int> >::type
+              , void(*)(void*, void*, int, void*)
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<
+                test::with_ntp<test::a1_is<int> >::type
+              , void(*)(void*, int, void*, void*)
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<
+                test::with_ntp<
+                    test::a2_is<int const>
+                  , test::a1_is<float>
+                >::type
+              , void(*)(void*, float, int const, void*)
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<
+                test::with_ntp<int const>::type
+              , void(*)(int const, void*, void*, void*)
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<
+                test::with_ntp<int,float>::type
+              , void(*)(int, float, void*, void*)
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<
+                test::with_ntp<int,float,char>::type
+              , void(*)(int, float, char, void*)
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<
+                test::with_ntp<test::a0_is<int>,test::Y>::type
+              , void(*)(int, void*, void*, test::Y)
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+    BOOST_MPL_ASSERT((
+        boost::mpl::if_<
+            boost::is_same<
+                test::with_ntp<int&,test::a2_is<char>,test::Y>::type
+              , void(*)(int&, void*, char, test::Y)
+            >
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+    ));
+}
 

--- a/test/optional_deduced_sfinae.cpp
+++ b/test/optional_deduced_sfinae.cpp
@@ -1,73 +1,72 @@
-// Copyright Daniel Wallin 2006. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2006.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/parameter/config.hpp>
 #include <boost/parameter/preprocessor.hpp>
 #include <boost/parameter/name.hpp>
-#include <boost/type_traits/is_convertible.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 #include <string>
-#include "basics.hpp"
-#include <boost/utility/enable_if.hpp>
 
 namespace test {
 
-namespace mpl = boost::mpl;
+    BOOST_PARAMETER_NAME(x)
 
-using mpl::_;
-using boost::is_convertible;
+    struct predicate
+    {
+        template <typename T, typename Args>
+        struct apply
+          : boost::mpl::if_<
+                boost::is_convertible<T,char const*>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+        {
+        };
+    };
 
-BOOST_PARAMETER_NAME(x)
+    BOOST_PARAMETER_FUNCTION((int), sfinae, test::tag,
+        (deduced
+            (optional
+                (x
+                  , *(test::predicate)
+                  , static_cast<char const*>(BOOST_TTI_DETAIL_NULLPTR)
+                )
+            )
+        )
+    )
+    {
+        return 1;
+    }
 
-// Sun has problems with this syntax:
-//
-//   template1< r* ( template2<x> ) >
-//
-// Workaround: factor template2<x> into a separate typedef
-
-#if BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
-
-typedef is_convertible<_,char const*> predicate;
-
-BOOST_PARAMETER_FUNCTION((int), sfinae, tag,
-  (deduced
-     (optional (x, *(predicate), 0))
-  )
-)
-{
-    return 1;
-}
-
-#else
-
-BOOST_PARAMETER_FUNCTION((int), sfinae, tag,
-  (deduced
-     (optional (x, *(is_convertible<_,char const*>), 0))
-  )
-)
-{
-    return 1;
-}
-
-#endif
-
-template<class A0>
-typename boost::enable_if<boost::is_same<int,A0>, int>::type
-sfinae(A0 const& a0)
-{
-    return 0;
-}
-
+    template <typename A0>
+    typename boost::enable_if<
+        typename boost::mpl::if_<
+            boost::is_same<int,A0>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+      , int
+    >::type
+        sfinae(A0 const& a0)
+    {
+        return 0;
+    }
 } // namespace test
+
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-    using namespace test;
-
-    assert(sfinae() == 1);
-    assert(sfinae("foo") == 1);
-    assert(sfinae(1) == 0);
-
-    return 0;
+    BOOST_TEST_EQ(1, test::sfinae());
+    BOOST_TEST_EQ(1, test::sfinae("foo"));
+    BOOST_TEST_EQ(0, test::sfinae(1));
+    return boost::report_errors();
 }
 

--- a/test/preprocessor.cpp
+++ b/test/preprocessor.cpp
@@ -1,531 +1,643 @@
-// Copyright Daniel Wallin 2006. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2006.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/parameter/config.hpp>
 #include <boost/parameter/preprocessor.hpp>
 #include <boost/parameter/keyword.hpp>
-#include <boost/parameter/binding.hpp>
-#include <boost/type_traits/is_const.hpp>
-#include <string>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include "basics.hpp"
 
-#ifndef BOOST_NO_SFINAE
-# include <boost/utility/enable_if.hpp>
+namespace test {
+
+    BOOST_PARAMETER_BASIC_FUNCTION((int), f, test::tag,
+        (required
+            (tester, *)
+            (name, *)
+        )
+        (optional
+            (value, *)
+            (index, (int))
+        )
+    )
+    {
+        typedef typename boost::parameter::binding<
+            Args,test::tag::index,int&
+        >::type index_type;
+
+        BOOST_MPL_ASSERT((
+            typename boost::mpl::if_<
+                boost::is_same<index_type,int&>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >::type
+        ));
+
+        args[test::_tester](
+            args[test::_name]
+          , args[test::_value | 1.f]
+          , args[test::_index | 2]
+        );
+
+        return 1;
+    }
+} // namespace test
+
+#include <boost/type_traits/remove_const.hpp>
+
+namespace test {
+
+    BOOST_PARAMETER_BASIC_FUNCTION((int), g, test::tag,
+        (required
+            (tester, *)
+            (name, *)
+        )
+        (optional
+            (value, *)
+            (index, (int))
+        )
+    )
+    {
+        typedef typename boost::parameter::value_type<
+            Args,test::tag::index,int
+        >::type index_type;
+
+        BOOST_MPL_ASSERT((
+            typename boost::mpl::if_<
+                boost::is_same<
+                    typename boost::remove_const<index_type>::type
+                  , int
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >::type
+        ));
+
+        args[test::_tester](
+            args[test::_name]
+          , args[test::_value | 1.f]
+          , args[test::_index | 2]
+        );
+
+        return 1;
+    }
+} // namespace test
+
+#include <boost/type_traits/remove_reference.hpp>
+
+namespace test {
+
+    BOOST_PARAMETER_FUNCTION((int), h, test::tag,
+        (required
+            (tester, *)
+            (name, *)
+        )
+        (optional
+            (value, *, 1.f)
+            (index, (int), 2)
+        )
+    )
+    {
+#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
+    !BOOST_WORKAROUND(BOOST_MSVC, <= 1300)
+        BOOST_MPL_ASSERT((
+            typename boost::mpl::if_<
+                boost::is_same<
+                    typename boost::remove_const<
+                        typename boost::remove_reference<index_type>::type
+                    >::type
+                  , int
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >::type
+        ));
+#endif  // Borland/MSVC workarounds not needed.
+
+        tester(name, value, index);
+
+        return 1;
+    }
+
+    BOOST_PARAMETER_FUNCTION((int), h2, test::tag,
+        (required
+            (tester, *)
+            (name, *)
+        )
+        (optional
+            (value, *, 1.f)
+            (index, (int), static_cast<int>(value * 2))
+        )
+    )
+    {
+#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
+    !BOOST_WORKAROUND(BOOST_MSVC, <= 1300)
+        BOOST_MPL_ASSERT((
+            typename boost::mpl::if_<
+                boost::is_same<
+                    typename boost::remove_const<
+                        typename boost::remove_reference<index_type>::type
+                    >::type
+                  , int
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >::type
+        ));
+#endif  // Borland/MSVC workarounds not needed.
+
+        tester(name, value, index);
+
+        return 1;
+    }
+} // namespace test
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+#include <string>
 #endif
 
 namespace test {
 
-BOOST_PARAMETER_BASIC_FUNCTION((int), f, tag,
-    (required
-      (tester, *)
-      (name, *)
-    )
-    (optional
-      (value, *)
-      (out(index), (int))
-    )
-)
-{
-    typedef typename boost::parameter::binding<
-        Args, tag::index, int&
-    >::type index_type;
-
-    BOOST_MPL_ASSERT((boost::is_same<index_type, int&>));
-
-    args[tester](
-        args[name]
-      , args[value | 1.f]
-      , args[index | 2]
-    );
-
-    return 1;
-}
-
-BOOST_PARAMETER_BASIC_FUNCTION((int), g, tag,
-    (required
-      (tester, *)
-      (name, *)
-    )
-    (optional
-      (value, *)
-      (out(index), (int))
-    )
-)
-{
-    typedef typename boost::parameter::binding<
-        Args, tag::index, int const&
-    >::type index_type;
-
-    BOOST_MPL_ASSERT((boost::is_same<index_type, int const&>));
-
-    args[tester](
-        args[name]
-      , args[value | 1.f]
-      , args[index | 2]
-    );
-
-    return 1;
-}
-
-BOOST_PARAMETER_FUNCTION((int), h, tag,
-    (required
-      (tester, *)
-      (name, *)
-    )
-    (optional
-      (value, *, 1.f)
-      (out(index), (int), 2)
-    )
-)
-{
-# if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) \
-  && !BOOST_WORKAROUND(BOOST_MSVC, <= 1300)
-    BOOST_MPL_ASSERT((boost::is_same<index_type, int>));
-# endif
-
-    tester(
-        name
-      , value
-      , index
-    );
-
-    return 1;
-}
-
-BOOST_PARAMETER_FUNCTION((int), h2, tag,
-    (required
-      (tester, *)
-      (name, *)
-    )
-    (optional
-      (value, *, 1.f)
-      (out(index), (int), (int)value * 2)
-    )
-)
-{
-# if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) \
-  && !BOOST_WORKAROUND(BOOST_MSVC, <= 1300)
-    BOOST_MPL_ASSERT((boost::is_same<index_type, int>));
-# endif
-
-    tester(
-        name
-      , value
-      , index
-    );
-
-    return 1;
-}
-
-struct base
-{
-    template <class Args>
-    base(Args const& args)
+    struct base_0
     {
-        args[tester](
-            args[name]
-          , args[value | 1.f]
-          , args[index | 2]
-        );
-    }
-};
+        float f;
+        int i;
 
-struct class_ : base
-{
-    BOOST_PARAMETER_CONSTRUCTOR(class_, (base), tag,
-        (required
-          (tester, *)
-          (name, *)
-        )
-        (optional
-          (value, *)
-          (index, *)
-        )
-    )
+        template <typename Args>
+        explicit base_0(
+            Args const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::disable_if<
+                typename boost::mpl::if_<
+                    boost::is_base_of<base_0,Args>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >::type
+            >::type* = BOOST_TTI_DETAIL_NULLPTR
+#endif  // BOOST_NO_SFINAE
+        ) : f(args[test::_value | 1.f]), i(args[test::_index | 2])
+        {
+        }
+    };
 
-    BOOST_PARAMETER_BASIC_MEMBER_FUNCTION((int), f, tag,
-        (required
-          (tester, *)
-          (name, *)
+    struct class_0 : test::base_0
+    {
+        BOOST_PARAMETER_CONSTRUCTOR(class_0, (test::base_0), test::tag,
+            (optional
+                (value, *)
+                (index, *)
+            )
         )
-        (optional
-          (value, *)
-          (index, *)
+    };
+
+    struct base_1
+    {
+        template <typename Args>
+        explicit base_1(
+            Args const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::disable_if<
+                typename boost::mpl::if_<
+                    boost::is_base_of<base_1,Args>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >::type
+            >::type* = BOOST_TTI_DETAIL_NULLPTR
+#endif  // BOOST_NO_SFINAE
+        )
+        {
+            args[test::_tester](
+                args[test::_name]
+              , args[test::_value | 1.f]
+              , args[test::_index | 2]
+            );
+        }
+    };
+
+    struct class_1 : test::base_1
+    {
+        BOOST_PARAMETER_CONSTRUCTOR(class_1, (test::base_1), test::tag,
+            (required
+                (tester, *)
+                (name, *)
+            )
+            (optional
+                (value, *)
+                (index, *)
+            )
+        )
+
+        BOOST_PARAMETER_BASIC_MEMBER_FUNCTION((int), f, test::tag,
+            (required
+                (tester, *)
+                (name, *)
+            )
+            (optional
+                (value, *)
+                (index, *)
+            )
+        )
+        {
+            args[test::_tester](
+                args[test::_name]
+              , args[test::_value | 1.f]
+              , args[test::_index | 2]
+            );
+
+            return 1;
+        }
+
+        BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION((int), f, test::tag,
+            (required
+                (tester, *)
+                (name, *)
+            )
+            (optional
+                (value, *)
+                (index, *)
+            )
+        )
+        {
+            args[test::_tester](
+                args[test::_name]
+              , args[test::_value | 1.f]
+              , args[test::_index | 2]
+            );
+
+            return 1;
+        }
+
+        BOOST_PARAMETER_MEMBER_FUNCTION((int), f2, test::tag,
+            (required
+                (tester, *)
+                (name, *)
+            )
+            (optional
+                (value, *, 1.f)
+                (index, *, 2)
+            )
+        )
+        {
+            tester(name, value, index);
+            return 1;
+        }
+
+        BOOST_PARAMETER_CONST_MEMBER_FUNCTION((int), f2, test::tag,
+            (required
+                (tester, *)
+                (name, *)
+            )
+            (optional
+                (value, *, 1.f)
+                (index, *, 2)
+            )
+        )
+        {
+            tester(name, value, index);
+            return 1;
+        }
+
+        BOOST_PARAMETER_MEMBER_FUNCTION((int), static f_static, test::tag,
+            (required
+                (tester, *)
+                (name, *)
+            )
+            (optional
+                (value, *, 1.f)
+                (index, *, 2)
+            )
+        )
+        {
+            tester(name, value, index);
+            return 1;
+        }
+
+        BOOST_PARAMETER_FUNCTION_CALL_OPERATOR((int), test::tag,
+            (required
+                (tester, *)
+                (name, *)
+            )
+            (optional
+                (value, *, 1.f)
+                (index, *, 2)
+            )
+        )
+        {
+            tester(name, value, index);
+            return 1;
+        }
+
+        BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR((int), test::tag,
+            (required
+                (tester, *)
+                (name, *)
+            )
+            (optional
+                (value, *, 1.f)
+                (index, *, 2)
+            )
+        )
+        {
+            tester(name, value, index);
+            return 1;
+        }
+    };
+
+    BOOST_PARAMETER_FUNCTION((int), sfinae, test::tag,
+        (required
+            (name, (std::string))
         )
     )
     {
-        args[tester](
-            args[name]
-          , args[value | 1.f]
-          , args[index | 2]
-        );
-
         return 1;
     }
 
-    BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION((int), f, tag,
+#if !defined(BOOST_NO_SFINAE)
+    // On compilers that actually support SFINAE, add another overload
+    // that is an equally good match and can only be in the overload set
+    // when the others are not.  This tests that the SFINAE is actually
+    // working.  On all other compilers we're just checking that everything
+    // about SFINAE-enabled code will work, except of course the SFINAE.
+    template <typename A0>
+    typename boost::enable_if<
+        typename boost::mpl::if_<
+            boost::is_same<int,A0>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+      , int
+    >::type
+        sfinae(A0 const& a0)
+    {
+        return 0;
+    }
+#endif  // BOOST_NO_SFINAE
+
+    struct predicate
+    {
+        template <typename T, typename Args>
+        struct apply
+          : boost::mpl::if_<
+                boost::is_convertible<T,std::string>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+        {
+        };
+    };
+
+    BOOST_PARAMETER_FUNCTION((int), sfinae1, test::tag,
         (required
-          (tester, *)
-          (name, *)
-        )
-        (optional
-          (value, *)
-          (index, *)
+            (name, *(test::predicate))
         )
     )
     {
-        args[tester](
-            args[name]
-          , args[value | 1.f]
-          , args[index | 2]
-        );
-
         return 1;
     }
 
-    BOOST_PARAMETER_MEMBER_FUNCTION((int), f2, tag,
-        (required
-          (tester, *)
-          (name, *)
-        )
-        (optional
-          (value, *, 1.f)
-          (index, *, 2)
-        )
-    )
+#if !defined(BOOST_NO_SFINAE)
+    // On compilers that actually support SFINAE, add another overload
+    // that is an equally good match and can only be in the overload set
+    // when the others are not.  This tests that the SFINAE is actually
+    // working.  On all other compilers we're just checking that everything
+    // about SFINAE-enabled code will work, except of course the SFINAE.
+    template <typename A0>
+    typename boost::enable_if<
+        typename boost::mpl::if_<
+            boost::is_same<int,A0>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+      , int
+    >::type
+        sfinae1(A0 const& a0)
     {
-        tester(name, value, index);
-        return 1;
+        return 0;
     }
+#endif  // BOOST_NO_SFINAE
 
-    BOOST_PARAMETER_CONST_MEMBER_FUNCTION((int), f2, tag,
-        (required
-          (tester, *)
-          (name, *)
-        )
-        (optional
-          (value, *, 1.f)
-          (index, *, 2)
-        )
-    )
+    template <typename T>
+    T const& as_lvalue(T const& x)
     {
-        tester(name, value, index);
-        return 1;
+        return x;
     }
 
-    BOOST_PARAMETER_FUNCTION_CALL_OPERATOR((int), test::tag,
+    struct udt
+    {
+        udt(int foo_, int bar_) : foo(foo_), bar(bar_)
+        {
+        }
+
+        int foo;
+        int bar;
+    };
+
+    BOOST_PARAMETER_FUNCTION((int), lazy_defaults, test::tag,
         (required
-            (tester, *)
             (name, *)
         )
         (optional
-            (value, *, 1.f)
-            (index, *, 2)
+            (value, *, name.foo)
+            (index, *, name.bar)
         )
     )
     {
-        tester(name, value, index);
-        return 1;
+        return 0;
     }
-
-    BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR((int), test::tag,
-        (required
-            (tester, *)
-            (name, *)
-        )
-        (optional
-            (value, *, 1.f)
-            (index, *, 2)
-        )
-    )
-    {
-        tester(name, value, index);
-        return 1;
-    }
-
-    BOOST_PARAMETER_MEMBER_FUNCTION((int), static f_static, tag,
-        (required
-          (tester, *)
-          (name, *)
-        )
-        (optional
-          (value, *, 1.f)
-          (index, *, 2)
-        )
-    )
-    {
-        tester(name, value, index);
-        return 1;
-    }
-};
-
-BOOST_PARAMETER_FUNCTION(
-    (int), sfinae, tag,
-    (required
-       (name, (std::string))
-    )
-)
-{
-    return 1;
-}
-
-#ifndef BOOST_NO_SFINAE
-// On compilers that actually support SFINAE, add another overload
-// that is an equally good match and can only be in the overload set
-// when the others are not.  This tests that the SFINAE is actually
-// working.  On all other compilers we're just checking that
-// everything about SFINAE-enabled code will work, except of course
-// the SFINAE.
-template<class A0>
-typename boost::enable_if<boost::is_same<int,A0>, int>::type
-sfinae(A0 const& a0)
-{
-    return 0;
-}
-#endif
-
-#if BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
-
-// Sun has problems with this syntax:
-//
-//   template1< r* ( template2<x> ) >
-//
-// Workaround: factor template2<x> into a separate typedef
-typedef boost::is_convertible<boost::mpl::_, std::string> predicate;
-
-BOOST_PARAMETER_FUNCTION(
-    (int), sfinae1, tag,
-    (required
-       (name, *(predicate))
-    )
-)
-{
-    return 1;
-}
-
-#else
-
-BOOST_PARAMETER_FUNCTION(
-    (int), sfinae1, tag,
-    (required
-       (name, *(boost::is_convertible<boost::mpl::_, std::string>))
-    )
-)
-{
-    return 1;
-}
-#endif 
-
-#ifndef BOOST_NO_SFINAE
-// On compilers that actually support SFINAE, add another overload
-// that is an equally good match and can only be in the overload set
-// when the others are not.  This tests that the SFINAE is actually
-// working.  On all other compilers we're just checking that
-// everything about SFINAE-enabled code will work, except of course
-// the SFINAE.
-template<class A0>
-typename boost::enable_if<boost::is_same<int,A0>, int>::type
-sfinae1(A0 const& a0)
-{
-    return 0;
-}
-#endif
-
-template <class T>
-T const& as_lvalue(T const& x)
-{
-    return x;
-}
-
-struct udt
-{
-    udt(int foo, int bar)
-      : foo(foo)
-      , bar(bar)
-    {}
-
-    int foo;
-    int bar;
-};
-
-BOOST_PARAMETER_FUNCTION((int), lazy_defaults, tag,
-    (required
-      (name, *)
-    )
-    (optional
-      (value, *, name.foo)
-      (index, *, name.bar)
-    )
-)
-{
-    return 0;
-}
-
 } // namespace test
+
+#include <boost/container/string.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-    using namespace test;
-
-    f(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+    test::f(
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
     );
-
-    f(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
+    test::f(
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
     );
 
     int index_lvalue = 2;
 
-    f(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
-      , value = 1.f
-      , test::index = index_lvalue
+    test::f(
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
+      , test::_value = 1.f
+      , test::_index = index_lvalue
     );
 
-    f(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+    test::f(
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
       , 1.f
       , index_lvalue
     );
 
-    g(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+    test::g(
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
       , 1.f
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1300)
-      , as_lvalue(2)
+      , test::as_lvalue(2)
 #else
       , 2
 #endif
     );
 
-    h(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+    test::h(
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
       , 1.f
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1300)
-      , as_lvalue(2)
+      , test::as_lvalue(2)
 #else
       , 2
 #endif
     );
 
-    h2(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
-      , value = 1.f
+    test::h2(
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
+      , test::_value = 1.f
     );
 
-    class_ x(
-        values(S("foo"), 1.f, 2)
-      , S("foo"), test::index = 2
+    test::class_0 u;
+
+    BOOST_TEST(2 == u.i);
+    BOOST_TEST(1.f == u.f);
+
+    test::class_1 x(
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
+      , test::_index = 2
     );
 
     x.f(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
     );
-
     x.f(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
     );
-
     x.f2(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
     );
-
     x.f2(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
     );
-
     x(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
     );
-
     x(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
     );
 
-    class_ const& x_const = x;
+    test::class_1 const& x_const = x;
 
     x_const.f(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
     );
-
     x_const.f(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
     );
-
     x_const.f2(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
     );
-
     x_const.f2(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
     );
-
-    x_const.f2(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
+    test::class_1::f_static(
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
     );
-
+    test::class_1::f_static(
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
+    );
     x_const(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
+        test::values(boost::container::string("foo"), 1.f, 2)
+      , boost::container::string("foo")
     );
-
     x_const(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
+        test::_tester = test::values(
+            boost::container::string("foo")
+          , 1.f
+          , 2
+        )
+      , test::_name = boost::container::string("foo")
     );
 
-    class_::f_static(
-        values(S("foo"), 1.f, 2)
-      , S("foo")
-    );
+#if !defined(BOOST_NO_SFINAE) && \
+    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    BOOST_TEST(test::sfinae("foo") == 1);
+    BOOST_TEST(test::sfinae(1) == 0);
 
-    class_::f_static(
-        tester = values(S("foo"), 1.f, 2)
-      , name = S("foo")
-    );
-
-#if ! defined(BOOST_NO_SFINAE) && ! BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
-    assert(sfinae("foo") == 1);
-    assert(sfinae(1) == 0);
-
-# if !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
+#if !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
     // Sun actually eliminates the desired overload for some reason.
     // Disabling this part of the test because SFINAE abilities are
     // not the point of this test.
-    assert(sfinae1("foo") == 1);
-# endif
+    BOOST_TEST(test::sfinae1("foo") == 1);
+#endif
     
-    assert(sfinae1(1) == 0);
+    BOOST_TEST(test::sfinae1(1) == 0);
 #endif
 
-    lazy_defaults(
-        name = udt(0,1)
-    );
-
-    lazy_defaults(
-        name = 0
-      , value = 1
-      , test::index = 2
-    );
+    test::lazy_defaults(test::_name = test::udt(0,1));
+    test::lazy_defaults(test::_name = 0, test::_value = 1, test::_index = 2);
 
     return boost::report_errors();
 }

--- a/test/sfinae.cpp
+++ b/test/sfinae.cpp
@@ -1,103 +1,151 @@
-// Copyright David Abrahams, Daniel Wallin 2003. Use, modification and 
-// distribution is subject to the Boost Software License, Version 1.0. 
-// (See accompanying file LICENSE_1_0.txt or copy at 
-// http://www.boost.org/LICENSE_1_0.txt
+// Copyright David Abrahams, Daniel Wallin 2003.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/parameter/config.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 2)
+#error Define BOOST_PARAMETER_MAX_ARITY as 2 or greater.
+#endif
 
 #include <boost/parameter.hpp>
-#include <boost/parameter/match.hpp>
-#include <boost/detail/lightweight_test.hpp>
-#include <string>
+
+namespace test {
+
+    BOOST_PARAMETER_NAME((name, keywords) in(name))
+    BOOST_PARAMETER_NAME((value, keywords) in(value))
+} // namespace test
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
-#if ! defined(BOOST_NO_SFINAE) && ! BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
-# include <boost/utility/enable_if.hpp>
-# include <boost/type_traits/is_same.hpp>
-#endif 
+namespace test {
 
-namespace test
-{
-  BOOST_PARAMETER_KEYWORD(keywords,name)
-  BOOST_PARAMETER_KEYWORD(keywords,value)
-  
-  using namespace boost::parameter;
-
-  struct f_parameters
-    : parameters<
-          optional<
-              keywords::name
-            , boost::is_convertible<boost::mpl::_, std::string>
-          >
-        , optional<
-              keywords::value
-            , boost::is_convertible<boost::mpl::_, float>
-          >
-      >
-  {};
-
-  // The use of assert_equal_string is just a nasty workaround for a
-  // vc++ 6 ICE.
-  void assert_equal_string(std::string x, std::string y)
-  {
-        BOOST_TEST(x == y);
-  }
-  
-  template<class P>
-  void f_impl(P const& p)
-  {
-      float v = p[value | 3.f];
-      BOOST_TEST(v == 3.f);
-      assert_equal_string(p[name | "bar"], "foo");
-  }
-
-  void f()
-  {
-      f_impl(f_parameters()());
-  }
-
-  template<class A0>
-  void f(
-      A0 const& a0
-    , BOOST_PARAMETER_MATCH(f_parameters, (A0), args))
-  {
-      f_impl(args(a0));
-  }
-
-  template<class A0, class A1>
-  void f(
-      A0 const& a0, A1 const& a1
-    , BOOST_PARAMETER_MATCH(f_parameters,(A0)(A1), args))
-  {
-      f_impl(args(a0, a1));
-  }
-
-#if ! defined(BOOST_NO_SFINAE) && ! BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
-  // On compilers that actually support SFINAE, add another overload
-  // that is an equally good match and can only be in the overload set
-  // when the others are not.  This tests that the SFINAE is actually
-  // working.  On all other compilers we're just checking that
-  // everything about SFINAE-enabled code will work, except of course
-  // the SFINAE.
-  template<class A0, class A1>
-  typename boost::enable_if<boost::is_same<int,A0>, int>::type
-  f(A0 const& a0, A1 const& a1)
-  {
-      return 0;
-  }
-#endif 
+    template <typename To>
+    struct f_predicate
+    {
+        template <typename From, typename Args>
+        struct apply
+          : boost::mpl::if_<
+                boost::is_convertible<From,To>
+              , boost::mpl::true_
+              , boost::mpl::false_
+            >
+        {
+        };
+    };
 } // namespace test
+
+#include <string>
+
+namespace test {
+
+    struct f_parameters
+      : boost::parameter::parameters<
+            boost::parameter::optional<
+                test::keywords::name
+              , test::f_predicate<std::string>
+            >
+          , boost::parameter::optional<
+                test::keywords::value
+              , test::f_predicate<float>
+            >
+        >
+    {
+    };
+} // namespace test
+
+#include <boost/core/lightweight_test.hpp>
+
+namespace test {
+
+    // The use of assert_equal_string is just a nasty workaround for a
+    // vc++ 6 ICE.
+    void assert_equal_string(std::string x, std::string y)
+    {
+        BOOST_TEST(x == y);
+    }
+
+    template <typename P>
+    void f_impl(P const& p)
+    {
+        float v = p[test::value | 3.f];
+        BOOST_TEST_EQ(v, 3.f);
+        test::assert_equal_string(p[test::name | "bar"], "foo");
+    }
+
+    void f()
+    {
+        test::f_impl(f_parameters()());
+    }
+} // namespace test
+
+#include <boost/parameter/match.hpp>
+
+namespace test {
+
+    template <typename A0>
+    void
+        f(
+            A0 const& a0
+          , BOOST_PARAMETER_MATCH(f_parameters, (A0), args)
+        )
+    {
+        test::f_impl(args(a0));
+    }
+
+    template <typename A0, typename A1>
+    void
+        f(
+            A0 const& a0
+          , A1 const& a1
+          , BOOST_PARAMETER_MATCH(f_parameters, (A0)(A1), args)
+        )
+    {
+        test::f_impl(args(a0, a1));
+    }
+} // namespace test
+
+#if !defined(BOOST_NO_SFINAE) && \
+    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+
+#include <boost/core/enable_if.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+namespace test {
+
+    // On compilers that actually support SFINAE, add another overload that is
+    // an equally good match and can only be in the overload set when the
+    // others are not.  This tests that the SFINAE is actually working.  On
+    // all other compilers we're just checking that everything about
+    // SFINAE-enabled code will work, except of course the SFINAE.
+    template <typename A0, typename A1>
+    typename boost::enable_if<
+        typename boost::mpl::if_<
+            boost::is_same<int,A0>
+          , boost::mpl::true_
+          , boost::mpl::false_
+        >::type
+      , int
+    >::type
+        f(A0 const& a0, A1 const& a1)
+    {
+        return 0;
+    }
+} // namespace test
+
+#endif  // SFINAE enabled, no Borland workarounds needed.
 
 int main()
 {
-    using test::name;
-    using test::value;    
-    using test::f;
-
-    f("foo");
-    f("foo", 3.f);
-    f(value = 3.f, name = "foo");
-
-#if ! defined(BOOST_NO_SFINAE) && ! BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
-    BOOST_TEST(f(3, 4) == 0);
+    test::f("foo");
+    test::f("foo", 3.f);
+    test::f(test::value = 3.f, test::name = "foo");
+#if !defined(BOOST_NO_SFINAE) && \
+    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    BOOST_TEST_EQ(0, test::f(3, 4));
 #endif
     return boost::report_errors();
 }

--- a/test/singular.cpp
+++ b/test/singular.cpp
@@ -1,42 +1,54 @@
-// Copyright Daniel Wallin 2005. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/parameter/keyword.hpp>
-#include <boost/detail/lightweight_test.hpp>
+namespace test {
 
-BOOST_PARAMETER_KEYWORD(tag, x)
-BOOST_PARAMETER_KEYWORD(tag, y)
-    
-struct default_src
-{
-    typedef int result_type;
-
-    int operator()() const
+    struct default_src
     {
-        return 0;
+        typedef int result_type;
+
+        int operator()() const
+        {
+            return 0;
+        }
+    };
+} // namespace test
+
+#include <boost/parameter/name.hpp>
+
+namespace test {
+
+    BOOST_PARAMETER_NAME(x)
+    BOOST_PARAMETER_NAME(y)
+} // namespace test
+
+#include <boost/core/lightweight_test.hpp>
+
+namespace test {
+
+    template <typename ArgumentPack, typename K, typename T>
+    void check(ArgumentPack const& p, K const& kw, T const& value)
+    {
+        BOOST_TEST_EQ(p[kw], value);
     }
-};
-    
-template <class ArgumentPack, class K, class T>
-void check(ArgumentPack const& p, K const& kw, T const& value)
-{
-    BOOST_TEST(p[kw] == value);
-}
+} // namespace test
 
 int main()
 {
-    check(x = 20, x, 20);
-    check(y = 20, y, 20);
+    test::check(test::_x = 20, test::_x, 20);
+    test::check(test::_y = 20, test::_y, 20);
 
-    check(x = 20, x | 0, 20);
-    check(y = 20, y | 0, 20);
+    test::check(test::_x = 20, test::_x | 0, 20);
+    test::check(test::_y = 20, test::_y | 0, 20);
 
-    check(x = 20, x | default_src(), 20);
-    check(y = 20, y | default_src(), 20);
-    
-    check(y = 20, x | 0, 0);
-    check(y = 20, x || default_src(), 0);
+    test::check(test::_x = 20, test::_x || test::default_src(), 20);
+    test::check(test::_y = 20, test::_y || test::default_src(), 20);
+
+    test::check(test::_y = 20, test::_x | 0, 0);
+    test::check(test::_y = 20, test::_x || test::default_src(), 0);
+
     return boost::report_errors();
 }
 

--- a/test/tutorial.cpp
+++ b/test/tutorial.cpp
@@ -1,38 +1,41 @@
-// Copyright David Abrahams 2005. Distributed under the Boost
-// Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright David Abrahams 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
-#include <iostream>
-#include <boost/parameter/keyword.hpp>
+#include <boost/parameter/name.hpp>
 
-namespace graphs
-{
-   BOOST_PARAMETER_KEYWORD(tag, graph)    // Note: no semicolon
-   BOOST_PARAMETER_KEYWORD(tag, visitor)
-   BOOST_PARAMETER_KEYWORD(tag, root_vertex)
-   BOOST_PARAMETER_KEYWORD(tag, index_map)
-   BOOST_PARAMETER_KEYWORD(tag, color_map)
-}
+namespace graphs {
 
-namespace graphs { namespace core
-{
-   template <class ArgumentPack>
-   void depth_first_search(ArgumentPack const& args)
-   {
-       std::cout << "graph:\t" << args[graph] << std::endl;
-       std::cout << "visitor:\t" << args[visitor] << std::endl;
-       std::cout << "root_vertex:\t" << args[root_vertex] << std::endl;
-       std::cout << "index_map:\t" << args[index_map] << std::endl;
-       std::cout << "color_map:\t" << args[color_map] << std::endl;
-   }
-}} // graphs::core
+    BOOST_PARAMETER_NAME(graph)    // Note: no semicolon
+    BOOST_PARAMETER_NAME(visitor)
+    BOOST_PARAMETER_NAME(root_vertex)
+    BOOST_PARAMETER_NAME(index_map)
+    BOOST_PARAMETER_NAME(color_map)
+} // namespace graphs
+
+#include <boost/core/lightweight_test.hpp>
+
+namespace graphs { namespace core {
+
+    template <typename ArgumentPack>
+    void depth_first_search(ArgumentPack const& args)
+    {
+        BOOST_TEST_EQ(false, args[_color_map]);
+        BOOST_TEST_EQ('G', args[_graph]);
+        BOOST_TEST_CSTR_EQ("hello, world", args[_index_map]);
+        BOOST_TEST_EQ(3.5, args[_root_vertex]);
+        BOOST_TEST_EQ(2, args[_visitor]);
+    }
+}} // namespace graphs::core
 
 int main()
 {
-     using namespace graphs;
+    using namespace graphs;
 
-     core::depth_first_search((
-       graph = 'G', visitor = 2, root_vertex = 3.5,
-       index_map = "hello, world", color_map = false));
-     return 0;
+    core::depth_first_search((
+        _graph = 'G', _visitor = 2, _root_vertex = 3.5
+      , _index_map = "hello, world", _color_map = false
+    ));
+    return boost::report_errors();
 }


### PR DESCRIPTION
<boost/parameter/parameters.hpp>:
* Add preprocessor conditional statement to prevent generation of ill-formed function call operator overloads.

"test/maybe.cpp"
"test/singular.cpp"
"test/tutorial.cpp"
"test/sfinae.cpp"
"test/earwicker.cpp"
* Replace BOOST_PARAMETER_KEYWORD statements with BOOST_PARAMETER_NAME statements.

"test/optional_deduced_sfinae.cpp"
"test/normalized_argument_types.cpp"
"test/literate/*.cpp"
* Use Boost.Core.LightweightTest where int main() is available.
* Replace assert statements with BOOST_TEST_EQ statements.

"test/basics.hpp"
* Remove preprocessor statements regarding borland, gcc-2, and msvc workarounds.

"test/ntp.cpp"
"test/sfinae.cpp"
"test/earwicker.cpp"
"test/normalized_argument_types.cpp"
"test/basics.hpp"
* Add preprocessor conditional statement to #error out if BOOST_PARAMETER_MAX_ARITY is set to an insufficient value.

"test/basics.cpp"
"test/deduced.cpp"
"test/macros.cpp"
"test/preprocessor.cpp"
"test/preprocessor_deduced.cpp"
* Replace S and char const* expressions with boost::container::string expressions.
* Uncomment any code that fails to compile, but add preprocessor conditional statement so that test suites can incorporate compile-fail statements regarding the code in question.
* Ensure that int main() returns boost::process_errors().

"test/literate/deduced-template-parameters0.cpp":
"test/literate/exercising-the-code-so-far0.cpp":
* Enclose BOOST_MPL_ASSERT statements within MPL_TEST_CASE block.

"test/literate/defining-the-keywords1.cpp":
* Add graphs::tag::graph::qualifier type definition because perfect forwarding code will check for it.
* Replace deprecated keyword::get() invocation with keyword::instance invocation.

test/Jamfile.v2:
* Add modifier <define>BOOST_PARAMETER_MAX_ARITY=# to run, run-fail, compile, and compile-fail statements to conserve compiler memory usage on GitHub's side.
* Add modifier <preserve-target-tests>off to run and run-fail statements to conserve executable space on GitHub's side.
* Separate bpl-test statement into its own target, parameter_python_test, which fails on xcode8.3 as well as on mingw and msvc compilers with address-model=64.
* The next commit (which will implement perfect forwarding) will subsume test/literate/Jamfile.v2 into this file.  Strangely enough, attempting to do so now will result in compiler errors.

.travis.yml:
* Add g++-4.7, g++-4.8, g++-4.9, clang++-3.5, clang++-3.6, clang++-3.7, clang++-3.8, clang++-3.9, clang++-4.0, xcode7.3, and xcode8.3 compiler configurations.
* Split compiler configurations by available CXXSTD values.  (This will keep the job times within limits for the next commit.)
* Ensure that the xcode8.3 compiler configurations exclude parameter_python_test from the test suite.

appveyor.yml:
* Add compiler configurations that support address-model=64 to the test matrix.
* Ensure that the new configurations exclude parameter_python_test from the test suite.