### PR TITLE
Fixed mismatched tag warning

### DIFF
--- a/include/boost/parameter/aux_/tagged_argument_fwd.hpp
+++ b/include/boost/parameter/aux_/tagged_argument_fwd.hpp
@@ -9,7 +9,7 @@
 namespace boost { namespace parameter { namespace aux {
 
     template <class Keyword, class Arg>
-    class tagged_argument;
+    struct tagged_argument;
 }}} // namespace boost::parameter::aux
 
 #endif  // include guard


### PR DESCRIPTION
```
In file included from ../boost/parameter/parameters.hpp:31:
In file included from ../boost/parameter/aux_/pack/tag_keyword_arg.hpp:9:
In file included from ../boost/parameter/aux_/tag.hpp:8:
../boost/parameter/aux_/tagged_argument.hpp:36:1: warning: 'tagged_argument' defined as a struct template here but previously declared as a class template [-Wmismatched-tags]
struct tagged_argument : tagged_argument_base
^
../boost/parameter/aux_/tagged_argument_fwd.hpp:12:5: note: did you mean struct here?
    class tagged_argument;
    ^~~~~
    struct
```