### PR TITLE
 Add keyword generation macro BOOST_PARAMETER_NESTED_KEYWORD

### DIFF
--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -155,43 +155,46 @@ arguments)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-name-name"
 id="id59">6.10&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_NAME(name)</tt></a></li>
+<li><a class="reference internal" href="#boost-parameter-nested-keyword-t-n-a"
+id="id60">6.11&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NESTED_KEYWORD(tag_namespace, name, alias)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-template-keyword-name"
-id="id60">6.11&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id61">6.12&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_TEMPLATE_KEYWORD(name)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-fun-r-n-l-h-p"
-id="id61">6.12&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id62">6.13&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_FUN(r,n,l,h,p)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-keyword-n-k"
-id="id62">6.13&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id63">6.14&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_KEYWORD(n,k)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-match-p-a-x"
-id="id63">6.14&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id64">6.15&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_MATCH(p,a,x)</tt></a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#configuration-macros"
-id="id64">7&nbsp;&nbsp;&nbsp;Configuration Macros</a>
+id="id65">7&nbsp;&nbsp;&nbsp;Configuration Macros</a>
 <ul class="auto-toc">
 <li><a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"
-id="id65">7.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id66">7.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-variadic-mpl-sequence"
-id="id66">7.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id67">7.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-has-arity"
-id="id67">7.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id68">7.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_MAX_ARITY</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-exponential-overload-threshold-arity"
-id="id68">7.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id69">7.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY</tt></a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#tutorial"
-id="id69">8&nbsp;&nbsp;&nbsp;Tutorial</a></li>
+id="id70">8&nbsp;&nbsp;&nbsp;Tutorial</a></li>
 </ul>
 </div>
 <hr class="docutils" />
@@ -3227,8 +3230,80 @@ namespace tag {
 forward(<em>tag-name</em>)
 </pre>
 </div>
-<div class="section" id="boost-parameter-template-keyword-name">
+<div class="section" id="boost-parameter-nested-keyword-t-n-a">
 <h2><a class="toc-backref" href="#id60">6.11&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NESTED_KEYWORD(tag_namespace, name,
+alias)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/nested_keyword.hpp"
+>boost/parameter/nested_keyword.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<p>Declares a tag-type, a keyword object, and an alias for that object nested
+in the tag-type.</p>
+<p><strong>If</strong> <em>name</em> is of the form:</p>
+<pre class="literal-block">
+<em>qualifier</em>(<em>tag-name</em>)
+</pre>
+<p><strong>then</strong></p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Requires:</th>
+<td class="field-body">
+<p class="first"><em>qualifier</em> is either <tt class="docutils literal"
+>in</tt>, <tt class="docutils literal">out</tt>, <tt class="docutils literal"
+>in_out</tt>, <tt class="docutils literal">consume</tt>, <tt
+class="docutils literal">move_from</tt>, or <tt class="docutils literal"
+>forward</tt>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<p>Expands to:</p>
+<pre class="literal-block">
+namespace tag {
+
+    struct <em>tag-name</em>
+    {
+        static char const* keyword_name()
+        {
+            return ##<em>tag-name</em>;
+        }
+
+        typedef <em>unspecified</em> _;
+        typedef <em>unspecified</em> _1;
+        typedef boost::parameter::<em>qualifier</em> ## _reference qualifier;
+        static ::boost::parameter::keyword&lt;<em>tag-name</em>&gt; const& <em
+>alias</em>;
+    };
+
+    ::boost::parameter::keyword&lt;<em>tag-name</em>&gt; const& <em
+>tag-name</em>::<em>alias</em>
+        = ::boost::parameter::keyword&lt;<em>tag-name</em>&gt;::instance;
+}
+
+::boost::parameter::keyword&lt;tag::<em>tag-name</em>&gt; const&amp; _ ## <em
+>tag-name</em>
+    = ::boost::parameter::keyword&lt;tag::<em>tag-name</em>&gt;::instance;
+</pre>
+<p><strong>Else</strong></p>
+<p>Treats <em>name</em> as if it were of the form:</p>
+<pre class="literal-block">
+forward(<em>tag-name</em>)
+</pre>
+</div>
+<div class="section" id="boost-parameter-template-keyword-name">
+<h2><a class="toc-backref" href="#id61">6.12&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_TEMPLATE_KEYWORD(name)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -3262,7 +3337,7 @@ function types as either <tt class="docutils literal">boost::function</tt> or
 <tt class="docutils literal">std::function</tt> specializations.</p>
 </div>
 <div class="section" id="boost-parameter-fun-r-n-l-h-p">
-<h2><a class="toc-backref" href="#id61">6.12&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id62">6.13&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_FUN(r, n, l, h, p)</tt></a></h2>
 <div class="admonition-deprecated admonition">
 <p class="first admonition-title">Deprecated</p>
@@ -3554,7 +3629,7 @@ href="../../test/macros_eval_category.cpp">test/macros_eval_category.cpp</a>
 test programs demonstrate proper usage of this macro.</p>
 </div>
 <div class="section" id="boost-parameter-keyword-n-k">
-<h2><a class="toc-backref" href="#id62">6.13&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id63">6.14&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_KEYWORD(n, k)</tt></a></h2>
 <div class="admonition-deprecated admonition">
 <p class="first admonition-title">Deprecated</p>
@@ -3603,7 +3678,7 @@ namespace {
 </dl>
 </div>
 <div class="section" id="boost-parameter-match-p-a-x">
-<h2><a class="toc-backref" href="#id63">6.14&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id64">6.15&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_MATCH(p, a, x)</tt></a></h2>
 <p>Generates a defaulted parameter declaration for a
 <a class="reference external"
@@ -3650,10 +3725,10 @@ href="../../../../boost/parameter/match.hpp"
 </div>
 </div>
 <div class="section" id="configuration-macros">
-<h1><a class="toc-backref" href="#id64">7&nbsp;&nbsp;&nbsp;Configuration
+<h1><a class="toc-backref" href="#id65">7&nbsp;&nbsp;&nbsp;Configuration
 Macros</a></h1>
 <div class="section" id="boost-parameter-has-perfect-forwarding">
-<h2><a class="toc-backref" href="#id65">7.1&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id66">7.1&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a></h2>
 <p>Determines whether or not the library supports perfect forwarding, or the
 preservation of parameter value categories.  Users can manually disable this
@@ -3688,7 +3763,7 @@ href="../../../../boost/parameter/config.hpp"
 </table>
 </div>
 <div class="section" id="boost-parameter-variadic-mpl-sequence">
-<h2><a class="toc-backref" href="#id66">7.2&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id67">7.2&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE</tt></a></h2>
 <p>If <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
@@ -3740,7 +3815,7 @@ href="../../../../boost/parameter/parameters.hpp"
 </table>
 </div>
 <div class="section" id="boost-parameter-max-arity">
-<h2><a class="toc-backref" href="#id67">7.3&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id68">7.3&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_MAX_ARITY</tt></a></h2>
 <p>Determines the maximum number of arguments supported by the library.</p>
 <p>If <a class="reference internal"
@@ -3816,7 +3891,7 @@ forwarding is supported, <tt class="docutils literal">8</tt> otherwise.</td>
 </table>
 </div>
 <div class="section" id="boost-parameter-exponential-overload-threshold-arity"
-><h2><a class="toc-backref" href="#id68">7.4&nbsp;&nbsp;&nbsp;<tt
+><h2><a class="toc-backref" href="#id69">7.4&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal"
 >BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY</tt></a></h2>
 <p>If this library does <strong>not</strong> support perfect forwarding,
@@ -3859,7 +3934,7 @@ href="../../../../boost/parameter/config.hpp"
 </div>
 </div>
 <div class="section" id="tutorial">
-<h1><a class="toc-backref" href="#id69">8&nbsp;&nbsp;&nbsp;Tutorial</a></h1>
+<h1><a class="toc-backref" href="#id70">8&nbsp;&nbsp;&nbsp;Tutorial</a></h1>
 <p>Follow <a class="reference external" href="index.html#tutorial">this
 link</a> to the Boost.Parameter tutorial documentation.</p>
 <hr class="docutils" />

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -1960,6 +1960,58 @@ Treats *name* as if it were of the form:
 
     forward(*tag-name*)
 
+``BOOST_PARAMETER_NESTED_KEYWORD(tag_namespace, name, alias)``
+------------------------------------------
+
+:Defined in: `boost/parameter/nested_keyword.hpp`__
+
+__ ../../../../boost/parameter/nested_keyword.hpp
+
+Declares a tag-type, a keyword object, and an alias for that object nested in
+the tag-type.
+
+**If** *name* is of the form:
+
+.. parsed-literal::
+
+    *qualifier*\ (*tag-name*)
+
+**then**
+
+:Requires: *qualifier* is either ``in``, ``out``, ``in_out``, ``consume``,
+``move_from``, or ``forward``.
+
+Expands to:
+
+.. parsed-literal::
+
+    namespace tag {
+
+        struct *tag-name*
+        {
+            static char const* keyword_name()
+            {
+                return ## *tag-name* ## _;
+            }
+
+            typedef *unspecified* _;
+            typedef *unspecified* _1;
+            typedef boost::parameter::*qualifier* ## _reference qualifier;
+            static ::boost::parameter::keyword<*tag-name*> const& *alias*;
+        };
+    }
+
+    ::boost::parameter::keyword<*tag-name*> const& *tag-name*::*alias*
+        = ::boost::parameter::keyword<*tag-name*>::instance;
+
+**Else**
+
+Treats *name* as if it were of the form:
+
+.. parsed-literal::
+
+    forward(*tag-name*)
+
 ``BOOST_PARAMETER_TEMPLATE_KEYWORD(name)``
 ------------------------------------------
 

--- a/include/boost/parameter.hpp
+++ b/include/boost/parameter.hpp
@@ -14,6 +14,7 @@
 #include <boost/parameter/optional.hpp>
 #include <boost/parameter/deduced.hpp>
 #include <boost/parameter/keyword.hpp>
+#include <boost/parameter/nested_keyword.hpp>
 #include <boost/parameter/binding.hpp>
 #include <boost/parameter/value_type.hpp>
 #include <boost/parameter/macros.hpp>

--- a/include/boost/parameter/aux_/tagged_argument.hpp
+++ b/include/boost/parameter/aux_/tagged_argument.hpp
@@ -66,7 +66,8 @@ namespace boost { namespace parameter { namespace aux {
     // Holds an lvalue reference to an argument of type Arg associated with
     // keyword Keyword
     template <typename Keyword, typename Arg>
-    class tagged_argument : ::boost::parameter::aux::tagged_argument_base
+    class tagged_argument
+      : public ::boost::parameter::aux::tagged_argument_base
     {
         typedef typename ::boost::mpl::eval_if<
             typename ::boost::mpl::eval_if<
@@ -464,7 +465,8 @@ namespace boost { namespace parameter { namespace aux {
     // Holds an lvalue reference to an argument of type Arg associated with
     // keyword Keyword
     template <typename Keyword, typename Arg>
-    class tagged_argument : ::boost::parameter::aux::tagged_argument_base
+    class tagged_argument
+      : public ::boost::parameter::aux::tagged_argument_base
     {
         typedef typename ::boost::remove_const<Arg>::type arg_type;
 

--- a/include/boost/parameter/nested_keyword.hpp
+++ b/include/boost/parameter/nested_keyword.hpp
@@ -1,0 +1,63 @@
+// Copyright Eric Niebler 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_NESTED_KEYWORD_HPP
+#define BOOST_PARAMETER_NESTED_KEYWORD_HPP
+
+#include <boost/parameter/aux_/name.hpp>
+#include <boost/parameter/keyword.hpp>
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/stringize.hpp>
+
+#define BOOST_PARAMETER_NESTED_KEYWORD_AUX(tag_namespace, q, name, alias)    \
+    namespace tag_namespace                                                  \
+    {                                                                        \
+        template <int Dummy = 0>                                             \
+        struct BOOST_PP_CAT(name, _)                                         \
+        {                                                                    \
+            static char const* keyword_name()                                \
+            {                                                                \
+                return BOOST_PP_STRINGIZE(BOOST_PP_CAT(name, _));            \
+            }                                                                \
+            typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(                    \
+                BOOST_PP_CAT(name, _)<Dummy>                                 \
+            ) _;                                                             \
+            typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(                    \
+                BOOST_PP_CAT(name, _)<Dummy>                                 \
+            ) _1;                                                            \
+            typedef ::boost::parameter::q qualifier;                         \
+            static ::boost::parameter::keyword<                              \
+                BOOST_PP_CAT(name, _)<Dummy>                                 \
+            > const& alias;                                                  \
+        };                                                                   \
+        template <int Dummy>                                                 \
+        ::boost::parameter::keyword<                                         \
+            BOOST_PP_CAT(name, _)<Dummy>                                     \
+        > const& BOOST_PP_CAT(name, _)<Dummy>::alias                         \
+            = ::boost::parameter::keyword<                                   \
+                BOOST_PP_CAT(name, _)<Dummy>                                 \
+            >::instance;                                                     \
+        typedef BOOST_PP_CAT(name, _)<> name;                                \
+    }                                                                        \
+    namespace                                                                \
+    {                                                                        \
+        ::boost::parameter::keyword<tag_namespace::name> const& name         \
+            = ::boost::parameter::keyword<tag_namespace::name>::instance;    \
+    }
+/**/
+
+#include <boost/parameter/aux_/preprocessor/qualifier.hpp>
+
+#define BOOST_PARAMETER_NESTED_KEYWORD(tag_namespace, name, alias)           \
+    BOOST_PARAMETER_NESTED_KEYWORD_AUX(                                      \
+        tag_namespace                                                        \
+      , BOOST_PARAMETER_GET_QUALIFIER(name)                                  \
+      , BOOST_PARAMETER_UNQUALIFIED(name)                                    \
+      , alias                                                                \
+    )
+/**/
+
+#endif  // include guard
+

--- a/include/boost/parameter/nested_keyword.hpp
+++ b/include/boost/parameter/nested_keyword.hpp
@@ -19,7 +19,7 @@
         {                                                                    \
             static char const* keyword_name()                                \
             {                                                                \
-                return BOOST_PP_STRINGIZE(BOOST_PP_CAT(name, _));            \
+                return BOOST_PP_STRINGIZE(name);                             \
             }                                                                \
             typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(                    \
                 BOOST_PP_CAT(name, _)<Dummy>                                 \

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -4,12 +4,13 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/parameter/nested_keyword.hpp>
 #include <boost/parameter/name.hpp>
 
 namespace param {
 
-    BOOST_PARAMETER_NAME(a0)
-    BOOST_PARAMETER_NAME(a1)
+    BOOST_PARAMETER_NESTED_KEYWORD(tag, a0, a_zero)
+    BOOST_PARAMETER_NESTED_KEYWORD(tag, a1, a_one)
     BOOST_PARAMETER_NAME(a2)
     BOOST_PARAMETER_NAME(a3)
     BOOST_PARAMETER_NAME(in(lrc))
@@ -50,7 +51,7 @@ namespace test {
         int j;
 
         template <typename ArgPack>
-        A(ArgPack const& args) : i(args[param::_a0]), j(args[param::_a1])
+        A(ArgPack const& args) : i(args[param::a0]), j(args[param::a1])
         {
             BOOST_MPL_ASSERT((boost::parameter::is_argument_pack<ArgPack>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::a0>));
@@ -157,7 +158,7 @@ namespace test {
 
         template <typename ArgPack>
         B(ArgPack const& args)
-          : A((args, param::_a0 = 1))
+          : A((args, param::tag::a0::a_zero = 1))
           , k(args[param::_a2 | E])
           , l(args[param::_a3 || C()])
         {
@@ -385,12 +386,12 @@ int main()
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails without this workaround.
     test::A a((
-        param::_a0 = 1
-      , param::_a1 = 13
+        param::a0 = 1
+      , param::a1 = 13
       , param::_a2 = std::function<double()>(test::D)
     ));
 #else
-    test::A a((param::_a0 = 1, param::_a1 = 13, param::_a2 = test::D));
+    test::A a((param::a0 = 1, param::a1 = 13, param::_a2 = test::D));
 #endif
     BOOST_TEST_EQ(1, a.i);
     BOOST_TEST_EQ(13, a.j);
@@ -399,11 +400,11 @@ int main()
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails without this workaround.
     test::B b0((
-        param::_a1 = 13
+        param::tag::a1::a_one = 13
       , param::_a2 = std::function<float()>(test::F)
     ));
 #else
-    test::B b0((param::_a1 = 13, param::_a2 = test::F));
+    test::B b0((param::tag::a1::a_one = 13, param::_a2 = test::F));
 #endif
     BOOST_TEST_EQ(1, b0.i);
     BOOST_TEST_EQ(13, b0.j);
@@ -415,10 +416,10 @@ int main()
     // MSVC 11.0 on AppVeyor fails without this workaround.
     test::B b1((
         param::_a3 = std::function<double()>(test::D)
-      , param::_a1 = 13
+      , param::a1 = 13
     ));
 #else
-    test::B b1((param::_a3 = test::D, param::_a1 = 13));
+    test::B b1((param::_a3 = test::D, param::a1 = 13));
 #endif
     BOOST_TEST_EQ(1, b1.i);
     BOOST_TEST_EQ(13, b1.j);


### PR DESCRIPTION
Upon approval and merging of this PR, replace the definition of BOOST_PARAMETER_NESTED_KEYWORD in <boost/accumulators/accumulators_fwd.hpp> with #include <boost/parameter/nested_keyword.hpp>.