### PR TITLE
Add are_tagged_arguments, add code generation macros, improve overloading support, update test suite, upgrade documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -203,6 +203,17 @@ matrix:
             - llvm-toolchain-trusty-5.0
 
     - os: linux
+      compiler: clang++-6.0
+      env: TOOLSET=clang COMPILER=clang++-6.0 CXXSTD=03,11,14,1z
+      addons:
+        apt:
+          packages:
+            - clang-6.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-6.0
+
+    - os: linux
       compiler: clang++
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
       addons:
@@ -237,6 +248,8 @@ install:
   - cd ..
   - git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
+  - git submodule update --init tools/boost_install
+  - git submodule update --init libs/headers
   - git submodule update --init tools/build
   - git submodule update --init libs/config
   - git submodule update --init tools/boostdep

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,8 @@ install:
   - cd ..
   - git clone -b %APPVEYOR_REPO_BRANCH% https://github.com/boostorg/boost.git boost-root
   - cd boost-root
+  - git submodule update --init tools/boost_install
+  - git submodule update --init libs/headers
   - git submodule update --init tools/build
   - git submodule update --init libs/config
   - git submodule update --init tools/boostdep

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -865,14 +865,16 @@ BOOST_PARAMETER_FUNCTION(
     std::cout &lt;&lt; std::endl;
 }
 
+#include &lt;boost/core/lightweight_test.hpp&gt;
+
 int main()
 {
     depth_first_search(1, 2, 3, 4, 5);
-
     depth_first_search(
         &quot;1&quot;, '2', _color_map = '5',
         _index_map = &quot;4&quot;, _root_vertex = &quot;3&quot;
     );
+    return boost::report_errors();
 }
 </pre>
 <p class="compound-last">Despite the fact that default expressions such as <tt
@@ -980,14 +982,18 @@ struct vertex_descriptor_predicate
 {
     template &lt;typename T, typename Args&gt;
     struct apply
-      : boost::is_convertible&lt;
-            T
-          , typename boost::graph_traits&lt;
-                typename boost::parameter::value_type&lt;
-                    Args
-                  , graphs::graph
-                &gt;::type
-            &gt;::vertex_descriptor
+      : boost::mpl::if_&lt;
+            boost::is_convertible&lt;
+                T
+              , typename boost::graph_traits&lt;
+                    typename boost::parameter::value_type&lt;
+                        Args
+                      , graphs::graph
+                    &gt;::type
+                &gt;::vertex_descriptor
+            &gt;
+          , boost::mpl::true_
+          , boost::mpl::false_
         &gt;
     {
     };
@@ -1034,15 +1040,20 @@ struct graph_predicate
 {
     template &lt;typename T, typename Args&gt;
     struct apply
-      : boost::mpl::and_&lt;
+      : boost::mpl::eval_if&lt;
             boost::is_convertible&lt;
                 typename boost::graph_traits&lt;T&gt;::traversal_category
               , boost::incidence_graph_tag
             &gt;
-          , boost::is_convertible&lt;
-                typename boost::graph_traits&lt;T&gt;::traversal_category
-              , boost::vertex_list_graph_tag
+          , boost::mpl::if_&lt;
+                boost::is_convertible&lt;
+                    typename boost::graph_traits&lt;T&gt;::traversal_category
+                  , boost::vertex_list_graph_tag
+                &gt;
+              , boost::mpl::true_
+              , boost::mpl::false_
             &gt;
+          , boost::mpl::false_
         &gt;
     {
     };
@@ -1052,18 +1063,22 @@ struct index_map_predicate
 {
     template &lt;typename T, typename Args&gt;
     struct apply
-      : boost::mpl::and_&lt;
+      : boost::mpl::eval_if&lt;
             boost::is_integral&lt;
                 typename boost::property_traits&lt;T&gt;::value_type
             &gt;
-          , boost::is_same&lt;
-                typename boost::property_traits&lt;T&gt;::key_type
-              , typename boost::graph_traits&lt;
-                    typename boost::parameter::value_type&lt;
-                        Args
-                      , graphs::graph
-                    &gt;::type
-                &gt;::vertex_descriptor
+          , boost::mpl::if_&lt;
+                boost::is_same&lt;
+                    typename boost::property_traits&lt;T&gt;::key_type
+                  , typename boost::graph_traits&lt;
+                        typename boost::parameter::value_type&lt;
+                            Args
+                          , graphs::graph
+                        &gt;::type
+                    &gt;::vertex_descriptor
+                &gt;
+              , boost::mpl::true_
+              , boost::mpl::false_
             &gt;
         &gt;
     {
@@ -1074,14 +1089,18 @@ struct color_map_predicate
 {
     template &lt;typename T, typename Args&gt;
     struct apply
-      : boost::is_same&lt;
-            typename boost::property_traits&lt;T&gt;::key_type
-          , typename boost::graph_traits&lt;
-                typename boost::parameter::value_type&lt;
-                    Args
-                  , graphs::graph
-                &gt;::type
-            &gt;::vertex_descriptor
+      : boost::mpl::if_&lt;
+            boost::is_same&lt;
+                typename boost::property_traits&lt;T&gt;::key_type
+              , typename boost::graph_traits&lt;
+                    typename boost::parameter::value_type&lt;
+                        Args
+                      , graphs::graph
+                    &gt;::type
+                &gt;::vertex_descriptor
+            &gt;
+          , boost::mpl::true_
+          , boost::mpl::false_
         &gt;
     {
     };
@@ -1160,6 +1179,10 @@ BOOST_PARAMETER_NAME((_color_map, graphs) in_out(color_map))
 {
 }
 
+#include <boost/core/lightweight_test.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <utility>
+
 int main()
 {
     typedef boost::adjacency_list<
@@ -1175,9 +1198,10 @@ int main()
 
     depth_first_search(g);
     depth_first_search(g, _root_vertex = static_cast<int>(x));
+    return boost::report_errors();
 }
 ''') -->
-<!-- @test('compile') -->
+<!-- @test('run') -->
 <p>It usually isn't necessary to so completely encode the type requirements on
 arguments to generic functions.  However, doing so is worth the effort: your
 code will be more self-documenting and will often provide a better user
@@ -1416,13 +1440,23 @@ struct callable2
         std::cout &lt;&lt; std::endl;
     }
 };
+
+#include &lt;boost/core/lightweight_test.hpp&gt;
+
+int main()
+{
+    callable2 c2;
+    callable2 const&amp; c2_const = c2;
+    c2_const.call(1, 2);
+    return boost::report_errors();
+}
 </pre>
 <!-- @example.prepend('''
 #include <boost/parameter.hpp>
 #include <iostream>
 using namespace boost::parameter;
 ''') -->
-<!-- @test('compile') -->
+<!-- @test('run') -->
 <p>These macros don't directly allow a function's interface to be
 separated from its implementation, but you can always forward
 arguments on to a separate implementation function:</p>
@@ -1433,8 +1467,9 @@ struct callable2
         (void), call, tag, (required (arg1,(int))(arg2,(int)))
     )
     {
-        call_impl(arg1,arg2);
+        call_impl(arg1, arg2);
     }
+
  private:
     void call_impl(int, int);  // implemented elsewhere.
 };
@@ -1463,13 +1498,22 @@ struct somebody
         std::cout &lt;&lt; arg1 &lt;&lt; std::endl;
     }
 };
+
+#include &lt;boost/core/lightweight_test.hpp&gt;
+
+int main()
+{
+    somebody::f();
+    somebody::f(4);
+    return boost::report_errors();
+}
 </pre>
 <!-- @example.prepend('''
 #include <boost/parameter.hpp>
 #include <iostream>
 using namespace boost::parameter;
 ''') -->
-<!-- @test('compile') -->
+<!-- @test('run') -->
 </div>
 </div>
 <div class="section" id="function-call-ops">
@@ -1497,13 +1541,23 @@ struct callable2
         std::cout &lt;&lt; second_arg &lt;&lt; std::endl;
     }
 };
+
+#include &lt;boost/core/lightweight_test.hpp&gt;
+
+int main()
+{
+    callable2 c2;
+    callable2 const&amp; c2_const = c2;
+    c2_const(1, 2);
+    return boost::report_errors();
+}
 </pre>
 <!-- @example.prepend('''
 #include <boost/parameter.hpp>
 #include <iostream>
 using namespace boost::parameter;
 ''') -->
-<!-- @test('compile') -->
+<!-- @test('run') -->
 </div>
 <div class="section" id="parameter-enabled-constructors">
 <h2><a class="toc-backref" href="#id30">2.4&nbsp;&nbsp;&nbsp;Parameter-Enabled
@@ -1514,8 +1568,8 @@ href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1986.pdf"
 >http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1986.pdf</a>) limits
 somewhat the quality of interface this library can provide for defining
 parameter-enabled constructors.  The usual workaround for a lack of
-constructor delegation applies: one must factor the common logic into a base
-class.</p>
+constructor delegation applies: one must factor the common logic into one or
+more base classes.</p>
 <p>Let's build a parameter-enabled constructor that simply prints its
 arguments.  The first step is to write a base class whose constructor accepts
 a single argument known as an <a class="reference external"
@@ -1570,7 +1624,11 @@ myclass x(&quot;bob&quot;, 3);                      // positional
 myclass y(_index = 12, _name = &quot;sally&quot;);  // named
 myclass z(&quot;june&quot;);                        // positional/defaulted
 </pre>
-<!-- @example.wrap('int main() {', '}') -->
+<!-- @example.wrap('''
+#include <boost/core/lightweight_test.hpp>
+
+int main() {
+''', ' return boost::report_errors(); }') -->
 <!-- @test('run', howmany='all') -->
 <p>For more on <span class="concept">ArgumentPack</span> manipulation, see the
 <a class="reference internal" href="#advanced-topics">Advanced Topics</a>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -768,11 +768,8 @@ corresponding names in <tt class="docutils literal">consume(…)</tt> or
 violate their category constraints, attempt to compile the
 <a class="reference external" href="../../test/compose.cpp"
 >test/compose.cpp</a> test program with either the
-<tt class="docutils literal">LIBS_PARAMETER_TEST_COMPILE_FAILURE_0</tt> macro,
-the <tt class="docutils literal">LIBS_PARAMETER_TEST_COMPILE_FAILURE_1</tt>
-macro, the
-<tt class="docutils literal">LIBS_PARAMETER_TEST_COMPILE_FAILURE_2</tt> macro,
-or the <tt class="docutils literal">LIBS_PARAMETER_TEST_COMPILE_FAILURE_3</tt>
+<tt class="docutils literal">LIBS_PARAMETER_TEST_COMPILE_FAILURE_0</tt> macro
+or the <tt class="docutils literal">LIBS_PARAMETER_TEST_COMPILE_FAILURE_1</tt>
 macro <tt class="docutils literal">#defined</tt>.  You should encounter a
 compiler error caused by a specific constraint violation.</p>
 </div>

--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -103,107 +103,148 @@ src="../../../../boost.png" /></a></p>
 >5.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal">lazy_binding</tt></a></li>
 <li><a class="reference internal" href="#value-type" id="id48"
 >5.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal">value_type</tt></a></li>
-<li><a class="reference internal" href="#value-type" id="id49"
+<li><a class="reference internal" href="#are-tagged-arguments" id="id49"
 >5.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>are_tagged_arguments</tt></a></li>
+<li><a class="reference internal" href="#is-argument-pack" id="id50"
+>5.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >is_argument_pack</tt></a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#code-generation-macros" id="id50"
+<li><a class="reference internal" href="#code-generation-macros" id="id51"
 >6&nbsp;&nbsp;&nbsp;Code Generation Macros</a><ul class="auto-toc">
 <li><a class="reference internal"
 href="#boost-parameter-function-result-name-tag-namespace-arguments"
-id="id51">6.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id52">6.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-member-function-result-name-tag-namespace-arguments"
-id="id52">6.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id53">6.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_MEMBER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-c-mem-function-result-name-tag-namespace-arguments"
-id="id53">6.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id54">6.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_CONST_MEMBER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-function-call-op-result-tag-namespace-arguments"
-id="id54">6.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id55">6.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_FUNCTION_CALL_OPERATOR(result, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-const-function-call-op-result-tag-namespace-arguments"
-id="id55">6.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id56">6.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR(result, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-constructor-cls-impl-tag-namespace-arguments"
-id="id56">6.6&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id57">6.6&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_CONSTRUCTOR(cls, impl, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-basic-function-result-name-tag-namespace-arguments"
-id="id57">6.7&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id58">6.7&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_BASIC_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-basic-member-function-result-name-tag-ns-arguments"
-id="id58">6.8&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id59">6.8&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_BASIC_MEMBER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-basic-c-mem-function-result-name-tag-ns-arguments"
-id="id59">6.9&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id60">6.9&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-basic-function-call-op-result-tag-namespace-arguments"
+id="id61">6.10&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR(result, tag_namespace,
+arguments)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-basic-const-function-call-op-result-tag-ns-args"
+id="id62">6.11&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR(result, tag_namespace,
+arguments)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-function-result-name"
+id="id63">6.12&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_FUNCTION(result, name)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-member-function-result-name"
+id="id64">6.13&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION(result, name)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-c-mem-function-result-name"
+id="id65">6.14&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION(result, name)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-function-call-op-result"
+id="id66">6.15&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR(result)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-const-func-call-op-result"
+id="id67">6.16&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR(result)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-constructor-cls-impl"
+id="id68">6.17&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(cls, impl)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-no-base-ctor-cls-func"
+id="id69">6.18&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(cls, func)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-name-name"
-id="id60">6.10&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id70">6.19&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_NAME(name)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-nested-keyword-t-n-a"
-id="id61">6.11&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id71">6.20&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_NESTED_KEYWORD(tag_namespace, name, alias)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-template-keyword-name"
-id="id62">6.12&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id72">6.21&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_TEMPLATE_KEYWORD(name)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-fun-r-n-l-h-p"
-id="id63">6.13&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id73">6.22&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_FUN(r,n,l,h,p)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-keyword-n-k"
-id="id64">6.14&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id74">6.23&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_KEYWORD(n,k)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-match-p-a-x"
-id="id65">6.15&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id75">6.24&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_MATCH(p,a,x)</tt></a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#configuration-macros"
-id="id66">7&nbsp;&nbsp;&nbsp;Configuration Macros</a>
+id="id76">7&nbsp;&nbsp;&nbsp;Configuration Macros</a>
 <ul class="auto-toc">
 <li><a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"
-id="id67">7.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id77">7.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-disable-perfect-forwarding"
-id="id68">7.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id78">7.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_DISABLE_PERFECT_FORWARDING</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-variadic-mpl-sequence"
-id="id69">7.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id79">7.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-has-arity"
-id="id70">7.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id80">7.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_MAX_ARITY</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-exponential-overload-threshold-arity"
-id="id71">7.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id81">7.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY</tt></a></li>
 <li><a class="reference internal" href="#outside-of-this-library"
-id="id72">7.6&nbsp;&nbsp;&nbsp;...Outside Of This Library</a></li>
+id="id82">7.6&nbsp;&nbsp;&nbsp;...Outside Of This Library</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#tutorial"
-id="id73">8&nbsp;&nbsp;&nbsp;Tutorial</a></li>
+id="id83">8&nbsp;&nbsp;&nbsp;Tutorial</a></li>
 </ul>
 </div>
 <hr class="docutils" />
@@ -525,10 +566,6 @@ class="reference external" href="../../../../boost/parameter/keyword.hpp"
 </tr>
 </tbody>
 </table>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <pre class="literal-block">
 template &lt;typename Tag&gt;
 struct keyword
@@ -958,246 +995,6 @@ href="#instance">instance</a>;
 href="#get">get</a>();
 };
 </pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"
-id="id61"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="literal-block">
-template &lt;typename Tag&gt;
-struct keyword
-{
-    typedef Tag tag;
-
-    template &lt;typename T&gt;
-    typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
-        typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-            boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                    typename Tag::qualifier
-                  , boost::parameter::in_reference
-                &gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                    boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                        typename Tag::qualifier
-                      , boost::parameter::forward_reference
-                    &gt;
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-                &gt;
-            &gt;
-        &gt;::type
-      , <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a>
-    &gt;::type constexpr
-        <a class="reference internal"
-href="#operator">operator=</a>(T const&amp; value) const;
-
-    template &lt;typename T&gt;
-    typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
-        typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-            typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                    typename Tag::qualifier
-                  , boost::parameter::out_reference
-                &gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                    boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                        typename Tag::qualifier
-                      , boost::parameter::forward_reference
-                    &gt;
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-                &gt;
-            &gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_const.html"><tt
-class="docutils literal">is_const</tt></a>&lt;T&gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-            &gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-        &gt;::type
-      , <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a>
-    &gt;::type constexpr
-        <a class="reference internal"
-href="#operator">operator=</a>(T&amp; value) const;
-
-    template &lt;typename T&gt;
-    typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
-        typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-            boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                    typename Tag::qualifier
-                  , boost::parameter::in_reference
-                &gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                    boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                        typename Tag::qualifier
-                      , boost::parameter::forward_reference
-                    &gt;
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-                &gt;
-            &gt;
-        &gt;::type
-      , <em>tagged default</em>
-    &gt;::type constexpr
-        <a class="reference internal"
-href="#id9">operator|</a>(T const&amp; x) const;
-
-    template &lt;typename T&gt;
-    typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
-        typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-            typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                    typename Tag::qualifier
-                  , boost::parameter::out_reference
-                &gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                    boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                        typename Tag::qualifier
-                      , boost::parameter::forward_reference
-                    &gt;
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-                &gt;
-            &gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_const.html"><tt
-class="docutils literal">is_const</tt></a>&lt;T&gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-            &gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-        &gt;::type
-      , <em>tagged default</em>
-    &gt;::type constexpr
-        <a class="reference internal"
-href="#id9">operator|</a>(T&amp; x) const;
-
-    template &lt;typename F&gt;
-    <em>tagged lazy default</em> <a class="reference internal"
-href="#id10">operator||</a>(F const&amp;) const;
-
-    template &lt;typename F&gt;
-    <em>tagged lazy default</em> <a class="reference internal"
-href="#id10">operator||</a>(F&amp;) const;
-
-    static keyword&lt;Tag&gt; const&amp; <a class="reference internal"
-href="#instance">instance</a>;
-
-    static keyword&lt;Tag&gt;&amp; <a class="reference internal"
-href="#get">get</a>();
-};
-</pre>
 <dl class="docutils" id="operator">
 <dt><tt class="docutils literal">operator=</tt></dt>
 <dd>
@@ -1208,12 +1005,6 @@ template &lt;typename T&gt; <a class="reference internal" href="#argumentpack"
 template &lt;typename T&gt; <a class="reference internal" href="#argumentpack"
 ><span class="concept">ArgumentPack</span></a
 > operator=(T&amp; value) const;
-</pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="first literal-block">
 template &lt;typename T&gt; <a class="reference internal" href="#argumentpack"
 ><span class="concept">ArgumentPack</span></a
 > operator=(T const&amp;&amp; value) const;
@@ -1278,12 +1069,6 @@ template &lt;typename T&gt; <em
 >tagged default</em> operator|(T const&amp; x) const;
 template &lt;typename T&gt; <em
 >tagged default</em> operator|(T&amp; x) const;
-</pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="first literal-block">
 template &lt;typename T&gt; <em
 >tagged default</em> operator|(T const&amp;&amp; x) const;
 template &lt;typename T&gt; <em
@@ -1465,8 +1250,12 @@ class="docutils literal">parameters</tt></a></h2>
 <cite>forwarding function</cite> into an <span class="concept"
 >ArgumentPack</span>, in which any <a class="reference internal"
 href="#positional">positional</a> arguments will be tagged according to the
-corresponding template argument to
-<tt class="docutils literal">parameters</tt>.</p>
+corresponding template argument to <tt class="docutils literal"
+>parameters</tt>.  If no template arguments are passed into <tt
+class="docutils literal">parameters</tt>, then the interface cannot assemble
+any <a class="reference internal" href="#positional">positional</a> arguments,
+only <a class="reference internal" href="#tagged-reference">tagged
+reference</a> arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -1479,10 +1268,6 @@ href="../../../../boost/parameter/parameters.hpp"
 </tr>
 </tbody>
 </table>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <pre class="literal-block">
 template &lt;typename ...PSpec&gt;
 struct parameters
@@ -1496,7 +1281,23 @@ struct parameters
     template &lt;typename ...Args&gt;
     <a class="reference internal" href="#argumentpack"><span
 class="concept">ArgumentPack</span></a> <a class="reference internal"
-href="#id13">operator()</a>(Args&amp;... args) const;
+href="#id13">operator()</a>(Args&amp;&amp;... args) const;
+};
+
+template &lt;&gt;
+struct parameters&lt;&gt;
+{
+    template &lt;typename ...Args&gt;
+    typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">enable_if</tt></a>&lt;
+        <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;Args...&gt;
+      , <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a>
+    &gt;::type
+        <a class="reference internal"
+href="#id13">operator()</a>(Args const&amp;... args) const;
 };
 </pre>
 <table class="docutils field-list" frame="void" rules="none">
@@ -1567,119 +1368,6 @@ href="#keyword-tag-type">keyword tag type</a>.</div>
 </div>
 </blockquote>
 </div>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="literal-block">
-template &lt;
-    typename P0 = <em>unspecified</em>
-  , typename P1 = <em>unspecified</em>
-  , …
-  , typename P ## β = <em>unspecified</em>
-&gt;
-struct parameters
-{
-    template &lt;
-        typename A0
-      , typename A1 = <em>unspecified</em>
-      , …
-      , typename A ## β = <em>unspecified</em>
-    &gt;
-    struct <a class="reference internal" href="#match">match</a>
-    {
-        typedef … type;
-    };
-
-    template &lt;typename A0&gt;
-    <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a> <a class="reference internal"
-href="#id13">operator()</a>(A0&amp; a0) const;
-
-    template &lt;typename A0, typename A1&gt;
-    <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a> <a class="reference internal"
-href="#id13">operator()</a>(A0&amp; a0, A1&amp; a1) const;
-
-    <span class="vellipsis">⋮</span>
-
-    template &lt;typename A0, typename A1, …, typename A ## β&gt;
-    <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a>
-    <a class="reference internal" href="#id13"
->operator()</a>(A0&amp; a0, A1&amp; a1, …, A ## β &amp; a ## β) const;
-};
-</pre>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
-<tbody valign="top">
-<tr class="field">
-<th class="field-name">Requires:</th>
-<td class="field-body"><tt class="docutils literal">P0</tt>,
-<tt class="docutils literal">P1</tt>, …, <tt class="docutils literal">P</tt>
-## β are models of <a class="reference internal" href="#parameterspec"
-><span class="concept">ParameterSpec</span></a>.</td>
-</tr>
-</tbody>
-</table>
-<div class="note">
-<p class="first admonition-title">Note</p>
-<p>In this section, <tt class="docutils literal">R</tt> ## <em>i</em> and
-<tt class="docutils literal">K</tt> ## <em>i</em> are defined as follows: for
-any argument type <tt class="docutils literal">A</tt> ## <em>i</em>:</p>
-<blockquote class="last">
-<div class="line-block">
-<div class="line">let <tt class="docutils literal">D0</tt> the set [d0, …, d
-## <em>j</em>] of all <strong>deduced</strong> <em>parameter specs</em> in
-[<tt class="docutils literal">P0</tt>, …, <tt class="docutils literal">P</tt>
-## β]</div>
-<div class="line"><tt class="docutils literal">R</tt> ## <em>i</em> is the
-<a class="reference internal" href="#intended-argument-type">intended argument
-type</a> of <tt class="docutils literal">A</tt> ## <em>i</em></div>
-<div class="line"><br /></div>
-<div class="line">if <tt class="docutils literal">A</tt> ## <em>i</em> is a
-result type of <tt class="docutils literal"><span class="pre"
->keyword&lt;T&gt;::</span></tt><a class="reference internal" href="#operator"
-><tt class="docutils literal">operator=</tt></a></div>
-<div class="line">then</div>
-<div class="line-block">
-<div class="line"><tt class="docutils literal">K</tt> ## <em>i</em> is
-<tt class="docutils literal">T</tt></div>
-</div>
-<div class="line">else</div>
-<div class="line-block">
-<div class="line">if some <tt class="docutils literal">A</tt> ## <em>j</em>
-where <em>j</em> ≤ <em>i</em> is a result type of <tt class="docutils literal"
-><span class="pre">keyword&lt;T&gt;::</span></tt><a class="reference internal"
-href="#operator"><tt class="docutils literal">operator=</tt></a></div>
-<div class="line"><em>or</em> some <tt class="docutils literal">P</tt> ##
-<em>j</em> in <em>j</em> ≤ <em>i</em> is <strong>deduced</strong></div>
-<div class="line">then</div>
-<div class="line-block">
-<div class="line">if some <em>parameter spec</em> <tt class="docutils literal"
->d</tt><em>j</em> in <tt class="docutils literal">D</tt> ## <em>i</em> matches
-<tt class="docutils literal">A</tt><em>i</em></div>
-<div class="line">then</div>
-<div class="line-block">
-<div class="line"><tt class="docutils literal">K</tt> ## <em>i</em> is <tt
-class="docutils literal">d</tt> ## <em>j</em>'s <a class="reference internal"
-href="#keyword-tag-type">keyword tag type</a>.</div>
-<div class="line"><tt class="docutils literal">D</tt><sub>i+1</sub> is
-<tt class="docutils literal">D</tt> ## <em>i</em> -
-[<tt class="docutils literal">d</tt> ## <em>j</em>]</div>
-</div>
-</div>
-<div class="line">else</div>
-<div class="line-block">
-<div class="line"><tt class="docutils literal">K</tt> ## <em>i</em> is <tt
-class="docutils literal">P</tt> ## <em>i</em>'s <a class="reference internal"
-href="#keyword-tag-type">keyword tag type</a>.</div>
-</div>
-</div>
-</div>
-</blockquote>
-</div>
 <dl class="docutils" id="match">
 <dt><tt class="docutils literal">match</tt></dt>
 <dd>
@@ -1688,10 +1376,6 @@ href="../../../mpl/doc/refmanual/metafunction.html"><span class="concept"
 >Metafunction</span></a> used to remove a <a class="reference external"
 href="index.html#forwarding-functions">forwarding function</a> from overload
 resolution.</p>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -1741,86 +1425,15 @@ default</li>
 </ul>
 </li>
 </ul>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
-<tbody valign="top">
-<tr class="field">
-<th class="field-name">Returns:</th>
-<td class="field-body">if <tt class="docutils literal">P0</tt>, <tt
-class="docutils literal">P1</tt>, …, <tt class="docutils literal">Pβ</tt> are
-<em>satisfied</em> (see below), then <tt class="docutils literal"><span
-class="pre">parameters&lt;P0,P1,…,Pβ&gt;</span></tt>.  Otherwise,
-<tt class="docutils literal"><span
-class="pre">match&lt;A0,A1,…,Aβ&gt;::type</span></tt> is not defined.</td>
-</tr>
-</tbody>
-</table>
-<p><tt class="docutils literal">P0</tt>, <tt class="docutils literal">P1</tt>,
-…, <tt class="docutils literal">Pβ</tt> are <strong>satisfied</strong> if, for
-every <em>j</em> in 0…β, either:</p>
-<ul class="last simple">
-<li><tt class="docutils literal">P</tt> ## <em>j</em> is the
-<em>unspecified</em> default</li>
-<li><strong>or</strong>, <tt class="docutils literal">P</tt> ## <em>j</em> is
-a <em>keyword tag type</em></li>
-<li><strong>or</strong>, <tt class="docutils literal">P</tt> ## <em>j</em> is
-<a class="reference internal" href="#optional"><tt class="docutils literal"
->optional</tt></a><tt class="docutils literal">&lt;X,F&gt;</tt> and either
-<ul>
-<li><tt class="docutils literal">X</tt> is not <tt class="docutils literal"
->K</tt> ## <em>i</em> for any <em>i</em>,</li>
-<li><strong>or</strong> <tt class="docutils literal">X</tt> is some
-<tt class="docutils literal">K</tt> ## <em>i</em> and
-<tt class="docutils literal"><span class="pre">mpl::apply&lt;F,R</span></tt>
-## <em>i</em><tt class="docutils literal"><span class="pre"
->&gt;::type::value</span></tt> is <tt class="docutils literal">true</tt></li>
-</ul>
-</li>
-<li><strong>or</strong>, <tt class="docutils literal">P</tt> ## <em>j</em> is
-<a class="reference internal" href="#required"><tt class="docutils literal"
->required</tt></a><tt class="docutils literal">&lt;X,F&gt;</tt>, and
-<ul>
-<li><tt class="docutils literal">X</tt> is some <tt class="docutils literal"
->K</tt> ## <em>i</em>, <strong>and</strong></li>
-<li><tt class="docutils literal"><span class="pre"
->mpl::apply&lt;F,R</span></tt> ## <em>i</em><tt class="docutils literal"
-><span class="pre">&gt;::type::value</span></tt> is
-<tt class="docutils literal">true</tt></li>
-</ul>
-</li>
-</ul>
 </dd>
 </dl>
 <dl class="docutils" id="id13">
 <dt><tt class="docutils literal">operator()</tt></dt>
 <dd>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"
-id="id61"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="first literal-block">
-template &lt;typename ...Args&gt; <a class="reference internal"
-href="#argumentpack"><span class="concept"
+\<pre class="first literal-block">
+template &lt;typename ...Args&gt;
+<a class="reference internal" href="#argumentpack"><span class="concept"
 >ArgumentPack</span></a> operator()(Args&amp;&amp;... args) const;
-</pre>
-<p><strong>Else</strong>:</p>
-<pre class="first literal-block">
-template &lt;typename A0&gt; <a class="reference internal"
-href="#argumentpack"><span class="concept"
->ArgumentPack</span></a> operator()(A0 const&amp; a0) const;
-
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## β&gt; <a class="reference internal"
-href="#argumentpack"><span class="concept"
->ArgumentPack</span></a> <a class="reference internal" href="#id13"
->operator()</a>(A0 const&amp; a0, …, A ## β const&amp; a ## β) const;
 </pre>
 <table class="last docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -2073,8 +1686,11 @@ tag type</a> <tt class="docutils literal">K</tt>, if any.  If no such
 <a class="reference internal" href="#tagged-reference">tagged reference</a>
 exists, returns <tt class="docutils literal">D</tt>.  Equivalent to:</p>
 <pre class="literal-block">
-typename remove_reference&lt;
-    typename binding&lt;A, K, D&gt;::type
+typename boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/remove_reference.html"
+><tt class="docutils literal">remove_reference</tt></a>&lt;
+    typename <a class="reference internal" href="#binding"
+>binding</a>&lt;A, K, D&gt;::type
 &gt;::type
 </pre>
 <p class="last">… when <tt class="docutils literal">D</tt> is not a reference
@@ -2084,8 +1700,91 @@ type.</p>
 </tbody>
 </table>
 </div>
-<div class="section" id="is-argument-pack">
+<div class="section" id="are-tagged-arguments">
 <h2><a class="toc-backref" href="#id49">5.4&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">are_tagged_arguments</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/are_tagged_arguments.hpp"
+>boost/parameter/are_tagged_arguments.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<pre class="literal-block">
+template &lt;typename T0, typename ...Pack&gt;
+struct are_tagged_arguments  // : mpl::true_ or mpl::false_
+{
+};
+</pre>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Returns:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body"><tt class="docutils literal"><span class="pre"
+>mpl::true_</span></tt> if <tt class="docutils literal">T0</tt> and all
+elements in parameter pack <tt class="docutils literal">Pack</tt> are
+<a class="reference internal" href="#tagged-reference">tagged reference</a>
+types, <tt class="docutils literal"><span class="pre">mpl::false_</span></tt>
+otherwise.</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">When implementing a Boost.Parameter-enabled constructor for a
+container that conforms to the C++ standard, one needs to remember that the
+standard requires the presence of other constructors that are typically
+defined as templates, such as range constructors.  To avoid overload
+ambiguities between the two constructors, use this metafunction in conjunction
+with <tt class="docutils literal"><span class="pre">disable_if</span></tt> to
+define the range constructor.</p>
+<pre class="first literal-block">
+template &lt;typename B&gt;
+class frontend : public B
+{
+    struct _enabler
+    {
+    };
+
+ public:
+    <a class="reference internal"
+href="#boost-parameter-no-spec-constructor-cls-impl"
+>BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR</a>(frontend, (B))
+
+    template &lt;typename Iterator&gt;
+    frontend(
+        Iterator itr
+      , Iterator itr_end
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">disable_if</tt></a>&lt;
+            are_tagged_arguments&lt;Iterator&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : B(itr, itr_end)
+    {
+    }
+};
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="section" id="is-argument-pack">
+<h2><a class="toc-backref" href="#id50">5.5&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">is_argument_pack</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -2110,13 +1809,74 @@ struct is_argument_pack  // : mpl::true_ or mpl::false_
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field">
-<th class="field-name">Returns:</th>
+<th class="field-name" colspan="2">Returns:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
 <td class="field-body"><tt class="docutils literal"><span class="pre"
 >mpl::true_</span></tt> if <tt class="docutils literal">T</tt> is a model of
 <a class="reference internal" href="#argumentpack"><span class="concept"
 >ArgumentPack</span></a>, <tt class="docutils literal"><span class="pre"
->mpl::false_</span></tt> otherwise.</a>
-exists, returns <tt class="docutils literal">D</tt>.</td>
+>mpl::false_</span></tt> otherwise.</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">To avoid overload ambiguities between a constructor that
+takes in an <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> and a templated conversion
+constructor, use this metafunction in conjunction with
+<tt class="docutils literal"><span class="pre">enable_if</span></tt>.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a0)
+
+template &lt;typename T&gt;
+class backend0
+{
+    struct _enabler
+    {
+    };
+
+    T a0;
+
+ public:
+    template &lt;typename ArgPack&gt;
+    explicit backend0(
+        ArgPack const&amp; args
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            is_argument_pack&lt;ArgPack&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : a0(args[_a0])
+    {
+    }
+
+    template &lt;typename U&gt;
+    backend0(
+        backend0&lt;U&gt; const&amp; copy
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/is_convertible.html"
+>is_convertible</a>&lt;U,T&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : a0(copy.get_a0())
+    {
+    }
+
+    T const&amp; get_a0() const
+    {
+        return this-&gt;a0;
+    }
+};
+</pre>
+</td>
 </tr>
 </tbody>
 </table>
@@ -2124,13 +1884,13 @@ exists, returns <tt class="docutils literal">D</tt>.</td>
 </div>
 <hr class="docutils" />
 <div class="section" id="code-generation-macros">
-<h1><a class="toc-backref" href="#id50">6&nbsp;&nbsp;&nbsp;Code Generation
+<h1><a class="toc-backref" href="#id51">6&nbsp;&nbsp;&nbsp;Code Generation
 Macros</a></h1>
 <p>Macros in this section can be used to ease the writing of code using the
 Parameter libray by eliminating repetitive boilerplate.</p>
 <div class="section"
 id="boost-parameter-function-result-name-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id51">6.1&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id52">6.1&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2150,18 +1910,217 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field">
-<th class="field-name" colspan="2">Requires:</th>
+<th class="field-name" colspan="2">Example usage:</th>
 </tr>
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first"><tt class="docutils literal">result</tt> is the parenthesized
-return type of the function.  <tt class="docutils literal">name</tt> is the
-base name of the function, this is the name of the generated forwarding
-functions.  <tt class="docutils literal">tag_namespace</tt> is the namespace
-in which the keywords used by the function
-resides.  <tt class="docutils literal">arguments</tt> is a list of
-<em>argument specifiers</em>, as defined below.</p>
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal function
+header.  Enclose the return type <tt class="docutils literal">bool</tt> in
+parentheses.  For each parameter, also enclose the expected value type in
+parentheses.  Since the value types are mutually exclusive, you can wrap the
+parameters in a <tt class="docutils literal">(deduced …)</tt>
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the
+corresponding argument.  Note that the second method doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+BOOST_PARAMETER_FUNCTION((bool), evaluate, kw,
+    (deduced
+        (required
+            (lrc, (std::bitset&lt;1&gt;))
+            (lr, (std::bitset&lt;2&gt;))
+        )
+        (optional
+            (rrc, (std::bitset&lt;3&gt;), rvalue_const_bitset&lt;2&gt;())
+            (rr, (std::bitset&lt;4&gt;), rvalue_bitset&lt;3&gt;())
+        )
+    )
+)
+{
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference_to_const
+      , U::evaluate_category&lt;0&gt;(lrc)
+    );
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference
+      , U::evaluate_category&lt;1&gt;(lr)
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference_to_const
+      , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference
+      , U::evaluate_category&lt;3&gt;(args[_rr0])
+    );
+
+    return true;
+}
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a>, <a
+class="reference external" href="../../test/preprocessor_deduced.cpp"
+>test/preprocessor_deduced.cpp</a>, and <a class="reference external"
+href="../../test/preprocessor_eval_category.cpp"
+>test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
 </td>
 </tr>
 <tr class="field">
@@ -2248,33 +2207,6 @@ type.</li>
 </tr>
 </tbody>
 </table>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
-<tbody valign="top">
-<tr class="field">
-<th class="field-name" colspan="2">Generated names in enclosing scope:</th>
-</tr>
-<tr>
-<td>&nbsp;</td>
-<td class="field-body">
-<ul class="first last simple">
-<li><tt class="docutils literal">boost_param_result_ ## __LINE__ ##
-name</tt></li>
-<li><tt class="docutils literal">boost_param_params_ ## __LINE__ ##
-name</tt></li>
-<li><tt class="docutils literal">boost_param_parameters_ ## __LINE__ ##
-name</tt></li>
-<li><tt class="docutils literal">boost_param_impl ## name</tt></li>
-<li><tt class="docutils literal">boost_param_dispatch_0boost_ ## __LINE__ ##
-name</tt></li>
-<li><tt class="docutils literal">boost_param_dispatch_1boost_ ## __LINE__ ##
-name</tt></li>
-</ul>
-</td>
-</tr>
-</tbody>
-</table>
 <dl class="docutils">
 <dt>Approximate expansion:</dt>
 <dd>
@@ -2285,10 +2217,6 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 <li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <pre class="last literal-block">
 template &lt;typename T&gt;
 struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
@@ -2297,7 +2225,7 @@ struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
 };
 
 struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
-  : boost::parameter::parameters&lt;
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
         <em>list of parameter specifications, based on arguments</em>
     &gt;
 {
@@ -2308,8 +2236,8 @@ typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
 
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## <strong
->name</strong>&lt;Args&gt;::type
-    boost_param_impl ## <strong>name</strong>(Args const&);
+>name</strong> ## _&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const&);
 
 template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
 <em>result type</em>
@@ -2317,13 +2245,13 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
         A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
 >n</strong>
       , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0, …, A ## <strong>n</strong>
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## <strong
 >name</strong>()
     )
 {
-    return boost_param_impl ## <strong>name</strong>(
+    return boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2345,13 +2273,13 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
         A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
 >m</strong>
       , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0, …, A ## <strong>m</strong>
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## <strong
 >name</strong>()
     )
 {
-    return boost_param_impl ## <strong>name</strong>(
+    return boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2406,10 +2334,15 @@ ResultType
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## <strong
 >name</strong>&lt;Args&gt;::type
-    boost_param_impl ## <strong>name</strong>(Args const& args)
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
 {
     return boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+        static_cast&lt;
+            typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
       , args
       , std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2506,234 +2439,12 @@ ResultType
 >argument name</em> ## <strong>m</strong>
     )
 </pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="last literal-block">
-template &lt;typename T&gt;
-struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
-{
-    typedef <strong>result</strong> type;
-};
-
-struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
-  : boost::parameter::parameters&lt;
-        <em>list of parameter specifications, based on arguments</em>
-    &gt;
-{
-};
-
-typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
-    boost_param_parameters_ ## __LINE__ ## <strong>name</strong>;
-
-template &lt;typename Args&gt;
-typename boost_param_result_ ## __LINE__ ## <strong
->name</strong>&lt;Args&gt;::type
-    boost_param_impl ## <strong>name</strong>(Args const&);
-
-template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>result type</em>
-    <strong>name</strong>(
-        A0 const&amp; a0, …, A ## <strong>n</strong> const&amp; a ## <strong
->n</strong>
-      , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0 const, …, A ## <strong>n</strong> const
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>()
-    )
-{
-    return boost_param_impl ## <strong>name</strong>(
-        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
-            a0, …, a ## <strong>n</strong>
-        )
-    );
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>result type</em>
-    <strong>name</strong>(
-        A0&amp; a0, …, A ## <strong>n</strong> &amp; a ## <strong>n</strong>
-      , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0, …, A ## <strong>n</strong>
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>()
-    )
-{
-    return boost_param_impl ## <strong>name</strong>(
-        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
-            a0, …, a ## <strong>n</strong>
-        )
-    );
-}
-
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>result type</em>
-    <strong>name</strong>(
-        A0 const&amp; a0, …, A ## <strong>m</strong> const&amp ## ; a<strong
->m</strong>
-      , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0 const, …, A ## <strong>m</strong> const
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>()
-    )
-{
-    return boost_param_impl ## <strong>name</strong>(
-        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
-            a0, …, a ## <strong>m</strong>
-        )
-    );
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>result type</em>
-    <strong>name</strong>(
-        A0&amp; a0, …, A ## <strong>m</strong> &amp ## ; a<strong>m</strong>
-      , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0, …, A ## <strong>m</strong>
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>()
-    )
-{
-    return boost_param_impl ## <strong>name</strong>(
-        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
-            a0, …, a ## <strong>m</strong>
-        )
-    );
-}
-
-template &lt;
-    typename ResultType
-  , typename Args
-  , typename <em>argument name</em> ## <strong>0</strong> ## _type
-  , …
-  , typename <em>argument name</em> ## <strong>n</strong> ## _type
-&gt;
-ResultType
-    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        (ResultType(*)())
-      , Args const&amp; args
-      , <em>argument name</em> ## <strong>0</strong> ## _type&amp; <em
->argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>n</strong> ## _type&amp; <em
->argument name</em> ## <strong>n</strong>
-    );
-
-<span class="vellipsis">⋮</span>
-
-template &lt;
-    typename ResultType
-  , typename Args
-  , typename <em>argument name</em> ## <strong>0</strong> ## _type
-  , …
-  , typename <em>argument name</em> ## <strong>m</strong> ## _type
-&gt;
-ResultType
-    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        (ResultType(*)())
-      , Args const&amp; args
-      , <em>argument name</em> ## <strong>0</strong> ## _type&amp; <em
->argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>m</strong> ## _type&amp; <em
->argument name</em> ## <strong>m</strong>
-    );
-
-template &lt;typename Args&gt;
-typename boost_param_result_ ## __LINE__ ## <strong
->name</strong>&lt;Args&gt;::type
-    boost_param_impl ## <strong>name</strong>(Args const& args)
-{
-    return boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
-      , args
-      , args[ <em>keyword object of required parameter</em> ## <strong
->0</strong>]
-      , …
-      , args[ <em>keyword object of required parameter</em> ## <strong
->n</strong>]
-    );
-}
-
-template &lt;
-    typename ResultType
-  , typename Args
-  , typename <em>argument name</em> ## <strong>0</strong> ## _type
-  , …
-  , typename <em>argument name</em> ## <strong>n</strong> ## _type
-&gt;
-ResultType
-    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        (ResultType(*)())
-      , Args const&amp; args
-      , <em>argument name</em> ## <strong>0</strong> ## _type&amp; <em
->argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>n</strong> ## _type&amp; <em
->argument name</em> ## <strong>n</strong>
-    )
-{
-    return boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
-      , (args, <em>keyword object of optional parameter</em> ## <strong
->n + 1</strong> =
-            <em>default value of optional parameter</em> ## <strong
->n + 1</strong>
-        )
-      , <em>argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>n</strong>
-      , <em>default value of optional parameter</em> ## <strong
->n + 1</strong>
-    );
-}
-
-<span class="vellipsis">⋮</span>
-
-template &lt;
-    typename ResultType
-  , typename Args
-  , typename <em>argument name</em> ## <strong>0</strong> ## _type
-  , …
-  , typename <em>argument name</em> ## <strong>m</strong> ## _type
-&gt;
-ResultType
-    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        (ResultType(*)())
-      , Args const&amp; args
-      , <em>argument name</em> ## <strong>0</strong> ## _type&amp; <em
->argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>m</strong> ## _type&amp; <em
->argument name</em> ## <strong>m</strong>
-    )
-</pre>
 </dd>
 </dl>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a>, <a class="reference external"
-href="../../test/preprocessor_deduced.cpp">test/preprocessor_deduced.cpp</a>,
-and <a class="reference external"
-href="../../test/preprocessor_eval_category.cpp"
->test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
-usage of this macro.</p>
 </div>
 <div class="section"
 id="boost-parameter-member-function-result-name-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id52">6.2&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id53">6.2&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_MEMBER_FUNCTION(result, name,
 tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2748,26 +2459,506 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_FUNCTION</tt></a>, except:</p>
-<ul>
-<li><tt class="docutils literal">name</tt> may be qualified by the
-<tt class="docutils literal">static</tt> keyword to declare the member
-function and its helpers as not associated with any object of the enclosing
-type.</li>
-<li>Expansion of this macro omits all forward declarations of the front-end
-implementation and dispatch functions.</li>
-</ul>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> and <a class="reference external"
-href="../../test/preprocessor_eval_category.cpp"
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">static</tt> member function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  Also, just as with a normal function, optional parameters
+have default values, whereas required parameters do not.  Within the function
+body, either simply use the parameter name or pass the matching identifier
+with the leading underscore to the bracket operator of <tt
+class="docutils literal">args</tt> to extract the corresponding
+argument.  Note that the second method doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    BOOST_PARAMETER_MEMBER_FUNCTION((bool), static evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;), rvalue_const_bitset&lt;2&gt;())
+                (rr, (std::bitset&lt;4&gt;), rvalue_bitset&lt;3&gt;())
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(lrc)
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(lr)
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(args[_rr0])
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B::evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+B::evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+B::evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+B::evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+B::evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+B::evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+B::evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> and <a
+class="reference external" href="../../test/preprocessor_eval_category.cpp"
 >test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
 usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.  <tt
+class="docutils literal">name</tt> may be qualified by the <tt
+class="docutils literal">static</tt> keyword to declare the member function
+and its helpers as not associated with any object of the enclosing type.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>optional-specifier</em> {<em>optional-specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>required-specifier</em> {<em>required-specifier</em>}
+        '<strong>)</strong>'
+    )
+
+optional-specifier ::=
+    '<strong>(</strong>'
+        <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> '<strong>,</strong>' <em>default-value</em>
+    ')'
+
+required-specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">default-value</tt> is any valid C++
+expression; if necessary, user code can compute it in terms of
+<tt class="docutils literal">previous-name ## _type</tt>, where
+<tt class="docutils literal">previous-name</tt> is the
+<tt class="docutils literal">argument-name</tt> in a previous
+<tt class="docutils literal">specifier-group0</tt> or
+<tt class="docutils literal">specifier-group1</tt>.  <em>This expression will
+be invoked exactly once.</em></li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.  If <tt class="docutils literal"
+>restriction</tt> uses this form, then the type of the generated name <tt
+class="docutils literal">argument-name ## _type</tt> will be computed in terms
+of the <strong>target type</strong>, and the generated reference
+<tt class="docutils literal">argument-name</tt> (but not its corresponding
+entry in <tt class="docutils literal">args</tt>) will be cast to that
+type.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong>name</strong>
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong>name</strong>
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
+{
+    return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## <strong
+>name</strong>(
+        static_cast&lt;
+            typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , args
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>0</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>0</strong>])
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>n</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>n</strong>])
+    );
+}
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>n</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>n</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>n</strong>
+    )
+{
+    return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## <strong
+>name</strong>(
+        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+      , (args, <em>keyword object of optional parameter</em> ## <strong
+>n + 1</strong> =
+            <em>default value of optional parameter</em> ## <strong
+>n + 1</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>0</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>0</strong>
+        )
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>n</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>n</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of optional parameter</em> ## <strong>n + 1</strong>
+            &gt;::type
+        &gt;(<em>default value of optional parameter</em> ## <strong
+>n + 1</strong>)
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>m</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>m</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>m</strong>
+    )
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-c-mem-function-result-name-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id53">6.3&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id54">6.3&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_CONST_MEMBER_FUNCTION(result, name,
 tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2782,18 +2973,511 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-member-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_MEMBER_FUNCTION</tt></a>,
-except that the overloaded forwarding member functions and their helper
-methods are <tt class="docutils literal">const</tt>-qualified.</p>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">const</tt> member function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  Also, just as with a normal function, optional parameters
+have default values, whereas required parameters do not.  Within the function
+body, either simply use the parameter name or pass the matching identifier
+with the leading underscore to the bracket operator of <tt
+class="docutils literal">args</tt> to extract the corresponding
+argument.  Note that the second method doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    B()
+    {
+    }
+
+    BOOST_PARAMETER_CONST_MEMBER_FUNCTION((bool), evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;), rvalue_const_bitset&lt;2&gt;())
+                (rr, (std::bitset&lt;4&gt;), rvalue_bitset&lt;3&gt;())
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(lrc)
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(lr)
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(args[_rr0])
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B const b = B();
+b.evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+b.evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+b.evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+b.evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+b.evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+b.evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+b.evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>optional-specifier</em> {<em>optional-specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>required-specifier</em> {<em>required-specifier</em>}
+        '<strong>)</strong>'
+    )
+
+optional-specifier ::=
+    '<strong>(</strong>'
+        <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> '<strong>,</strong>' <em>default-value</em>
+    ')'
+
+required-specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">default-value</tt> is any valid C++
+expression; if necessary, user code can compute it in terms of
+<tt class="docutils literal">previous-name ## _type</tt>, where
+<tt class="docutils literal">previous-name</tt> is the
+<tt class="docutils literal">argument-name</tt> in a previous
+<tt class="docutils literal">specifier-group0</tt> or
+<tt class="docutils literal">specifier-group1</tt>.  <em>This expression will
+be invoked exactly once.</em></li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.  If <tt class="docutils literal"
+>restriction</tt> uses this form, then the type of the generated name <tt
+class="docutils literal">argument-name ## _type</tt> will be computed in terms
+of the <strong>target type</strong>, and the generated reference
+<tt class="docutils literal">argument-name</tt> (but not its corresponding
+entry in <tt class="docutils literal">args</tt>) will be cast to that
+type.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_const_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_const_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_const_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_const_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(Args const& args) const
+{
+    return this-&gt;
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## <strong>name</strong>(
+        static_cast&lt;
+            typename boost_param_result_const_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , args
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>0</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>0</strong>])
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>n</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>n</strong>])
+    );
+}
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>n</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>n</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>n</strong>
+    ) const
+{
+    return this-&gt;
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## <strong>name</strong>(
+        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+      , (args, <em>keyword object of optional parameter</em> ## <strong
+>n + 1</strong> =
+            <em>default value of optional parameter</em> ## <strong
+>n + 1</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>0</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>0</strong>
+        )
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>n</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>n</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of optional parameter</em> ## <strong>n + 1</strong>
+            &gt;::type
+        &gt;(<em>default value of optional parameter</em> ## <strong
+>n + 1</strong>)
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>m</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>m</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>m</strong>
+    ) const
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-function-call-op-result-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id54">6.4&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id55">6.4&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_FUNCTION_CALL_OPERATOR(result,
 tag_ns, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2808,45 +3492,411 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-member-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_MEMBER_FUNCTION</tt></a>,
-except that the name of the forwarding member function overloads is
-<tt class="docutils literal">operator()</tt>.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field">
-<th class="field-name" colspan="2">Generated names in enclosing scope:</th>
+<th class="field-name" colspan="2">Example usage:</th>
 </tr>
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<ul class="first last simple">
-<li><tt class="docutils literal">boost_param_result_ ## __LINE__ ##
-operator</tt></li>
-<li><tt class="docutils literal">boost_param_params_ ## __LINE__ ##
-operator</tt></li>
-<li><tt class="docutils literal">boost_param_parameters_ ## __LINE__ ##
-operator</tt></li>
-<li><tt class="docutils literal">boost_param_impl ## operator</tt></li>
-<li><tt class="docutils literal">boost_param_dispatch_0boost_ ## __LINE__ ##
-operator</tt></li>
-<li><tt class="docutils literal">boost_param_dispatch_1boost_ ## __LINE__ ##
-operator</tt></li>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">tag</tt> by
+default.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(y)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(z)
+</pre>
+<p class="first">Use the macro as a substitute for a normal function call
+operator header.  Enclose the return type in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  This is especially useful
+when implementing multiple Boost.Parameter-enabled function call operator
+overloads.</p>
+<pre class="first literal-block">
+class char_reader
+{
+    int index;
+    char const* key;
+
+ public:
+    explicit char_reader(char const* k) : index(0), key(k)
+    {
+    }
+
+    BOOST_PARAMETER_FUNCTION_CALL_OPERATOR((void), tag,
+        (deduced
+            (required
+                (y, (int))
+                (z, (char const*))
+            )
+        )
+    )
+    {
+        this->index = y;
+        this->key = z;
+    }
+
+    <a class="reference internal"
+href="#boost-parameter-const-function-call-op-result-tag-namespace-arguments"
+>BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR</a>((char), tag,
+        (deduced
+            (required
+                (y, (bool))
+                (z, (std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;))
+            )
+        )
+    )
+    {
+        return y ? (
+            (z.find(this->key)->second)[this->index]
+        ) : this->key[this->index];
+    }
+};
+</pre>
+<p class="first">As with regular argument-dependent lookup, the value types of
+the arguments passed in determine which function call operator overload gets
+invoked.</p>
+<pre class="first literal-block">
+char const* keys[] = {"foo", "bar", "baz"};
+std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt; k2s;
+k2s[keys[0]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("qux");
+k2s[keys[1]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("wmb");
+k2s[keys[2]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("zxc");
+char_reader r(keys[0]);
+
+// positional arguments
+BOOST_TEST_EQ('q', (r(true, k2s)));
+BOOST_TEST_EQ('f', (r(false, k2s)));
+
+// named arguments
+r(_z = keys[1], _y = 1);
+BOOST_TEST_EQ('m', (r(_z = k2s, _y = true)));
+BOOST_TEST_EQ('a', (r(_z = k2s, _y = false)));
+
+// deduced arguments
+r(keys[2], 2);
+BOOST_TEST_EQ('c', (r(k2s, true)));
+BOOST_TEST_EQ('z', (r(k2s, false)));
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> and <a
+class="reference external" href="../../test/preprocessor_deduced.cpp"
+>test/preprocessor_deduced.cpp</a> test programs demonstrate proper usage of
+this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function call operator resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>optional-specifier</em> {<em>optional-specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>required-specifier</em> {<em>required-specifier</em>}
+        '<strong>)</strong>'
+    )
+
+optional-specifier ::=
+    '<strong>(</strong>'
+        <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> '<strong>,</strong>' <em>default-value</em>
+    ')'
+
+required-specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">default-value</tt> is any valid C++
+expression; if necessary, user code can compute it in terms of
+<tt class="docutils literal">previous-name ## _type</tt>, where
+<tt class="docutils literal">previous-name</tt> is the
+<tt class="docutils literal">argument-name</tt> in a previous
+<tt class="docutils literal">specifier-group0</tt> or
+<tt class="docutils literal">specifier-group1</tt>.  <em>This expression will
+be invoked exactly once.</em></li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.  If <tt class="docutils literal"
+>restriction</tt> uses this form, then the type of the generated name <tt
+class="docutils literal">argument-name ## _type</tt> will be computed in terms
+of the <strong>target type</strong>, and the generated reference
+<tt class="docutils literal">argument-name</tt> (but not its corresponding
+entry in <tt class="docutils literal">args</tt>) will be cast to that
+type.</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## operator
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## operator
+    boost_param_parameters_ ## __LINE__ ## operator;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## operator()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## operator(
+        boost_param_parameters_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## operator()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## operator(
+        boost_param_parameters_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## operator&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## operator(Args const& args)
+{
+    return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## operator(
+        static_cast&lt;
+            typename boost_param_result_ ## __LINE__ ## operator&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , args
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>0</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>0</strong>])
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>n</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>n</strong>])
+    );
+}
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>n</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_0boost_ ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>n</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>n</strong>
+    )
+{
+    return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## operator(
+        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+      , (args, <em>keyword object of optional parameter</em> ## <strong
+>n + 1</strong> =
+            <em>default value of optional parameter</em> ## <strong
+>n + 1</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>0</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>0</strong>
+        )
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>n</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>n</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of optional parameter</em> ## <strong>n + 1</strong>
+            &gt;::type
+        &gt;(<em>default value of optional parameter</em> ## <strong
+>n + 1</strong>)
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>m</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_0boost_ ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>m</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>m</strong>
+    )
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-const-function-call-op-result-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id55">6.5&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id56">6.5&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR(result,
 tag_ns, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2861,20 +3911,506 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-function-call-op-result-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_FUNCTION_CALL_OPERATOR</tt></a>,
-except that the overloaded function call operators and their helper methods
-are <tt class="docutils literal">const</tt>-qualified.</p>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> and <a class="reference external"
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">const</tt> function call operator header.  Enclose
+the return type <tt class="docutils literal">bool</tt> in parentheses.  For
+each parameter, also enclose the expected value type in parentheses.  Since
+the value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  Also, just as with a normal function, optional parameters
+have default values, whereas required parameters do not.  Within the function
+body, either simply use the parameter name or pass the matching identifier
+with the leading underscore to the bracket operator of <tt
+class="docutils literal">args</tt> to extract the corresponding
+argument.  Note that the second method doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    B()
+    {
+    }
+
+    BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR((bool), kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;), rvalue_const_bitset&lt;2&gt;())
+                (rr, (std::bitset&lt;4&gt;), rvalue_bitset&lt;3&gt;())
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(lrc)
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(lr)
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(args[_rr0])
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B const b = B();
+b(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+b(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+b((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+b(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+b(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+b(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+b(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a>, <a
+class="reference external" href="../../test/preprocessor_deduced.cpp"
+>test/preprocessor_deduced.cpp</a>, and <a class="reference external"
 href="../../test/preprocessor_eval_cat_8.cpp"
 >test/preprocessor_eval_cat_8.cpp</a> test programs demonstrate proper usage
 of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function call operator resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>optional-specifier</em> {<em>optional-specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>required-specifier</em> {<em>required-specifier</em>}
+        '<strong>)</strong>'
+    )
+
+optional-specifier ::=
+    '<strong>(</strong>'
+        <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> '<strong>,</strong>' <em>default-value</em>
+    ')'
+
+required-specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">default-value</tt> is any valid C++
+expression; if necessary, user code can compute it in terms of
+<tt class="docutils literal">previous-name ## _type</tt>, where
+<tt class="docutils literal">previous-name</tt> is the
+<tt class="docutils literal">argument-name</tt> in a previous
+<tt class="docutils literal">specifier-group0</tt> or
+<tt class="docutils literal">specifier-group1</tt>.  <em>This expression will
+be invoked exactly once.</em></li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.  If <tt class="docutils literal"
+>restriction</tt> uses this form, then the type of the generated name <tt
+class="docutils literal">argument-name ## _type</tt> will be computed in terms
+of the <strong>target type</strong>, and the generated reference
+<tt class="docutils literal">argument-name</tt> (but not its corresponding
+entry in <tt class="docutils literal">args</tt>) will be cast to that
+type.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_const_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_const_ ## __LINE__ ## operator
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_const_ ## __LINE__ ## operator
+    boost_param_parameters_const_ ## __LINE__ ## operator;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## operator()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
+        boost_param_parameters_const_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## operator()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
+        boost_param_parameters_const_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_const_ ## __LINE__ ## operator&lt;Args&gt;::type
+    boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+{
+    return this-&gt;
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## operator(
+        static_cast&lt;
+            typename boost_param_result_const_ ## __LINE__ ## operator&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , args
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>0</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>0</strong>])
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>n</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>n</strong>])
+    );
+}
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>n</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>n</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>n</strong>
+    ) const
+{
+    return this-&gt;
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## operator(
+        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+      , (args, <em>keyword object of optional parameter</em> ## <strong
+>n + 1</strong> =
+            <em>default value of optional parameter</em> ## <strong
+>n + 1</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>0</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>0</strong>
+        )
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>n</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>n</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of optional parameter</em> ## <strong>n + 1</strong>
+            &gt;::type
+        &gt;(<em>default value of optional parameter</em> ## <strong
+>n + 1</strong>)
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>m</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>m</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>m</strong>
+    ) const
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-constructor-cls-impl-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id56">6.6&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id57">6.6&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_CONSTRUCTOR(cls, impl, tag_namespace,
 arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2894,36 +4430,215 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field">
-<th class="field-name" colspan="2">Requires:</th>
+<th class="field-name" colspan="2">Example usage:</th>
 </tr>
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first"><tt class="docutils literal">cls</tt> is the name of this
-class.  <tt class="docutils literal">impl</tt> is the parenthesized
-implementation base class for <tt class="docutils literal"
->cls</tt>.  <tt class="docutils literal">tag_namespace</tt> is the namespace
-in which the keywords used by the function resides.  <tt
-class="docutils literal">arguments</tt> is a list of
-<em>argument-specifiers</em>, as defined in <a class="reference internal"
-href="#boost-parameter-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_FUNCTION</tt></a> except that
-<em>optional-specifier</em> no longer includes <em>default-value</em>.  It is
-up to the delegate constructor in <tt class="docutils literal">impl</tt> to
-determine the default value of all optional arguments.</p>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">tag</tt> by
+default.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(y)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(z)
+</pre>
+<p class="first">In the base class, implement a delegate constructor template
+that takes in an <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a>.  You must pass the identifiers with
+leading underscores to <tt class="docutils literal">args</tt> in order to
+extract the corresponding arguments.</p>
+<pre class="first literal-block">
+class char_read_base
+{
+    int index;
+    char const* key;
+
+ public:
+    template &lt;typename Args&gt;
+    explicit char_read_base(Args const& args)
+      : index(args[_y]), key(args[_z])
+    {
+    }
+
+    BOOST_PARAMETER_FUNCTION_CALL_OPERATOR((void), tag,
+        (deduced
+            (required
+                (y, (int))
+                (z, (char const*))
+            )
+        )
+    )
+    {
+        this-&gt;index = y;
+        this-&gt;key = z;
+    }
+
+    <a class="reference internal"
+href="#boost-parameter-const-function-call-op-result-tag-namespace-arguments"
+>BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR</a>((char), tag,
+        (deduced
+            (required
+                (y, (bool))
+                (z, (std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;))
+            )
+        )
+    )
+    {
+        return y ? (
+            (z.find(this-&gt;key)-&gt;second)[this-&gt;index]
+        ) : this-&gt;key[this-&gt;index];
+    }
+};
+</pre>
+<p class="first">Use the macro as a substitute for a normal constructor
+definition.  Note the lack of an explicit body.  Enclose the base type in
+parentheses.  For each parameter, also enclose the expected value type in
+parentheses.  Since the value types are mutually exclusive, you can wrap the
+parameters in a <tt class="docutils literal">(deduced …)</tt> clause.</p>
+<pre class="first literal-block">
+struct char_reader : public char_read_base
+{
+    BOOST_PARAMETER_CONSTRUCTOR(char_reader, (char_read_base), tag,
+        (deduced
+            (required
+                (y, (int))
+                (z, (char const*))
+            )
+        )
+    )
+};
+</pre>
+<p class="first">The following <tt class="docutils literal">char_reader</tt>
+constructor calls are legal.</p>
+<pre class="first literal-block">
+char const* keys[] = {"foo", "bar", "baz"};
+std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt; k2s;
+k2s[keys[0]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("qux");
+k2s[keys[1]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("wmb");
+k2s[keys[2]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("zxc");
+
+// positional arguments
+char_reader r0(0, keys[0]);
+BOOST_TEST_EQ('q', (r0(true, k2s)));
+BOOST_TEST_EQ('f', (r0(false, k2s)));
+
+// named arguments
+char_reader r1(_z = keys[1], _y = 1);
+BOOST_TEST_EQ('m', (r1(_z = k2s, _y = true)));
+BOOST_TEST_EQ('a', (r1(_z = k2s, _y = false)));
+
+// deduced arguments
+char_reader r2(keys[2], 2);
+BOOST_TEST_EQ('c', (r2(k2s, true)));
+BOOST_TEST_EQ('z', (r2(k2s, false)));
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> and <a
+class="reference external" href="../../test/preprocessor_eval_category.cpp"
+>test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
 </td>
 </tr>
 <tr class="field">
-<th class="field-name" colspan="2">Generated names in enclosing scope:</th>
+<th class="field-name" colspan="2">Macro parameters:</th>
 </tr>
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<ul class="first last simple">
-<li><tt class="docutils literal">boost_param_params_ ## __LINE__ ##
-ctor</tt></li>
-<li><tt class="docutils literal">constructor_parameters ## __LINE__</tt></li>
+<ul class="last simple">
+<li><tt class="docutils literal">cls</tt> is the name of the enclosing
+class.</li>
+<li><tt class="docutils literal">impl</tt> is the parenthesized implementation
+base class for <tt class="docutils literal">cls</tt>.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the constructor resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
 </ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the delegate constructor in <tt class="docutils literal">impl</tt> to
+determine the default value of all optional arguments.</p>
 </td>
 </tr>
 </tbody>
@@ -2938,25 +4653,21 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 <li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <pre class="last literal-block">
 struct boost_param_params_ ## __LINE__ ## ctor
-  : boost::parameter::parameters&lt;
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
         <em>list of parameter specifications, based on arguments</em>
     &gt;
 {
 };
 
-typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
+typedef boost_param_params_ ## __LINE__ ## ctor
     constructor_parameters ## __LINE__;
 
 template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>cls</em>(A0&amp;&amp; a0, …, A ## <strong
+<strong>cls</strong>(A0&amp;&amp; a0, …, A ## <strong
 >n</strong> &amp;&amp; a ## <strong>n</strong>)
-  : <em>impl</em>(
+  : <strong>impl</strong>(
         constructor_parameters ## __LINE__(
             std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2974,9 +4685,9 @@ class="docutils literal">forward</tt></a>&lt;A ## <strong
 <span class="vellipsis">⋮</span>
 
 template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>cls</em>(A0&amp;&amp; a0, …, A ## <strong
+<strong>cls</strong>(A0&amp;&amp; a0, …, A ## <strong
 >m</strong>&amp;&amp; a ## <strong>m</strong>)
-  : <em>impl</em>(
+  : <strong>impl</strong>(
         constructor_parameters ## __LINE__(
             std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2991,72 +4702,12 @@ class="docutils literal">forward</tt></a>&lt;A ## <strong
 {
 }
 </pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="last literal-block">
-struct boost_param_params_ ## __LINE__ ## ctor
-  : boost::parameter::parameters&lt;
-        <em>list of parameter specifications, based on arguments</em>
-    &gt;
-{
-};
-
-typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
-    constructor_parameters ## __LINE__;
-
-template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>cls</em>(A0 const&amp; a0, …, A ## <strong
->n</strong> const&amp; a ## <strong>n</strong>)
-  : <em>impl</em>(constructor_parameters ## __LINE__(a0, …, a ## <strong
->n</strong>))
-{
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>cls</em>(A0&amp; a0, …, A ## <strong
->n</strong> &amp; a ## <strong>n</strong>)
-  : <em>impl</em>(constructor_parameters ## __LINE__(a0, …, a ## <strong
->n</strong>))
-{
-}
-
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>cls</em>(A0 const&amp; a0, …, A ## <strong
->m</strong> const&amp; a ## <strong>m</strong>)
-  : <em>impl</em>(constructor_parameters ## __LINE__(a0, …, a ## <strong
->m</strong>))
-{
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>cls</em>(A0&amp; a0, …, A ## <strong
->m</strong> &amp; a ## <strong>m</strong>)
-  : <em>impl</em>(constructor_parameters ## __LINE__(a0, …, a ## <strong
->m</strong>))
-{
-}
-</pre>
 </dd>
 </dl>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> and <a class="reference external"
-href="../../test/preprocessor_eval_category.cpp"
->test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
-usage of this macro.</p>
 </div>
 <div class="section"
 id="boost-parameter-basic-function-result-name-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id57">6.7&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id58">6.7&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_BASIC_FUNCTION(result, name,
 tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -3071,34 +4722,388 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_FUNCTION</tt></a>, except:</p>
-<ul>
-<li>For the argument specifiers syntax, <em>optional-specifier</em> no longer
-includes <em>default-value</em>.  It is up to the function body to determine
-the default value of all optional arguments.</li>
-<li>Generated names in the enclosing scope no longer include
-<tt class="docutils literal">boost_param_dispatch_0boost_ ## __LINE__ ##
-name</tt> or <tt class="docutils literal">boost_param_dispatch_1boost_ ##
-__LINE__ ## name</tt>.</li>
-<li>Expansion of this macro omits all overloads of <tt
-class="docutils literal">boost_param_dispatch_0boost_ ## __LINE__ ## name</tt>
-and <tt class="docutils literal">boost_param_dispatch_1boost_ ## __LINE__ ##
-name</tt> and stops at the header of <tt class="docutils literal"
->boost_param_impl ## name</tt>.  Therefore, only the <a
-class="reference internal" href="#argumentpack"><span class="concept"
->ArgumentPack</span></a> type <tt class="docutils literal">Args</tt> and its
-object instance <tt class="docutils literal">args</tt> are available for use
-within the function body.</li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal function
+header.  Enclose the return type <tt class="docutils literal">bool</tt> in
+parentheses.  For each parameter, also enclose the expected value type in
+parentheses.  Since the value types are mutually exclusive, you can wrap the
+parameters in a <tt class="docutils literal">(deduced …)</tt>
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of <tt class="docutils literal"
+>args</tt> to extract the corresponding argument, but at least this doesn't
+require <tt class="docutils literal">std::forward</tt> to preserve value
+categories.</p>
+<pre class="first literal-block">
+BOOST_PARAMETER_BASIC_FUNCTION((bool), evaluate, kw,
+    (deduced
+        (required
+            (lrc, (std::bitset&lt;1&gt;))
+            (lr, (std::bitset&lt;2&gt;))
+        )
+        (optional
+            (rrc, (std::bitset&lt;3&gt;))
+            (rr, (std::bitset&lt;4&gt;))
+        )
+    )
+)
+{
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference_to_const
+      , U::evaluate_category&lt;0&gt;(args[_lrc])
+    );
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference
+      , U::evaluate_category&lt;1&gt;(args[_lr])
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference_to_const
+      , U::evaluate_category&lt;2&gt;(
+            args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+        )
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference
+      , U::evaluate_category&lt;3&gt;(args[_rr0 | rvalue_bitset&lt;3&gt;()])
+    );
+
+    return true;
+}
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
 </ul>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const&);
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>n</strong>
+        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>()
+    )
+{
+    return boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>m</strong>
+        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>()
+    )
+{
+    return boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-basic-member-function-result-name-tag-ns-arguments">
-<h2><a class="toc-backref" href="#id58">6.8&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id59">6.8&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_BASIC_MEMBER_FUNCTION(result, name,
 tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -3113,25 +5118,391 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-basic-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_BASIC_FUNCTION</tt></a>,
-except that:</p>
-<ul>
-<li><tt class="docutils literal">name</tt> may be qualified by the
-<tt class="docutils literal">static</tt> keyword to declare the member
-function and its helpers as not associated with any object of the enclosing
-type.</li>
-<li>Expansion of this macro omits the forward declaration of the
-implementation function.</li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">static</tt> member function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  However, unlike a normal function, default values must be
+specified within the function body.  Also within the function body, you must
+pass the matching identifier with the leading underscore to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the
+corresponding argument, but at least this doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    BOOST_PARAMETER_BASIC_MEMBER_FUNCTION((bool), static evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;))
+                (rr, (std::bitset&lt;4&gt;))
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B::evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+B::evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+B::evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+B::evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+B::evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+B::evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+B::evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.  <tt
+class="docutils literal">name</tt> may be qualified by the <tt
+class="docutils literal">static</tt> keyword to declare the member function
+and its helpers as not associated with any object of the enclosing type.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
 </ul>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>n</strong>
+        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>m</strong>
+        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-basic-c-mem-function-result-name-tag-ns-arguments">
-<h2><a class="toc-backref" href="#id59">6.9&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id60">6.9&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION(result,
 name, tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -3146,17 +5517,2693 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-basic-member-function-result-name-tag-ns-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_BASIC_MEMBER_FUNCTION</tt></a>,
-except that the overloaded forwarding member functions and their helper
-methods are <tt class="docutils literal">const</tt>-qualified.</p>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">const</tt> member function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  However, unlike a normal function, default values must be
+specified within the function body.  Also within the function body, you must
+pass the matching identifier with the leading underscore to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the
+corresponding argument, but at least this doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    B()
+    {
+    }
+
+    BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION((bool), evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;))
+                (rr, (std::bitset&lt;4&gt;))
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B const b = B();
+b.evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+b.evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+b.evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+b.evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+b.evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+b.evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+b.evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_const_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_const_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_const_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>n</strong>
+        &gt;::type = boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>m</strong>
+        &gt;::type = boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_const_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(Args const& args) const
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section"
+id="boost-parameter-basic-function-call-op-result-tag-namespace-arguments">
+<h2><a class="toc-backref" href="#id61">6.10&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR(result,
+tag_ns, arguments)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">tag</tt> by
+default.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(y)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(z)
+</pre>
+<p class="first">Use the macro as a substitute for a normal function call
+operator header.  Enclose the return type in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  This is especially useful
+when implementing multiple Boost.Parameter-enabled function call operator
+overloads.</p>
+<pre class="first literal-block">
+class char_reader
+{
+    int index;
+    char const* key;
+
+ public:
+    explicit char_reader(char const* k) : index(0), key(k)
+    {
+    }
+
+    BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR((void), tag,
+        (deduced
+            (required
+                (y, (int))
+                (z, (char const*))
+            )
+        )
+    )
+    {
+        this-&gt;index = args[_y];
+        this-&gt;key = args[_z];
+    }
+
+    <a class="reference internal"
+href="#boost-parameter-basic-const-function-call-op-result-tag-ns-args"
+>BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR</a>((char), tag,
+        (deduced
+            (required
+                (y, (bool))
+                (z, (std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;))
+            )
+        )
+    )
+    {
+        return args[_y] ? (
+            (args[_z].find(this-&gt;key)-&gt;second)[this-&gt;index]
+        ) : this-&gt;key[this-&gt;index];
+    }
+};
+</pre>
+<p class="first">As with regular argument-dependent lookup, the value types of
+the arguments passed in determine which function call operator overload gets
+invoked.</p>
+<pre class="first literal-block">
+char const* keys[] = {"foo", "bar", "baz"};
+std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt; k2s;
+k2s[keys[0]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("qux");
+k2s[keys[1]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("wmb");
+k2s[keys[2]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("zxc");
+char_reader r(keys[0]);
+
+// positional arguments
+BOOST_TEST_EQ('q', (r(true, k2s)));
+BOOST_TEST_EQ('f', (r(false, k2s)));
+
+// named arguments
+r(_z = keys[1], _y = 1);
+BOOST_TEST_EQ('m', (r(_z = k2s, _y = true)));
+BOOST_TEST_EQ('a', (r(_z = k2s, _y = false)));
+
+// deduced arguments
+r(keys[2], 2);
+BOOST_TEST_EQ('c', (r(k2s, true)));
+BOOST_TEST_EQ('z', (r(k2s, false)));
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function call operator resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## operator
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## operator
+    boost_param_parameters_ ## __LINE__ ## operator;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## operator()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## operator(
+        boost_param_parameters_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## operator()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## operator(
+        boost_param_parameters_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## operator&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## operator(Args const& args)
+</pre>
+</dd>
+</dl>
+</div>
+<div class="section"
+id="boost-parameter-basic-const-function-call-op-result-tag-ns-args">
+<h2><a class="toc-backref" href="#id62">6.11&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal"
+>BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR(result, tag_ns,
+args)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">const</tt> function call operator header.  Enclose
+the return type <tt class="docutils literal">bool</tt> in parentheses.  For
+each parameter, also enclose the expected value type in parentheses.  Since
+the value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  However, unlike a normal function, default values must be
+specified within the function body.  Also within the function body, you must
+pass the matching identifier with the leading underscore to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the
+corresponding argument, but at least this doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    B()
+    {
+    }
+
+    BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR((bool), kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;))
+                (rr, (std::bitset&lt;4&gt;))
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B const b = B();
+b(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+b(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+b((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+b(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+b(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+b(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+b(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function call operator resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_const_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_const_ ## __LINE__ ## operator
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_const_ ## __LINE__ ## operator
+    boost_param_parameters_const_ ## __LINE__ ## operator;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## operator()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
+        boost_param_parameters_const_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## operator()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
+        boost_param_parameters_const_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_const_ ## __LINE__ ## operator&lt;Args&gt;::type
+    boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+</pre>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-function-result-name">
+<h2><a class="toc-backref" href="#id63">6.12&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_FUNCTION(result,
+name)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the function;
+however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw1) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw2) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a variadic function
+header.  Enclose the return type <tt class="docutils literal">bool</tt> in
+parentheses.</p>
+<pre class="first literal-block">
+BOOST_PARAMETER_NO_SPEC_FUNCTION((bool), evaluate)
+{
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference_to_const
+      , U::evaluate_category&lt;0&gt;(args[_lrc])
+    );
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference
+      , U::evaluate_category&lt;1&gt;(args[_lr])
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference_to_const
+      , U::evaluate_category&lt;2&gt;(
+            args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+        )
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference
+      , U::evaluate_category&lt;3&gt;(args[_rr0 | rvalue_bitset&lt;3&gt;()])
+    );
+
+    return true;
+}
+</pre>
+<p class="first">To invoke the function, bind all its arguments to named
+parameters.</p>
+<pre class="first literal-block">
+evaluate(
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated implementation function.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const& args
+    );
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    <strong>name</strong
+>(TaggedArg0 const&amp; arg0, TaggedArgs const&amp;... args)
+{
+    return boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const& args
+    )
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-member-function-result-name">
+<h2><a class="toc-backref" href="#id64">6.13&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION(result,
+name)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">When designing a front-end class template whose back-end is
+configurable via parameterized inheritance, it can be useful to omit argument
+specifiers from a named-parameter member function so that the delegate member
+functions of the back-end classes can enforce their own specifications.</p>
+<pre class="first literal-block">
+template &lt;typename B&gt;
+struct frontend : B
+{
+    frontend() : B()
+    {
+    }
+
+    BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((void), initialize)
+    {
+        this-&gt;initialize_impl(args);
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the member
+function; however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a0)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a1)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a2)
+</pre>
+<p class="first">For this example, each of the back-end class templates
+requires its own parameter to be present in the argument pack.  In practice,
+such parameters should be optional, with default values.</p>
+<pre class="first literal-block">
+template &lt;typename T&gt;
+class backend0
+{
+    T a0;
+
+ public:
+    backend0() : a0()
+    {
+    }
+
+    T const&amp; get_a0() const
+    {
+        return this-&gt;a0;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        this-&gt;a0 = args[_a0];
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend1 : public B
+{
+    T a1;
+
+ public:
+    backend1() : B(), a1()
+    {
+    }
+
+    T const&amp; get_a1() const
+    {
+        return this-&gt;a1;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        B::initialize_impl(args);
+        this-&gt;a1 = args[_a1];
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend2 : public B
+{
+    T a2;
+
+ public:
+    backend2() : B(), a2()
+    {
+    }
+
+    T const&amp; get_a2() const
+    {
+        return this-&gt;a2;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        B::initialize_impl(args);
+        this-&gt;a2 = args[_a2];
+    }
+};
+</pre>
+<p class="first">This example shows that while <tt class="docutils literal"
+>backend0</tt> must always be the root base class template and that <tt
+class="docutils literal">frontend</tt> must always be the most derived class
+template, the other back-ends can be chained together in different orders.</p>
+<pre class="first literal-block">
+char const* p = "foo";
+frontend&lt;
+    backend2&lt;backend1&lt;backend0&lt;char const*&gt;, char&gt;, int&gt;
+&gt; composed_obj0;
+frontend&lt;
+    backend1&lt;backend2&lt;backend0&lt;char const*&gt;, int&gt;, char&gt;
+&gt; composed_obj1;
+composed_obj0.initialize(_a2 = 4, _a1 = ' ', _a0 = p);
+composed_obj1.initialize(_a0 = p, _a1 = ' ', _a2 = 4);
+BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/parameterized_inheritance.cpp"
+>test/parameterized_inheritance.cpp</a> and <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated implementation function.  <tt
+class="docutils literal">name</tt> may be qualified by the <tt
+class="docutils literal">static</tt> keyword to declare the member function
+and its helpers as not associated with any object of the enclosing type.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    <strong>name</strong
+>(TaggedArg0 const&amp; arg0, TaggedArgs const&amp;... args)
+{
+    return this-&gt;boost_param_no_spec_impl ## __LINE__ ## <strong
+>name</strong>(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const& args
+    )
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-c-mem-function-result-name">
+<h2><a class="toc-backref" href="#id65">6.14&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION(result,
+name)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the member
+function; however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw1) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw2) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a variadic function
+header.  Enclose the return type <tt class="docutils literal">bool</tt> in
+parentheses.  The macro will qualify the function with the <tt
+class="docutils literal">const</tt> keyword.</p>
+<pre class="first literal-block">
+struct D
+{
+    D()
+    {
+    }
+
+    BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION((bool), evaluate_m)
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">To invoke the member function, bind all its arguments to
+named parameters.</p>
+<pre class="first literal-block">
+D const d = D();
+d.evaluate_m(
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+d.evaluate_m(
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated implementation function.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_const_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_const_ ## __LINE__ ## <strong>name</strong>&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    <strong>name</strong
+>(TaggedArg0 const&amp; arg0, TaggedArgs const&amp;... args) const
+{
+    return this-&gt;boost_param_no_spec_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_const_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl_const ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const& args
+    ) const
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-function-call-op-result">
+<h2><a class="toc-backref" href="#id66">6.15&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR(result)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">When designing a front-end class template whose back-end is
+configurable via parameterized inheritance, it can be useful to omit argument
+specifiers from a named-parameter function call operator so that the delegate
+member functions of the back-end classes can enforce their own
+specifications.</p>
+<pre class="first literal-block">
+template &lt;typename B&gt;
+struct frontend : B
+{
+    frontend() : B()
+    {
+    }
+
+    BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR((void))
+    {
+        this-&gt;initialize_impl(args);
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the function call
+operator; however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a0)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a1)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a2)
+</pre>
+<p class="first">For this example, each of the back-end class templates
+requires its own parameter to be present in the argument pack.  In practice,
+such parameters should be optional, with default values.</p>
+<pre class="first literal-block">
+template &lt;typename T&gt;
+class backend0
+{
+    T a0;
+
+ public:
+    backend0() : a0()
+    {
+    }
+
+    T const&amp; get_a0() const
+    {
+        return this-&gt;a0;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        this-&gt;a0 = args[_a0];
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend1 : public B
+{
+    T a1;
+
+ public:
+    backend1() : B(), a1()
+    {
+    }
+
+    T const&amp; get_a1() const
+    {
+        return this-&gt;a1;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        B::initialize_impl(args);
+        this-&gt;a1 = args[_a1];
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend2 : public B
+{
+    T a2;
+
+ public:
+    backend2() : B(), a2()
+    {
+    }
+
+    T const&amp; get_a2() const
+    {
+        return this-&gt;a2;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        B::initialize_impl(args);
+        this-&gt;a2 = args[_a2];
+    }
+};
+</pre>
+<p class="first">This example shows that while <tt class="docutils literal"
+>backend0</tt> must always be the root base class template and that <tt
+class="docutils literal">frontend</tt> must always be the most derived class
+template, the other back-ends can be chained together in different orders.</p>
+<pre class="first literal-block">
+char const* p = "foo";
+frontend&lt;
+    backend2&lt;backend1&lt;backend0&lt;char const*&gt;, char&gt;, int&gt;
+&gt; composed_obj0;
+frontend&lt;
+    backend1&lt;backend2&lt;backend0&lt;char const*&gt;, int&gt;, char&gt;
+&gt; composed_obj1;
+composed_obj0(_a2 = 4, _a1 = ' ', _a0 = p);
+composed_obj1(_a0 = p, _a1 = ' ', _a2 = 4);
+BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/parameterized_inheritance.cpp"
+>test/parameterized_inheritance.cpp</a> and <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_ ## __LINE__ ## operator&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    operator()(TaggedArg0 const&amp; arg0, TaggedArgs const&amp;... args)
+{
+    return this-&gt;boost_param_no_spec_impl ## __LINE__ ## operator(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_ ## __LINE__ ## operator&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const& args
+    )
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-const-func-call-op-result">
+<h2><a class="toc-backref" href="#id67">6.16&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR(result)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the function call
+operator; however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw1) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw2) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a variadic function call
+operator header.  Enclose the return type <tt class="docutils literal"
+>bool</tt> in parentheses.  The macro will qualify the function with the <tt
+class="docutils literal">const</tt> keyword.</p>
+<pre class="first literal-block">
+struct D
+{
+    D()
+    {
+    }
+
+    BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR((bool))
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">To invoke the function call operator, bind all its arguments
+to named parameters.</p>
+<pre class="first literal-block">
+D const d = D();
+d(
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+d(
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_const_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_const_ ## __LINE__ ## operator&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    operator()(
+        TaggedArg0 const&amp; arg0
+      , TaggedArgs const&amp;... args
+    ) const
+{
+    return this-&gt;boost_param_no_spec_impl_const ## __LINE__ ## operator(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_const_ ## __LINE__ ## operator&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl_const ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const& args
+    ) const
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-constructor-cls-impl">
+<h2><a class="toc-backref" href="#id68">6.17&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(cls,
+impl)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">When designing a front-end class template whose back-end is
+configurable via parameterized inheritance, it can be useful to omit argument
+specifiers from a named-parameter constructor so that the delegate
+constructors of the back-end classes can enforce their own specifications.</p>
+<pre class="first literal-block">
+template &lt;typename B&gt;
+struct frontend : B
+{
+    BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(frontend, (B))
+};
+</pre>
+<p class="first">Named parameters are required when invoking the constructor;
+however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a0)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a1)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a2)
+</pre>
+<p class="first">For this example, each of the back-end class templates
+requires its own parameter to be present in the argument pack.  In practice,
+such parameters should be optional, with default values.</p>
+<pre class="first literal-block">
+struct _enabler
+{
+};
+
+template &lt;typename T&gt;
+class backend0
+{
+    T a0;
+
+ public:
+    template &lt;typename ArgPack&gt;
+    explicit backend0(
+        ArgPack const&amp; args
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#is-argument-pack"
+>is_argument_pack</a>&lt;ArgPack&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : a0(args[_a0])
+    {
+    }
+
+    T const&amp; get_a0() const
+    {
+        return this-&gt;a0;
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend1 : public B
+{
+    T a1;
+
+ public:
+    template &lt;typename ArgPack&gt;
+    explicit backend1(
+        ArgPack const&amp; args
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#is-argument-pack"
+>is_argument_pack</a>&lt;ArgPack&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : B(args), a1(args[_a1])
+    {
+    }
+
+    T const&amp; get_a1() const
+    {
+        return this-&gt;a1;
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend2 : public B
+{
+    T a2;
+
+ public:
+    template &lt;typename ArgPack&gt;
+    explicit backend2(
+        ArgPack const&amp; args
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#is-argument-pack"
+>is_argument_pack</a>&lt;ArgPack&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : B(args), a2(args[_a2])
+    {
+    }
+
+    T const&amp; get_a2() const
+    {
+        return this-&gt;a2;
+    }
+};
+</pre>
+<p class="first">This example shows that while <tt class="docutils literal"
+>backend0</tt> must always be the root base class template and that <tt
+class="docutils literal">frontend</tt> must always be the most derived class
+template, the other back-ends can be chained together in different orders.</p>
+<pre class="first literal-block">
+char const* p = "foo";
+frontend&lt;
+    backend2&lt;backend1&lt;backend0&lt;char const*&gt;, char&gt;, int&gt;
+&gt; composed_obj0(_a2 = 4, _a1 = ' ', _a0 = p);
+frontend&lt;
+    backend1&lt;backend2&lt;backend0&lt;char const*&gt;, int&gt;, char&gt;
+&gt; composed_obj1(_a0 = p, _a1 = ' ', _a2 = 4);
+BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/parameterized_inheritance.cpp"
+>test/parameterized_inheritance.cpp</a> and <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">cls</tt> is the name of the enclosing
+class.</li>
+<li><tt class="docutils literal">impl</tt> is the parenthesized implementation
+base class for <tt class="docutils literal">cls</tt>.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;
+    template <
+        typename TaggedArg0
+      , typename ...TaggedArgs
+      , typename = typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+        &gt;::type
+&gt;
+inline explicit <strong>cls</strong>(
+    TaggedArg0 const&amp; arg0
+  , TaggedArgs const&amp;... args
+) : <strong>impl</strong>(<a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...))
+{
+}
+</pre>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-no-base-ctor-cls-func">
+<h2><a class="toc-backref" href="#id69">6.18&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(cls,
+func)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following functon templates
+falls under a different reference category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+reference category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the constructor;
+however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw1) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw2) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
+</pre>
+<p class="first">Unlike <a class="reference internal"
+href="#boost-parameter-no-spec-constructor-cls-impl"><tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR</tt></a>, this
+macro doesn't require a base class, only a delegate function to which the
+generated constructor can pass its <a class="reference internal"
+href="#argumentpack"><span class="concept">ArgumentPack</span></a>.</p>
+<pre class="first literal-block">
+struct D
+{
+    BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(D, D::_evaluate)
+    {
+    }
+
+ private:
+    template &lt;typename Args&gt;
+    static bool _evaluate(Args const&amp; args)
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">To invoke the constructor, bind all its arguments to named
+parameters.</p>
+<pre class="first literal-block">
+D dp0(
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+D dp1(
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">cls</tt> is the name of the enclosing
+class.</li>
+<li><tt class="docutils literal">func</tt> is a function that takes in the
+<a class="reference internal" href="#argumentpack"><span class="concept"
+>ArgumentPack</span></a> that the generated constructor passes on.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;
+    template <
+        typename TaggedArg0
+      , typename ...TaggedArgs
+      , typename = typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+        &gt;::type
+&gt;
+inline explicit <strong>cls</strong>(
+    TaggedArg0 const&amp; arg0
+  , TaggedArgs const&amp;... args
+)
+{
+    <strong>func</strong>(<a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...));
+}
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section" id="boost-parameter-name-name">
-<h2><a class="toc-backref" href="#id60">6.10&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id70">6.19&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_NAME(name)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -3273,7 +8320,7 @@ forward(<em>tag-name</em>)
 </pre>
 </div>
 <div class="section" id="boost-parameter-nested-keyword-t-n-a">
-<h2><a class="toc-backref" href="#id61">6.11&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id71">6.20&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_NESTED_KEYWORD(tag_namespace, name,
 alias)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -3345,7 +8392,7 @@ forward(<em>tag-name</em>)
 </pre>
 </div>
 <div class="section" id="boost-parameter-template-keyword-name">
-<h2><a class="toc-backref" href="#id62">6.12&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id72">6.21&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_TEMPLATE_KEYWORD(name)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -3383,7 +8430,7 @@ href="../../test/function_type_tpl_param.cpp"
 of this macro.</p>
 </div>
 <div class="section" id="boost-parameter-fun-r-n-l-h-p">
-<h2><a class="toc-backref" href="#id63">6.13&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id73">6.22&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_FUN(r, n, l, h, p)</tt></a></h2>
 <div class="admonition-deprecated admonition">
 <p class="first admonition-title">Deprecated</p>
@@ -3423,10 +8470,6 @@ class="docutils literal">l</tt> &lt; <tt class="docutils literal">h</tt></td>
 </tr>
 </tbody>
 </table>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <dl class="docutils">
 <dt>Expands to:</dt>
 <dd>
@@ -3534,148 +8577,13 @@ class="docutils literal">forward</tt></a>&lt;A ## <strong
 </pre>
 </dd>
 </dl>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<dl class="docutils">
-<dt>Expands to:</dt>
-<dd>
-<pre class="first last literal-block">
-template &lt;typename A1, typename A2, …, typename A ## <strong>l</strong>&gt;
-r
-    name(
-        A1 const&amp; a1, A2 const&amp; a2, …, A ## <strong
->l</strong> const&amp; a ## <strong>l</strong>
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A ## <strong
->l</strong>&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(pk(a1, a2, …, a ## <strong
->l</strong>));
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A1, typename A2, …, typename A ## <strong>l</strong>&gt;
-r
-    name(
-        A1&amp; a1, A2&amp; a2, …, A ## <strong
->l</strong> &amp; a ## <strong>l</strong>
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A ## <strong
->l</strong>&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(pk(a1, a2, …, a ## <strong
->l</strong>));
-}
-
-template &lt;
-    typename A1
-  , typename A2
-  , …
-  , typename A ## <strong>l</strong>
-  , typename A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)
-&gt;
-r
-    name(
-        A1 const&amp; a1, A2 const&amp; a2, …, A ## <strong
->l</strong> const&amp; a ## <strong>l</strong>
-      , A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>) const&amp; a ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A<strong
->l</strong>, A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(
-        pk(a1, a2, …, a ## <strong>l</strong>, a ## <a
-class="reference external" href="../../../preprocessor/doc/ref/inc.html"
->BOOST_PP_INC</a>(<strong>l</strong>))
-    );
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;
-    typename A1
-  , typename A2
-  , …
-  , typename A ## <strong>l</strong>
-  , typename A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)
-&gt;
-r
-    name(
-        A1&amp; a1, A2&amp; a2, …, A ## <strong
->l</strong> &amp; a ## <strong>l</strong>
-      , A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>) &amp; a ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A<strong
->l</strong>, A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(
-        pk(a1, a2, …, a ## <strong>l</strong>, a ## <a
-class="reference external" href="../../../preprocessor/doc/ref/inc.html"
->BOOST_PP_INC</a>(<strong>l</strong>))
-    );
-}
-
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A1, typename A2, …, typename A ## <strong>h</strong>&gt;
-r
-    name(
-        A1 const&amp; a1, A2 const&amp; a2, …, A ## <strong
->h</strong> const&amp; a ## <strong>h</strong>
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A ## <strong
->h</strong>&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(pk(a1, a2, …, a ## <strong
->h</strong>));
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A1, typename A2, …, typename A ## <strong>h</strong>&gt;
-r
-    name(
-        A1&amp; a1, A2&amp; a2, …, A ## <strong
->h</strong>&amp; a ## <strong>h</strong>
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A ## <strong
->h</strong>&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(pk(a1, a2, …, a ## <strong
->h</strong>));
-}
-</pre>
-</dd>
-</dl>
 <p>The <a class="reference external" href="../../test/macros.cpp"
 >test/macros.cpp</a> and <a class="reference external"
 href="../../test/macros_eval_category.cpp">test/macros_eval_category.cpp</a>
 test programs demonstrate proper usage of this macro.</p>
 </div>
 <div class="section" id="boost-parameter-keyword-n-k">
-<h2><a class="toc-backref" href="#id64">6.14&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id74">6.23&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_KEYWORD(n, k)</tt></a></h2>
 <div class="admonition-deprecated admonition">
 <p class="first admonition-title">Deprecated</p>
@@ -3724,7 +8632,7 @@ namespace {
 </dl>
 </div>
 <div class="section" id="boost-parameter-match-p-a-x">
-<h2><a class="toc-backref" href="#id65">6.15&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id75">6.24&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_MATCH(p, a, x)</tt></a></h2>
 <p>Generates a defaulted parameter declaration for a
 <a class="reference external"
@@ -3771,10 +8679,10 @@ href="../../../../boost/parameter/match.hpp"
 </div>
 </div>
 <div class="section" id="configuration-macros">
-<h1><a class="toc-backref" href="#id66">7&nbsp;&nbsp;&nbsp;Configuration
+<h1><a class="toc-backref" href="#id76">7&nbsp;&nbsp;&nbsp;Configuration
 Macros</a></h1>
 <div class="section" id="boost-parameter-has-perfect-forwarding">
-<h2><a class="toc-backref" href="#id67">7.1&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id77">7.1&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a></h2>
 <p>Determines whether or not the library supports perfect forwarding, or the
 preservation of parameter value categories.  Users can manually disable this
@@ -3811,7 +8719,7 @@ href="../../../../boost/parameter/config.hpp"
 </table>
 </div>
 <div class="section" id="boost-parameter-disable-perfect-forwarding">
-<h2><a class="toc-backref" href="#id68">7.2&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id78">7.2&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_DISABLE_PERFECT_FORWARDING</tt></a
 ></h2>
 <p>It may be necessary to test user code in case perfect forwarding support is
@@ -3822,7 +8730,7 @@ href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> undefined.</p>
 </div>
 <div class="section" id="boost-parameter-variadic-mpl-sequence">
-<h2><a class="toc-backref" href="#id69">7.3&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id79">7.3&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE</tt></a></h2>
 <p>If <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
@@ -3877,7 +8785,7 @@ href="../../../../boost/parameter/parameters.hpp"
 </table>
 </div>
 <div class="section" id="boost-parameter-max-arity">
-<h2><a class="toc-backref" href="#id70">7.4&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id80">7.4&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_MAX_ARITY</tt></a></h2>
 <p>Determines the maximum number of arguments supported by the library.</p>
 <p>If <a class="reference internal"
@@ -3955,7 +8863,7 @@ href="../../../mpl/doc/refmanual/limit-vector-size.html"
 </table>
 </div>
 <div class="section" id="boost-parameter-exponential-overload-threshold-arity"
-><h2><a class="toc-backref" href="#id71">7.5&nbsp;&nbsp;&nbsp;<tt
+><h2><a class="toc-backref" href="#id81">7.5&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal"
 >BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY</tt></a></h2>
 <p>If this library does <strong>not</strong> support perfect forwarding,
@@ -3997,7 +8905,7 @@ href="../../../../boost/parameter/config.hpp"
 </table>
 </div>
 <div class="section" id="outside-of-this-library"
-><h2><a class="toc-backref" href="#id72">7.6&nbsp;&nbsp;&nbsp;...Outside Of
+><h2><a class="toc-backref" href="#id82">7.6&nbsp;&nbsp;&nbsp;...Outside Of
 This Library</a></h2>
 <ol>
 <li>If <a class="reference external"
@@ -4089,7 +8997,7 @@ href="#boost-parameter-max-arity"><tt class="docutils literal"
 </div>
 </div>
 <div class="section" id="tutorial">
-<h1><a class="toc-backref" href="#id73">8&nbsp;&nbsp;&nbsp;Tutorial</a></h1>
+<h1><a class="toc-backref" href="#id83">8&nbsp;&nbsp;&nbsp;Tutorial</a></h1>
 <p>Follow <a class="reference external" href="index.html#tutorial">this
 link</a> to the Boost.Parameter tutorial documentation.</p>
 <hr class="docutils" />

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -781,14 +781,16 @@ that prints the arguments:
         std::cout << std::endl;
     }
 
+    #include <boost/core/lightweight_test.hpp>
+
     int main()
     {
         depth_first_search(1, 2, 3, 4, 5);
-
         depth_first_search(
             "1", '2', _color_map = '5',
             _index_map = "4", _root_vertex = "3"
         );
+        return boost::report_errors();
     }
 
 Despite the fact that default expressions such as ``vertices(graph).first``
@@ -815,7 +817,7 @@ and each one will print exactly the same thing.
         (color_map, \*)
     )
 ''')
-.. @test('compile')
+.. @test('run')
 
 Signature Matching and Overloading
 ----------------------------------
@@ -893,14 +895,18 @@ __ `parameter table`_
     {
         template <typename T, typename Args>
         struct apply
-          : boost::is_convertible<
-                T
-              , typename boost::graph_traits<
-                    typename boost::parameter::value_type<
-                        Args
-                      , graphs::graph
-                    >::type
-                >::vertex_descriptor
+          : boost::mpl::if_<
+                boost::is_convertible<
+                    T
+                  , typename boost::graph_traits<
+                        typename boost::parameter::value_type<
+                            Args
+                          , graphs::graph
+                        >::type
+                    >::vertex_descriptor
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
             >
         {
         };
@@ -949,14 +955,18 @@ classes provide the necessary checks.
     {
         template <typename T, typename Args>
         struct apply
-          : boost::mpl::and_<
+          : boost::mpl::eval_if<
                 boost::is_convertible<
                     typename boost::graph_traits<T>::traversal_category
                   , boost::incidence_graph_tag
                 >
-              , boost::is_convertible<
-                    typename boost::graph_traits<T>::traversal_category
-                  , boost::vertex_list_graph_tag
+              , boost::mpl::if_<
+                    boost::is_convertible<
+                        typename boost::graph_traits<T>::traversal_category
+                      , boost::vertex_list_graph_tag
+                    >
+                  , boost::mpl::true_
+                  , boost::mpl::false_
                 >
             >
         {
@@ -967,18 +977,22 @@ classes provide the necessary checks.
     {
         template <typename T, typename Args>
         struct apply
-          : boost::mpl::and_<
+          : boost::mpl::eval_if<
                 boost::is_integral<
                     typename boost::property_traits<T>::value_type
                 >
-              , boost::is_same<
-                    typename boost::property_traits<T>::key_type
-                  , typename boost::graph_traits<
-                        typename boost::parameter::value_type<
-                            Args
-                          , graphs::graph
-                        >::type
-                    >::vertex_descriptor
+              , boost::mpl::if_<
+                    boost::is_same<
+                        typename boost::property_traits<T>::key_type
+                      , typename boost::graph_traits<
+                            typename boost::parameter::value_type<
+                                Args
+                              , graphs::graph
+                            >::type
+                        >::vertex_descriptor
+                    >
+                  , boost::mpl::true_
+                  , boost::mpl::false_
                 >
             >
         {
@@ -989,14 +1003,18 @@ classes provide the necessary checks.
     {
         template <typename T, typename Args>
         struct apply
-          : boost::is_same<
-                typename boost::property_traits<T>::key_type
-              , typename boost::graph_traits<
-                    typename boost::parameter::value_type<
-                        Args
-                      , graphs::graph
-                    >::type
-                >::vertex_descriptor
+          : boost::mpl::if_<
+                boost::is_same<
+                    typename boost::property_traits<T>::key_type
+                  , typename boost::graph_traits<
+                        typename boost::parameter::value_type<
+                            Args
+                          , graphs::graph
+                        >::type
+                    >::vertex_descriptor
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
             >
         {
         };
@@ -1080,6 +1098,10 @@ by an asterix*, as follows:
     {
     }
 
+    #include <boost/core/lightweight_test.hpp>
+    #include <boost/graph/adjacency_list.hpp>
+    #include <utility>
+
     int main()
     {
         typedef boost::adjacency_list<
@@ -1095,11 +1117,11 @@ by an asterix*, as follows:
 
         depth_first_search(g);
         depth_first_search(g, _root_vertex = static_cast<int>(x));
-        return 0;
+        return boost::report_errors();
     }
 ''')
 
-.. @test('compile')
+.. @test('run')
 
 It usually isn't necessary to so completely encode the type requirements on
 arguments to generic functions.  However, doing so is worth the effort: your
@@ -1346,13 +1368,23 @@ the body of a class::
         }
     };
 
+    #include <boost/core/lightweight_test.hpp>
+
+    int main()
+    {
+        callable2 c2;
+        callable2 const& c2_const = c2;
+        c2_const.call(1, 2);
+        return boost::report_errors();
+    }
+
 .. @example.prepend('''
     #include <boost/parameter.hpp>
     #include <iostream>
     using namespace boost::parameter;
 ''')
 
-.. @test('compile')
+.. @test('run')
 
 These macros don't directly allow a function's interface to be separated from
 its implementation, but you can always forward arguments on to a separate
@@ -1364,7 +1396,7 @@ implementation function::
             (void), call, tag, (required (arg1,(int))(arg2,(int)))
         )
         {
-            call_impl(arg1,arg2);
+            call_impl(arg1, arg2);
         }
 
      private:
@@ -1401,13 +1433,22 @@ before the function name:
         }
     };
 
+    #include <boost/core/lightweight_test.hpp>
+
+    int main()
+    {
+        somebody::f();
+        somebody::f(4);
+        return boost::report_errors();
+    }
+
 .. @example.prepend('''
     #include <boost/parameter.hpp>
     #include <iostream>
     using namespace boost::parameter;
 ''')
 
-.. @test('compile')
+.. @test('run')
 
 -----------------------------------------
 Parameter-Enabled Function Call Operators
@@ -1434,13 +1475,23 @@ function objects::
         }
     };
 
+    #include <boost/core/lightweight_test.hpp>
+
+    int main()
+    {
+        callable2 c2;
+        callable2 const& c2_const = c2;
+        c2_const(1, 2);
+        return boost::report_errors();
+    }
+
 .. @example.prepend('''
     #include <boost/parameter.hpp>
     #include <iostream>
     using namespace boost::parameter;
 ''')
 
-.. @test('compile')
+.. @test('run')
 
 ------------------------------
 Parameter-Enabled Constructors
@@ -1451,7 +1502,7 @@ The lack of a “delegating constructor” feature in C++
 limits somewhat the quality of interface this library can provide
 for defining parameter-enabled constructors.  The usual workaround
 for a lack of constructor delegation applies: one must factor the
-common logic into a base class.  
+common logic into one or more base classes.  
 
 Let's build a parameter-enabled constructor that simply prints its
 arguments.  The first step is to write a base class whose
@@ -1501,7 +1552,11 @@ only ``name`` is required.  We can exercise our new interface as follows::
     myclass y(_index = 12, _name = "sally");  // named
     myclass z("june");                        // positional/defaulted
 
-.. @example.wrap('int main() {', ' return 0; }')
+.. @example.wrap('''
+    #include <boost/core/lightweight_test.hpp>
+
+    int main() {
+''', ' return boost::report_errors(); }')
 .. @test('run', howmany='all')
 
 For more on |ArgumentPack| manipulation, see the `Advanced Topics`_ section.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,7 +23,7 @@ that can accept arguments by name:
     );
 
     smart_ptr<
-        Foo 
+        Foo
       , **deleter<Deallocate<Foo> >**
       , **copy_policy<DeepCopy>**
     > p(new Foo);
@@ -674,10 +674,8 @@ names in ``consume(…)`` or ``move_from(…)``.
 
 In order to see what happens when parameters are bound to arguments that
 violate their category constraints, attempt to compile the |compose_cpp|_ test
-program with either the ``LIBS_PARAMETER_TEST_COMPILE_FAILURE_0`` macro, the
-``LIBS_PARAMETER_TEST_COMPILE_FAILURE_1`` macro, the
-``LIBS_PARAMETER_TEST_COMPILE_FAILURE_2`` macro, or the
-``LIBS_PARAMETER_TEST_COMPILE_FAILURE_3`` macro ``#defined``.  You should
+program with either the ``LIBS_PARAMETER_TEST_COMPILE_FAILURE_0`` macro or the
+``LIBS_PARAMETER_TEST_COMPILE_FAILURE_1`` macro ``#defined``.  You should
 encounter a compiler error caused by a specific constraint violation.
 
 .. @example.prepend('''

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -291,8 +291,6 @@ The type of every |keyword object| is a specialization of |keyword|.
 
 __ ../../../../boost/parameter/keyword.hpp
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-
 .. parsed-literal::
 
     template <typename Tag>
@@ -519,135 +517,6 @@ __ ../../../../boost/parameter/keyword.hpp
         static keyword<Tag>& get_\();
     };
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-.. parsed-literal::
-
-    template <typename Tag>
-    struct keyword
-    {
-        typedef Tag tag;
-
-        template <typename T>
-        typename boost::`enable_if`_<
-            typename boost::mpl::`eval_if_`_<
-                boost::`is_scalar`_<T>
-              , boost::mpl::`true_`_
-              , boost::mpl::`eval_if_`_<
-                    boost::`is_same`_<
-                        typename Tag::qualifier
-                      , boost::parameter::in_reference
-                    >
-                  , boost::mpl::`true_`_
-                  , boost::mpl::`if_`_<
-                        boost::`is_same`_<
-                            typename Tag::qualifier
-                          , boost::parameter::forward_reference
-                        >
-                      , boost::mpl::`true_`_
-                      , boost::mpl::`false_`_
-                    >
-                >
-            >::type
-          , |ArgumentPack|_
-        >::type constexpr
-            `operator=`_\(T const& value) const;
-
-        template <typename T>
-        typename boost::`enable_if`_<
-            typename boost::mpl::`eval_if_`_<
-                typename boost::mpl::`eval_if_`_<
-                    boost::`is_same`_<
-                        typename Tag::qualifier
-                      , boost::parameter::out_reference
-                    >
-                  , boost::mpl::`true_`_
-                  , boost::mpl::`if_`_<
-                        boost::`is_same`_<
-                            typename Tag::qualifier
-                          , boost::parameter::forward_reference
-                        >
-                      , boost::mpl::`true_`_
-                      , boost::mpl::`false_`_
-                    >
-                >::type
-              , boost::mpl::`if_`_<
-                    boost::`is_const`_<T>
-                  , boost::mpl::`false_`_
-                  , boost::mpl::`true_`_
-                >
-              , boost::mpl::`false_`_
-            >::type
-          , |ArgumentPack|_
-        >::type constexpr
-            `operator=`_\(T& value) const;
-
-        template <typename T>
-        typename boost::`enable_if`_<
-            typename boost::mpl::`eval_if_`_<
-                boost::`is_scalar`_<T>
-              , boost::mpl::`true_`_
-              , boost::mpl::`eval_if_`_<
-                    boost::`is_same`_<
-                        typename Tag::qualifier
-                      , boost::parameter::in_reference
-                    >
-                  , boost::mpl::`true_`_
-                  , boost::mpl::`if_`_<
-                        boost::`is_same`_<
-                            typename Tag::qualifier
-                          , boost::parameter::forward_reference
-                        >
-                      , boost::mpl::`true_`_
-                      , boost::mpl::`false_`_
-                    >
-                >
-            >::type
-          , *tagged default*
-        >::type
-            `operator|`_\(T const& x) const;
-
-        template <typename T>
-        typename boost::`enable_if`_<
-            typename boost::mpl::`eval_if_`_<
-                typename boost::mpl::`eval_if_`_<
-                    boost::`is_same`_<
-                        typename Tag::qualifier
-                      , boost::parameter::out_reference
-                    >
-                  , boost::mpl::`true_`_
-                  , boost::mpl::`if_`_<
-                        boost::`is_same`_<
-                            typename Tag::qualifier
-                          , boost::parameter::forward_reference
-                        >
-                      , boost::mpl::`true_`_
-                      , boost::mpl::`false_`_
-                    >
-                >::type
-              , boost::mpl::`if_`_<
-                    boost::`is_const`_<T>
-                  , boost::mpl::`false_`_
-                  , boost::mpl::`true_`_
-                >
-              , boost::mpl::`false_`_
-            >::type
-          , *tagged default*
-        >::type
-            `operator|`_\(T& x) const;
-
-        template <typename F>
-        *tagged lazy default* `operator||`_\(F const&) const;
-
-        template <typename F>
-        *tagged lazy default* `operator||`_\(F&) const;
-
-        static keyword<Tag> const& instance;
-
-        static keyword<Tag>& get_\();
-    };
-
 .. _enable_if: ../../../core/doc/html/core/enable_if.html
 .. _eval_if_: ../../../mpl/doc/refmanual/eval-if.html
 .. _false_: ../../../mpl/doc/refmanual/bool.html
@@ -665,10 +534,6 @@ __ ../../../../boost/parameter/keyword.hpp
 
     template <typename T> |ArgumentPack|_ operator=(T const& value) const;
     template <typename T> |ArgumentPack|_ operator=(T& value) const;
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-.. parsed-literal::
-
     template <typename T> |ArgumentPack|_ operator=(T const&& value) const;
     template <typename T> |ArgumentPack|_ operator=(T&& value) const;
 
@@ -700,10 +565,6 @@ nested ``qualifier`` type of ``Tag`` must be ``consume_reference`` or
 
     template <typename T> *tagged default* operator|(T const& x) const;
     template <typename T> *tagged default* operator|(T& x) const;
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-.. parsed-literal::
-
     template <typename T> *tagged default* operator|(T const&& x) const;
     template <typename T> *tagged default* operator|(T&& x) const;
 
@@ -801,18 +662,17 @@ The |ntp_cpp|_ test program demonstrates proper usage of this class template.
 ``parameters``
 --------------
 
-Provides an interface for assembling the actual arguments to a
-`forwarding function` into an |ArgumentPack|, in which any
-|positional| arguments will be tagged according to the
-corresponding template argument to ``parameters``.  
+Provides an interface for assembling the actual arguments to a `forwarding
+function` into an |ArgumentPack|, in which any |positional| arguments will be
+tagged according to the corresponding template argument to ``parameters``.  If
+no template arguments are passed into ``parameters``, then the interface
+cannot assemble any |positional| arguments, only |tagged reference| arguments.
 
 .. _forwarding function: `forwarding functions`_
 
 :Defined in: `boost/parameter/parameters.hpp`__
 
 __ ../../../../boost/parameter/parameters.hpp
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
 
 .. parsed-literal::
 
@@ -827,6 +687,17 @@ __ ../../../../boost/parameter/parameters.hpp
 
         template <typename ...Args>
         |ArgumentPack|_ `operator()`_\(Args&&... args) const;
+    };
+
+    template <>
+    struct parameters<>
+    {
+        template <typename ...Args>
+        typename boost::`enable_if`_<
+            |are_tagged_arguments|_<Args...>
+          , |ArgumentPack|_
+        >::type
+            `operator()`_\(Args const&... args) const;
     };
 
 :Requires: Each element in the ``PSpec`` parameter pack must be a model of
@@ -857,77 +728,11 @@ __ ../../../../boost/parameter/parameters.hpp
     |     else
     |         ``K`` ## *i* is the |keyword tag type| of ``P`` ## *i*.
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-.. parsed-literal::
-
-    template <
-        typename P0 = *unspecified*
-      , typename P1 = *unspecified*
-      , …
-      , typename P ## β = *unspecified*
-    >
-    struct parameters
-    {
-        template <
-            typename A0
-          , typename A1 = *unspecified*
-          , …
-          , typename A ## β = *unspecified*
-        >
-        struct `match`_
-        {
-            typedef … type;
-        };
-
-        template <typename A0>
-        |ArgumentPack|_ `operator()`_\(A0& a0) const;
-
-        template <typename A0, typename A1>
-        |ArgumentPack|_ `operator()`_\(A0& a0, A1& a1) const;
-
-        :vellipsis:`⋮`
-
-        template <typename A0, typename A1, …, typename A ## β>
-        |ArgumentPack|_
-        `operator()`_\(A0& a0, A1& a1, …, A ## β & a ## β) const;
-    };
-
-:Requires: ``P0``, ``P1``, …, ``P`` ## β must be models of |ParameterSpec|_.
-
-.. Note::
-
-    In this section, ``R`` ## *i* and ``K`` ## *i* are defined as follows: for
-    any argument type ``A`` ## *i*:
-
-    | let ``D0`` the set [ d0, …, d ## *j*] of all **deduced**
-    | *parameter specs* in [ ``P0``, …, ``P`` ## β]
-    | ``R`` ## *i* is the |intended argument type| of ``A`` ## *i*
-    |
-    | if ``A`` ## *i* is a result type of ``keyword<T>::`` |operator=|_
-    | then 
-    |     ``K`` ## *i* is ``T``
-    | else
-    |     if some ``A`` ## *j* where *j* ≤ *i* is a result type of
-    |     ``keyword<T>::`` |operator=|_
-    |     *or* some ``P`` ## *j* in *j* ≤ *i* is **deduced**
-    |     then
-    |         if some *parameter spec* ``d`` ## *j* in ``D`` ## *i*
-    |         matches ``A`` ## *i*
-    |         then
-    |             ``K`` ## *i* is the |keyword tag type| of ``d`` ## *j*.
-    |             ``D``:sub:`i+1` is ``D`` ## *i* - [ ``d`` ## *j*]
-    |     else
-    |         ``K`` ## *i* is the |keyword tag type| of ``P`` ## *i*.
-
 .. _match:
 
 ``match``
     A |Metafunction|_ used to remove a `forwarding function`_ from overload
     resolution.
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
 
 :Returns: if all elements in ``Params...`` are *satisfied* (see below), then
 ``parameters<Params...>``.  Otherwise, ``match<Args...>::type`` is not
@@ -945,48 +750,14 @@ Each element ``P`` in ``Params...`` is **satisfied** if either:
     - ``X`` is some ``K`` ## *i*, **and**
     - ``mpl::apply<F,R`` ## *i* ``>::type::value`` is ``true``
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-:Returns: if ``P0``, ``P1``, …, ``Pβ`` are *satisfied* (see below), then
-``parameters<P0,P1,…,Pβ>``.  Otherwise, ``match<A0,A1,…,Aβ>::type`` is not
-defined.
-
-``P0``, ``P1``, …, ``Pβ`` are **satisfied** if, for every *j* in 0…β,
-either:
-
-* ``P`` ## *j* is the *unspecified* default
-* **or**, ``P`` ## *j* is a *keyword tag type*
-* **or**, ``P`` ## *j* is |optional|_ ``<X,F>`` and either
-    - ``X`` is not ``K`` ## *i* for any *i*,
-    - **or** ``X`` is some ``K`` ## *i*  and ``mpl::apply<F,R`` ## *i*\
-        ``>::type::value`` is ``true``
-* **or**, ``P`` ## *j* is |required|_ ``<X,F>``, and
-    - ``X`` is some ``K`` ## *i*, **and**
-    - ``mpl::apply<F,R`` ## *i* ``>::type::value`` is ``true``
-
 .. _operator():
 
 ``operator()``
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
 
 .. parsed-literal::
 
     template <typename ...Args>
     |ArgumentPack|_ operator()(Args&&... args) const;
-
-**Else**
-
-.. parsed-literal::
-
-    template <typename A0> |ArgumentPack|_ operator()(A0 const& a0) const;
-
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## β>
-    |ArgumentPack|_
-    `operator()`_\(A0 const& a0, …, A ## β const& a ## β) const;
 
 :Returns: An |ArgumentPack|_ containing, for each ``a`` ## *i*,  
 
@@ -1132,13 +903,68 @@ __ ../../../../boost/parameter/value_type.hpp
 
 :Returns: the (possibly const-qualified) type of the |tagged reference| in
 ``A`` having |keyword tag type| ``K``, if any.  If no such |tagged reference|
-exists, returns ``D``. Equivalent to::
+exists, returns ``D``.  Equivalent to::
 
-    typename remove_reference<
-        typename binding<A, K, D>::type
+    typename boost::`remove_reference`_<
+        typename |binding|_<A, K, D>::type
     >::type
 
 … when ``D`` is not a reference type.
+
+.. _remove_reference: ../../../type_traits/doc/html/boost_typetraits/remove_reference.html
+
+``are_tagged_arguments``
+------------------------
+
+:Defined in: `boost/parameter/are_tagged_arguments.hpp`__
+
+__ ../../../../boost/parameter/are_tagged_arguments.hpp
+
+.. parsed-literal::
+
+    template <typename T0, typename ...Pack>
+    struct are_tagged_arguments  // : mpl::true_ or mpl::false_
+    {
+    };
+
+:Returns:
+``mpl::true_`` if ``T0`` and all elements in parameter pack ``Pack`` are
+|tagged reference| types, ``mpl::false_`` otherwise.
+
+:Example usage:
+When implementing a Boost.Parameter-enabled constructor for a container that
+conforms to the C++ standard, one needs to remember that the standard requires
+the presence of other constructors that are typically defined as templates,
+such as range constructors.  To avoid overload ambiguities between the two
+constructors, use this metafunction in conjunction with ``disable_if`` to
+define the range constructor.
+
+.. parsed-literal::
+
+    template <typename B>
+    class frontend : public B
+    {
+        struct _enabler
+        {
+        };
+
+     public:
+        |BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR|_(frontend, (B))
+
+        template <typename Iterator>
+        frontend(
+            Iterator itr
+          , Iterator itr_end
+          , typename boost::`disable_if`_<
+                are_tagged_arguments<Iterator>
+              , _enabler
+            >::type = _enabler()
+        ) : B(itr, itr_end)
+        {
+        }
+    };
+
+.. _disable_if: ../../../core/doc/html/core/enable_if.html
 
 ``is_argument_pack``
 --------------------
@@ -1154,8 +980,58 @@ __ ../../../../boost/parameter/is_argument_pack.hpp
     {
     };
 
-:Returns: ``mpl::true_`` if ``T`` is a model of |ArgumentPack|_,
-``mpl::false_`` otherwise.
+:Returns:
+``mpl::true_`` if ``T`` is a model of |ArgumentPack|_, ``mpl::false_``
+otherwise.
+
+:Example usage:
+To avoid overload ambiguities between a constructor that takes in an
+|ArgumentPack|_ and a templated conversion constructor, use this metafunction
+in conjunction with ``enable_if``.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(a0)
+
+    template <typename T>
+    class backend0
+    {
+        struct _enabler
+        {
+        };
+
+        T a0;
+
+     public:
+        template <typename ArgPack>
+        explicit backend0(
+            ArgPack const& args
+          , typename boost::`enable_if`_<
+                is_argument_pack<ArgPack>
+              , _enabler
+            >::type = _enabler()
+        ) : a0(args[_a0])
+        {
+        }
+
+        template <typename U>
+        backend0(
+            backend0<U> const& copy
+          , typename boost::`enable_if`_<
+                boost::`is_convertible`_<U,T>
+              , _enabler
+            >::type = _enabler()
+        ) : a0(copy.get_a0())
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->a0;
+        }
+    };
+
+.. _is_convertible: ../../../type_traits/doc/html/boost_typetraits/is_convertible.html
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -1172,11 +1048,206 @@ using the Parameter library by eliminating repetitive boilerplate.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-:Requires: ``result`` is the parenthesized return type of the
-function.  ``name`` is the base name of the function; it determines the name
-of the generated forwarding functions.  ``tag_namespace`` is the namespace in
-which the keywords used by the function resides.  ``arguments`` is a
-`Boost.Preprocessor`_ `sequence`_ of *argument-specifiers*, as defined below.
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal function header.  Enclose the
+return type ``bool`` in parentheses.  For each parameter, also enclose the
+expected value type in parentheses.  Since the value types are mutually
+exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of ``args`` to extract the corresponding argument.  Note that the
+second method doesn't require ``std::forward`` to preserve value categories.
+
+.. parsed-literal::
+
+    BOOST_PARAMETER_FUNCTION((bool), evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset<1>))
+                (lr, (std::bitset<2>))
+            )
+            (optional
+                (rrc, (std::bitset<3>), rvalue_const_bitset<2>())
+                (rr, (std::bitset<4>), rvalue_bitset<3>())
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category<0>(lrc)
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category<1>(lr)
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category<2>(std::`forward`_<rrc0_type>(rrc0))
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category<3>(args[_rr0])
+        );
+
+        return true;
+    }
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
+
+The |preprocessor|_, |preprocessor_deduced|_, and |preprocessor_eval_cat|_
+test programs demonstrate proper usage of this macro.
+
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
+.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
+.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
+.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
 
 :Argument specifiers syntax:
 .. parsed-literal::
@@ -1214,17 +1285,17 @@ which the keywords used by the function resides.  ``arguments`` is a
         ( '**(**' *type-name* '**)**' ) |
         '**\***'
 
-* ``argument-name`` is any valid C++ identifier.
-* ``default-value`` is any valid C++ expression; if necessary, user code can
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
 compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
 the ``argument-name`` in a previous ``specifier-group0`` or
 ``specifier-group1``.  *This expression will be invoked exactly once.*
-* ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will be
-the type of the corresponding ``argument-name``, whose second argument will be
-the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
 Constant`_; however, user code *cannot* compute ``mfc`` in terms of
 ``previous-name ## _type``.
-* ``type-name`` is either the name of a **target type** or an `MPL Binary
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
 Metafunction Class`_ whose first argument will be the type of the
 corresponding ``argument-name``, whose second argument will be the entire
 |ArgumentPack|_, and whose return type is the **target type**.  If
@@ -1238,21 +1309,11 @@ in ``args``) will be cast to that type.
 .. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
 .. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
 
-:Generated names in enclosing scope:
-* ``boost_param_result_ ## __LINE__ ## name``
-* ``boost_param_params_ ## __LINE__ ## name``
-* ``boost_param_parameters_ ## __LINE__ ## name``
-* ``boost_param_impl ## name``
-* ``boost_param_dispatch_0boost_ ## __LINE__ ## name``
-* ``boost_param_dispatch_1boost_ ## __LINE__ ## name``
-
 Approximate expansion:
 **Where**:
 
 * ``n`` denotes the *minimum* arity, as determined from ``arguments``.
 * ``m`` denotes the *maximum* arity, as determined from ``arguments``.
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
 
 .. parsed-literal::
 
@@ -1263,28 +1324,28 @@ Approximate expansion:
     };
 
     struct boost_param_params\_ ## __LINE__ ## **name**
-      : boost::parameter::parameters<
+      : |parameters|_<
             *list of parameter specifications, based on arguments*
         >
     {
     };
 
-    typedef boost_param_params\_ ## __LINE__ ## **name** 
+    typedef boost_param_params\_ ## __LINE__ ## **name**
         boost_param_parameters\_ ## __LINE__ ## **name**;
 
     template <typename Args>
     typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
-        boost_param_impl ## **name**\ (Args const&);
+        boost_param_impl ## __LINE__ ## **name**\ (Args const&);
 
     template <typename A0, …, typename A ## **n**>
     **result** **name**\ (
         A0&& a0, …, A ## **n**\ && a ## **n**
-      , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-            A0, …, A ## **n**
-        >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
     )
     {
-        return boost_param_impl ## **name**\ (
+        return boost_param_impl ## __LINE__ ## **name**\ (
             boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
                 std::`forward`_<A0>(a0)
               , …
@@ -1298,12 +1359,12 @@ Approximate expansion:
     template <typename A0, …, typename A ## **m**>
     **result** **name**\ (
         A0&& a0, …, A ## **m**\ && a ## **m**
-      , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-            A0, …, A ## **m**
-        >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
     )
     {
-        return boost_param_impl ## **name**\ (
+        return boost_param_impl ## __LINE__ ## **name**\ (
             boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
                 std::`forward`_<A0>(a0)
               , …
@@ -1348,10 +1409,14 @@ Approximate expansion:
 
     template <typename Args>
     typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
-        boost_param_impl ## **name**\ (Args const& args)
+        boost_param_impl ## __LINE__ ## **name**\ (Args const& args)
     {
         return boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
-            static_cast<ResultType(\ *)()>(std::nullptr)
+            static_cast<
+                typename boost_param_result\_ ## __LINE__ ## **name**\ <
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
           , args
           , std::`forward`_<
                 typename boost::parameter::value_type<
@@ -1424,8 +1489,284 @@ Approximate expansion:
           , *argument name* ## **m** ## _type&& *argument name* ## **m**
         )
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+
+``BOOST_PARAMETER_MEMBER_FUNCTION(result, name, tag_namespace, arguments)``
+---------------------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``static`` member function
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of ``args`` to extract the corresponding argument.  Note that the
+second method doesn't require ``std::forward`` to preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        BOOST_PARAMETER_MEMBER_FUNCTION((bool), static evaluate, kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>), rvalue_const_bitset<2>())
+                    (rr, (std::bitset<4>), rvalue_bitset<3>())
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(lrc)
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(lr)
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(std::`forward`_<rrc0_type>(rrc0))
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(args[_rr0])
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B::evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    B::evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    B::evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    B::evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    B::evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    B::evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    B::evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
+
+The |preprocessor|_ and |preprocessor_eval_cat|_ test programs demonstrate
+proper usage of this macro.
+
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
+.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.  ``name`` may be qualified by the ``static``
+keyword to declare the member function and its helpers as not associated with
+any object of the enclosing type.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *optional-specifier* {*optional-specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *required-specifier* {*required-specifier*\ }
+            '**)**'
+        )
+
+    optional-specifier ::=
+        '**(**'
+            *argument-name* '**,**' *restriction* '**,**' *default-value*
+        ')'
+
+    required-specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
+compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
+the ``argument-name`` in a previous ``specifier-group0`` or
+``specifier-group1``.  *This expression will be invoked exactly once.*
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.  If
+``restriction`` uses this form, then the type of the generated name
+``argument-name ## _type`` will be computed in terms of the **target type**,
+and the generated reference ``argument-name`` (but not its corresponding entry
+in ``args``) will be cast to that type.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
 
 .. parsed-literal::
 
@@ -1436,50 +1777,28 @@ Approximate expansion:
     };
 
     struct boost_param_params\_ ## __LINE__ ## **name**
-      : boost::parameter::parameters<
+      : |parameters|_<
             *list of parameter specifications, based on arguments*
         >
     {
     };
 
-    typedef boost_param_params\_ ## __LINE__ ## **name** 
+    typedef boost_param_params\_ ## __LINE__ ## **name**
         boost_param_parameters\_ ## __LINE__ ## **name**;
 
-    template <typename Args>
-    typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
-        boost_param_impl ## **name**\ (Args const&);
-
     template <typename A0, …, typename A ## **n**>
-    **result**
-        **name**\ (
-            A0 const& a0, …, A ## **n** const& a ## **n**
-          , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-                A0 const, …, A ## **n** const
-            >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
-        )
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
     {
-        return boost_param_impl ## **name**\ (
+        return this->boost_param_impl ## __LINE__ ## **name**\ (
             boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
-                a0, …, a ## **n**
-            )
-        );
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **n**>
-    **result**
-        **name**\ (
-            A0& a0, …, A ## **n** & a ## **n**
-          , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-                A0, …, A ## **n**
-            >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
-        )
-    {
-        return boost_param_impl ## **name**\ (
-            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
-                a0, …, a ## **n**
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
             )
         );
     }
@@ -1487,84 +1806,46 @@ Approximate expansion:
     :vellipsis:`⋮`
 
     template <typename A0, …, typename A ## **m**>
-    **result**
-        **name**\ (
-            A0 const& a0, …, A ## **m** const& a ## **m**
-          , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-                A0 const, …, A ## **m** const
-            >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
-        )
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
     {
-        return boost_param_impl ## **name**\ (
+        return this->boost_param_impl ## __LINE__ ## **name**\ (
             boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
-                a0, …, a ## **m**
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
             )
         );
     }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **m**>
-    **result**
-        **name**\ (
-            A0& a0, …, A ## **m** & a ## **m**
-          , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-                A0, …, A ## **m**
-            >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
-        )
-    {
-        return boost_param_impl ## **name**\ (
-            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
-                a0, …, a ## **m**
-            )
-        );
-    }
-
-    template <
-        typename ResultType
-      , typename Args
-      , typename *argument name* ## **0** ## _type
-      , …
-      , typename *argument name* ## **n** ## _type
-    >
-    ResultType
-        boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
-            (ResultType(\ *)())
-          , Args const& args
-          , *argument name* ## **0** ## _type& *argument name* ## **0**
-          , …
-          , *argument name* ## **n** ## _type& *argument name* ## **m**
-        );
-
-    :vellipsis:`⋮`
-
-    template <
-        typename ResultType
-      , typename Args
-      , typename *argument name* ## **0** ## _type
-      , …
-      , typename *argument name* ## **m** ## _type
-    >
-    ResultType
-        boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
-            (ResultType(\ *)())
-          , Args const& args
-          , *argument name* ## **0** ## _type& *argument name* ## **0**
-          , …
-          , *argument name* ## **m** ## _type& *argument name* ## **m**
-        );
 
     template <typename Args>
     typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
-        boost_param_impl ## **name**\ (Args const& args)
+        boost_param_impl ## __LINE__ ## **name**\ (Args const& args)
     {
-        return boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
-            static_cast<ResultType(\ *)()>(std::nullptr)
+        return this->boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
+            static_cast<
+                typename boost_param_result\_ ## __LINE__ ## **name**\ <
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
           , args
-          , args[ *keyword object of required parameter* ## **0**]
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **0**
+                >::type
+            >(args[ *keyword object of required parameter* ## **0**])
           , …
-          , args[ *keyword object of required parameter* ## **n**]
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **n**
+                >::type
+            >(args[ *keyword object of required parameter* ## **n**])
         );
     }
 
@@ -1579,20 +1860,29 @@ Approximate expansion:
         boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
             (ResultType(\ *)())
           , Args const& args
-          , *argument name* ## **0** ## _type& *argument name* ## **0**
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
           , …
-          , *argument name* ## **n** ## _type& *argument name* ## **m**
+          , *argument name* ## **n** ## _type&& *argument name* ## **n**
         )
     {
-        return boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
+        return this->boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
             static_cast<ResultType(\ *)()>(std::nullptr)
           , (args, *keyword object of optional parameter* ## **n + 1** =
                 *default value of optional parameter* ## **n + 1**
             )
-          , *argument name* ## **0**
+          , std::`forward`_<*argument name* ## **0** ## _type>(
+                *argument name* ## **0**
+            )
           , …
-          , *argument name* ## **n**
-          , *default value of optional parameter* ## **n + 1**
+          , std::`forward`_<*argument name* ## **n** ## _type>(
+                *argument name* ## **n**
+            )
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of optional parameter* ## **n + 1**
+                >::type
+            >(*default value of optional parameter* ## **n + 1**)
         );
     }
 
@@ -1609,45 +1899,12 @@ Approximate expansion:
         boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
             (ResultType(\ *)())
           , Args const& args
-          , *argument name* ## **0** ## _type& *argument name* ## **0**
-            :vellipsis:`⋮`
-          , *argument name* ## **m** ## _type& *argument name* ## **m**
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **m** ## _type&& *argument name* ## **m**
         )
 
-The |preprocessor|_, |preprocessor_deduced|_, and |preprocessor_eval_cat|_
-test programs demonstrate proper usage of this macro.
-
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
-.. |preprocessor| replace:: preprocessor.cpp
-.. _preprocessor: ../../test/preprocessor.cpp
-.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
-.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
-.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
-.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
-
-``BOOST_PARAMETER_MEMBER_FUNCTION(result, name, tag_namespace, arguments)``
----------------------------------------------------------------------------
-
-:Defined in: `boost/parameter/preprocessor.hpp`__
-
-__ ../../../../boost/parameter/preprocessor.hpp
-
-Same as ``BOOST_PARAMETER_FUNCTION``, except:
-
-\*. ``name`` may be qualified by the ``static`` keyword to declare the member
-function and its helpers as not associated with any object of the enclosing
-type.
-
-\*. Expansion of this macro omits all forward declarations of the front-end
-implementation and dispatch functions.
-
-The |preprocessor|_ and |preprocessor_eval_cat|_ test programs demonstrate
-proper usage of this macro.
-
-.. |preprocessor| replace:: preprocessor.cpp
-.. _preprocessor: ../../test/preprocessor.cpp
-.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
-.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
 
 ``BOOST_PARAMETER_CONST_MEMBER_FUNCTION(result, name, tag_ns, arguments)``
 --------------------------------------------------------------------------
@@ -1656,14 +1913,415 @@ proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_MEMBER_FUNCTION``, except that the overloaded
-forwarding member functions and their helper methods are
-``const``-qualified.
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``const`` member function
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of ``args`` to extract the corresponding argument.  Note that the
+second method doesn't require ``std::forward`` to preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        B()
+        {
+        }
+
+        BOOST_PARAMETER_CONST_MEMBER_FUNCTION((bool), evaluate, kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>), rvalue_const_bitset<2>())
+                    (rr, (std::bitset<4>), rvalue_bitset<3>())
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(lrc)
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(lr)
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(std::`forward`_<rrc0_type>(rrc0))
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(args[_rr0])
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B const b = B();
+    b.evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    b.evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    b.evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    b.evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    b.evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    b.evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    b.evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
 
 The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *optional-specifier* {*optional-specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *required-specifier* {*required-specifier*\ }
+            '**)**'
+        )
+
+    optional-specifier ::=
+        '**(**'
+            *argument-name* '**,**' *restriction* '**,**' *default-value*
+        ')'
+
+    required-specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
+compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
+the ``argument-name`` in a previous ``specifier-group0`` or
+``specifier-group1``.  *This expression will be invoked exactly once.*
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.  If
+``restriction`` uses this form, then the type of the generated name
+``argument-name ## _type`` will be computed in terms of the **target type**,
+and the generated reference ``argument-name`` (but not its corresponding entry
+in ``args``) will be cast to that type.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result_const\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params_const\_ ## __LINE__ ## **name**
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params_const\_ ## __LINE__ ## **name**
+        boost_param_parameters_const\_ ## __LINE__ ## **name**;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## **name**\ (
+            boost_param_parameters_const\_ ## __LINE__ ## **name**\ (
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## **name**\ (
+            boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result_const\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl_const ## __LINE__ ## **name**\ (Args const& args) const
+    {
+        return this->
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## **name**\ (
+            static_cast<
+                typename boost_param_result_const\_ ## __LINE__ ## **name**\ <
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
+          , args
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **0**
+                >::type
+            >(args[ *keyword object of required parameter* ## **0**])
+          , …
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **n**
+                >::type
+            >(args[ *keyword object of required parameter* ## **n**])
+        );
+    }
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **n** ## _type
+    >
+    ResultType
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **n** ## _type&& *argument name* ## **n**
+        ) const
+    {
+        return this->
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## **name**\ (
+            static_cast<ResultType(\ *)()>(std::nullptr)
+          , (args, *keyword object of optional parameter* ## **n + 1** =
+                *default value of optional parameter* ## **n + 1**
+            )
+          , std::`forward`_<*argument name* ## **0** ## _type>(
+                *argument name* ## **0**
+            )
+          , …
+          , std::`forward`_<*argument name* ## **n** ## _type>(
+                *argument name* ## **n**
+            )
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of optional parameter* ## **n + 1**
+                >::type
+            >(*default value of optional parameter* ## **n + 1**)
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **m** ## _type
+    >
+    ResultType
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **m** ## _type&& *argument name* ## **m**
+        ) const
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_FUNCTION_CALL_OPERATOR(result, tag_namespace, arguments)``
 ----------------------------------------------------------------------------
@@ -1672,21 +2330,309 @@ The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_MEMBER_FUNCTION``, except that the name of the
-forwarding member function overloads is ``operator()``.
+:Example usage:
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``tag`` by default.
 
-:Generated names in enclosing scope:
-* ``boost_param_result_ ## __LINE__ ## operator``
-* ``boost_param_params_ ## __LINE__ ## operator``
-* ``boost_param_parameters_ ## __LINE__ ## operator``
-* ``boost_param_impl ## operator``
-* ``boost_param_dispatch_0boost_ ## __LINE__ ## operator``
-* ``boost_param_dispatch_1boost_ ## __LINE__ ## operator``
+.. parsed-literal::
 
-The |preprocessor|_ test program demonstrates proper usage of this macro.
+    |BOOST_PARAMETER_NAME|_(y)
+    |BOOST_PARAMETER_NAME|_(z)
 
+Use the macro as a substitute for a normal function call operator
+header.  Enclose the return type in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  This is especially useful when implementing multiple
+Boost.Parameter-enabled function call operator overloads.
+
+.. parsed-literal::
+
+    class char_reader
+    {
+        int index;
+        char const* key;
+
+     public:
+        explicit char_reader(char const* k) : index(0), key(k)
+        {
+        }
+
+        BOOST_PARAMETER_FUNCTION_CALL_OPERATOR((void), tag,
+            (deduced
+                (required
+                    (y, (int))
+                    (z, (char const*))
+                )
+            )
+        )
+        {
+            this->index = y;
+            this->key = z;
+        }
+
+        |BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR|_((char), tag,
+            (deduced
+                (required
+                    (y, (bool))
+                    (z, (std::`map`_<char const*,std::`string`_>))
+                )
+            )
+        )
+        {
+            return y ? (
+                (z.find(this->key)->second)[this->index]
+            ) : this->key[this->index];
+        }
+    };
+
+As with regular argument-dependent lookup, the value types of the arguments
+passed in determine which function call operator overload gets invoked.
+
+.. parsed-literal::
+
+    char const* keys[] = {"foo", "bar", "baz"};
+    std::`map`_<char const*,std::`string`_> k2s;
+    k2s[keys[0]] = std::`string`_("qux");
+    k2s[keys[1]] = std::`string`_("wmb");
+    k2s[keys[2]] = std::`string`_("zxc");
+    char_reader r(keys[0]);
+
+    // positional arguments
+    BOOST_TEST_EQ('q', (r(true, k2s)));
+    BOOST_TEST_EQ('f', (r(false, k2s)));
+
+    // named arguments
+    r(_z = keys[1], _y = 1);
+    BOOST_TEST_EQ('m', (r(_z = k2s, _y = true)));
+    BOOST_TEST_EQ('a', (r(_z = k2s, _y = false)));
+
+    // deduced arguments
+    r(keys[2], 2);
+    BOOST_TEST_EQ('c', (r(k2s, true)));
+    BOOST_TEST_EQ('z', (r(k2s, false)));
+
+The |preprocessor|_ and |preprocessor_deduced|_ test programs demonstrate
+proper usage of this macro.
+
+.. _`map`: http\://en.cppreference.com/w/cpp/container/map
+.. _`string`: http\://en.cppreference.com/w/cpp/string/basic_string
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
+.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function call operator resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *optional-specifier* {*optional-specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *required-specifier* {*required-specifier*\ }
+            '**)**'
+        )
+
+    optional-specifier ::=
+        '**(**'
+            *argument-name* '**,**' *restriction* '**,**' *default-value*
+        ')'
+
+    required-specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
+compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
+the ``argument-name`` in a previous ``specifier-group0`` or
+``specifier-group1``.  *This expression will be invoked exactly once.*
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.  If
+``restriction`` uses this form, then the type of the generated name
+``argument-name ## _type`` will be computed in terms of the **target type**,
+and the generated reference ``argument-name`` (but not its corresponding entry
+in ``args``) will be cast to that type.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params\_ ## __LINE__ ## operator
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params\_ ## __LINE__ ## operator
+        boost_param_parameters\_ ## __LINE__ ## operator;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** operator()(
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## operator::match<
+            A0, …, A ## **n**
+        >::type = boost_param_parameters\_ ## __LINE__ ## operator()
+    )
+    {
+        return this->boost_param_impl ## __LINE__ ## operator(
+            boost_param_parameters\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** operator()(
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## operator::match<
+            A0, …, A ## **m**
+        >::type = boost_param_parameters\_ ## __LINE__ ## operator()
+    )
+    {
+        return this->boost_param_impl ## __LINE__ ## operator(
+            boost_param_parameters\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## operator<Args>::type
+        boost_param_impl ## __LINE__ ## operator(Args const& args)
+    {
+        return this->boost_param_dispatch_0boost\_ ## __LINE__ ## operator(
+            static_cast<
+                typename boost_param_result\_ ## __LINE__ ## operator<
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
+          , args
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **0**
+                >::type
+            >(args[ *keyword object of required parameter* ## **0**])
+          , …
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **n**
+                >::type
+            >(args[ *keyword object of required parameter* ## **n**])
+        );
+    }
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **n** ## _type
+    >
+    ResultType
+        boost_param_dispatch_0boost\_ ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **n** ## _type&& *argument name* ## **n**
+        )
+    {
+        return this->boost_param_dispatch_0boost\_ ## __LINE__ ## operator(
+            static_cast<ResultType(\ *)()>(std::nullptr)
+          , (args, *keyword object of optional parameter* ## **n + 1** =
+                *default value of optional parameter* ## **n + 1**
+            )
+          , std::`forward`_<*argument name* ## **0** ## _type>(
+                *argument name* ## **0**
+            )
+          , …
+          , std::`forward`_<*argument name* ## **n** ## _type>(
+                *argument name* ## **n**
+            )
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of optional parameter* ## **n + 1**
+                >::type
+            >(*default value of optional parameter* ## **n + 1**)
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **m** ## _type
+    >
+    ResultType
+        boost_param_dispatch_0boost\_ ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **m** ## _type&& *argument name* ## **m**
+        )
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR(result, tag_ns, arguments)``
 ---------------------------------------------------------------------------
@@ -1695,16 +2641,419 @@ The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_FUNCTION_CALL_OPERATOR``, except that the overloaded
-function call operators and their helper methods are ``const``-qualified.
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
 
-The |preprocessor|_ and |preprocessor_eval_cat_8|_ test programs demonstrate
-proper usage of this macro.
+.. parsed-literal::
 
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``const`` function call operator
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of ``args`` to extract the corresponding argument.  Note that the
+second method doesn't require ``std::forward`` to preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        B()
+        {
+        }
+
+        BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR((bool), kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>), rvalue_const_bitset<2>())
+                    (rr, (std::bitset<4>), rvalue_bitset<3>())
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(lrc)
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(lr)
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(std::`forward`_<rrc0_type>(rrc0))
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(args[_rr0])
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B const b = B();
+    b(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    b(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    b((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    b(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    b(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    b(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    b(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
+
+The |preprocessor|_, |preprocessor_deduced|_, and |preprocessor_eval_cat_8|_
+test programs demonstrate proper usage of this macro.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
+.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
 .. |preprocessor_eval_cat_8| replace:: preprocessor_eval_cat_8.cpp
 .. _preprocessor_eval_cat_8: ../../test/preprocessor_eval_cat_8.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function call operator resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *optional-specifier* {*optional-specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *required-specifier* {*required-specifier*\ }
+            '**)**'
+        )
+
+    optional-specifier ::=
+        '**(**'
+            *argument-name* '**,**' *restriction* '**,**' *default-value*
+        ')'
+
+    required-specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
+compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
+the ``argument-name`` in a previous ``specifier-group0`` or
+``specifier-group1``.  *This expression will be invoked exactly once.*
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.  If
+``restriction`` uses this form, then the type of the generated name
+``argument-name ## _type`` will be computed in terms of the **target type**,
+and the generated reference ``argument-name`` (but not its corresponding entry
+in ``args``) will be cast to that type.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result_const\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params_const\_ ## __LINE__ ## operator
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params_const\_ ## __LINE__ ## operator
+        boost_param_parameters_const\_ ## __LINE__ ## operator;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** operator()(
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## operator
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## operator()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## operator(
+            boost_param_parameters_const\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** operator()(
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## operator
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## operator()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## operator(
+            boost_param_parameters_const\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result_const\_ ## __LINE__ ## operator<Args>::type
+        boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+    {
+        return this->
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## operator(
+            static_cast<
+                typename boost_param_result_const\_ ## __LINE__ ## operator<
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
+          , args
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **0**
+                >::type
+            >(args[ *keyword object of required parameter* ## **0**])
+          , …
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **n**
+                >::type
+            >(args[ *keyword object of required parameter* ## **n**])
+        );
+    }
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **n** ## _type
+    >
+    ResultType
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **n** ## _type&& *argument name* ## **n**
+        ) const
+    {
+        return this->
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## operator(
+            static_cast<ResultType(\ *)()>(std::nullptr)
+          , (args, *keyword object of optional parameter* ## **n + 1** =
+                *default value of optional parameter* ## **n + 1**
+            )
+          , std::`forward`_<*argument name* ## **0** ## _type>(
+                *argument name* ## **0**
+            )
+          , …
+          , std::`forward`_<*argument name* ## **n** ## _type>(
+                *argument name* ## **n**
+            )
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of optional parameter* ## **n + 1**
+                >::type
+            >(*default value of optional parameter* ## **n + 1**)
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **m** ## _type
+    >
+    ResultType
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **m** ## _type&& *argument name* ## **m**
+        ) const
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_CONSTRUCTOR(cls, impl, tag_namespace, arguments)``
 --------------------------------------------------------------------
@@ -1713,17 +3062,163 @@ proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-:Requires: ``cls`` is the name of the enclosing class.  ``impl`` is the
-parenthesized implementation base class for ``cls``.  ``tag_namespace`` is the
-namespace in which the keywords used by the function resides.  ``arguments``
-is a list of *argument-specifiers*, as defined in ``BOOST_PARAMETER_FUNCTION``
-except that *optional-specifier* no longer includes *default-value*.  It is up
-to the delegate constructor in ``impl`` to determine the default value of all
+:Example usage:
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``tag`` by default.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(y)
+    |BOOST_PARAMETER_NAME|_(z)
+
+In the base class, implement a delegate constructor template that takes in an
+|ArgumentPack|_.  You must pass the identifiers with leading underscores to
+``args`` in order to extract the corresponding arguments.
+
+.. parsed-literal::
+
+    class char_read_base
+    {
+        int index;
+        char const* key;
+
+     public:
+        template <typename Args>
+        explicit char_read_base(Args const& args)
+          : index(args[_y]), key(args[_z])
+        {
+        }
+
+        |BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR|_((char), tag,
+            (deduced
+                (required
+                    (y, (bool))
+                    (z, (std::`map`_<char const*,std::`string`_>))
+                )
+            )
+        )
+        {
+            return y ? (
+                (z.find(this->key)->second)[this->index]
+            ) : this->key[this->index];
+        }
+    };
+
+Use the macro as a substitute for a normal constructor definition.  Note the
+lack of an explicit body.  Enclose the base type in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a
+``(deduced …)`` clause.
+
+.. parsed-literal::
+
+    struct char_reader : public char_read_base
+    {
+        BOOST_PARAMETER_CONSTRUCTOR(char_reader, (char_read_base), tag,
+            (deduced
+                (required
+                    (y, (int))
+                    (z, (char const*))
+                )
+            )
+        )
+    };
+
+The following ``char_reader`` constructor calls are legal.
+
+.. parsed-literal::
+
+    char const* keys[] = {"foo", "bar", "baz"};
+    std::`map`_<char const*,std::`string`_> k2s;
+    k2s[keys[0]] = std::`string`_("qux");
+    k2s[keys[1]] = std::`string`_("wmb");
+    k2s[keys[2]] = std::`string`_("zxc");
+
+    // positional arguments
+    char_reader r0(0, keys[0]);
+    BOOST_TEST_EQ('q', (r0(true, k2s)));
+    BOOST_TEST_EQ('f', (r0(false, k2s)));
+
+    // named arguments
+    char_reader r1(_z = keys[1], _y = 1);
+    BOOST_TEST_EQ('m', (r1(_z = k2s, _y = true)));
+    BOOST_TEST_EQ('a', (r1(_z = k2s, _y = false)));
+
+    // deduced arguments
+    char_reader r2(keys[2], 2);
+    BOOST_TEST_EQ('c', (r2(k2s, true)));
+    BOOST_TEST_EQ('z', (r2(k2s, false)));
+
+The |preprocessor|_ and |preprocessor_deduced|_ test programs demonstrate
+proper usage of this macro.
+
+.. _`map`: http\://en.cppreference.com/w/cpp/container/map
+.. _`string`: http\://en.cppreference.com/w/cpp/string/basic_string
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
+.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
+.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
+.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
+
+:Macro parameters:
+\*. ``cls`` is the name of the enclosing class.
+\*. ``impl`` is the parenthesized implementation base class for ``cls``.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+constructor resides.
+\*. ``arguments`` is a list of *argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+delegate constructor in ``impl`` to determine the default value of all
 optional arguments.
 
-:Generated names in enclosing scope:
-* ``boost_param_params_ ## __LINE__ ## ctor``
-* ``constructor_parameters ## __LINE__``
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
 
 Approximate expansion:
 **Where**:
@@ -1731,23 +3226,21 @@ Approximate expansion:
 * ``n`` denotes the *minimum* arity, as determined from ``arguments``.
 * ``m`` denotes the *maximum* arity, as determined from ``arguments``.
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-
 .. parsed-literal::
 
     struct boost_param_params\_ ## __LINE__ ## ctor
-      : boost::parameter::parameters<
+      : |parameters|_<
             *list of parameter specifications, based on arguments*
         >
     {
     };
 
-    typedef boost_param_params\_ ## __LINE__ ## **name**
+    typedef boost_param_params\_ ## __LINE__ ## ctor
         constructor_parameters ## __LINE__;
 
     template <typename A0, …, typename A ## **n**>
-    *cls*\ (A0&& a0, …, A ## **n** && a ## **n**)
-      : *impl*\ (
+    **cls**\ (A0&& a0, …, A ## **n** && a ## **n**)
+      : **impl**\ (
             constructor_parameters ## __LINE__(
                 std::`forward`_<A0>(a0)
               , …
@@ -1760,8 +3253,8 @@ Approximate expansion:
     :vellipsis:`⋮`
 
     template <typename A0, …, typename A ## **m**>
-    *cls*\ (A0&& a0, …, A ## **m** && a ## **m**)
-      : *impl*\ (
+    **cls**\ (A0&& a0, …, A ## **m** && a ## **m**)
+      : **impl**\ (
             constructor_parameters ## __LINE__(
                 std::`forward`_<A0>(a0)
               , …
@@ -1771,61 +3264,7 @@ Approximate expansion:
     {
     }
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-.. parsed-literal::
-
-    struct boost_param_params\_ ## __LINE__ ## ctor
-      : boost::parameter::parameters<
-            *list of parameter specifications, based on arguments*
-        >
-    {
-    };
-
-    typedef boost_param_params\_ ## __LINE__ ## **name**
-        constructor_parameters ## __LINE__;
-
-    template <typename A0, …, typename A ## **n**>
-    *cls*\ (A0 const& a0, …, A ## **n** const& a ## **n**)
-      : *impl*\ (constructor_parameters ## __LINE__(a0, …, a ## **n**))
-    {
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **n**>
-    *cls*\ (A0& a0, …, A ## **n** & a ## **n**)
-      : *impl*\ (constructor_parameters ## __LINE__(a0, …, a ## **n**))
-    {
-    }
-
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **m**>
-    *cls*\ (A0 const& a0, …, A ## **m** const& a ## **m**)
-      : *impl*\ (constructor_parameters ## __LINE__(a0, …, a ## **m**))
-    {
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **m**>
-    *cls*\ (A0& a0, …, A ## **m** & a ## **m**)
-      : *impl*\ (constructor_parameters ## __LINE__(a0, …, a ## **m**))
-    {
-    }
-
-The |preprocessor|_ and |preprocessor_eval_cat|_ test programs demonstrate
-proper usage of this macro.
-
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
-.. |preprocessor| replace:: preprocessor.cpp
-.. _preprocessor: ../../test/preprocessor.cpp
-.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
-.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
 
 ``BOOST_PARAMETER_BASIC_FUNCTION(result, name, tag_namespace, arguments)``
 --------------------------------------------------------------------------
@@ -1834,27 +3273,326 @@ proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_FUNCTION``, except:
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
 
-\*. For the argument specifiers syntax, *optional-specifier* no longer
-includes *default-value*.  It is up to the function body to determine the
-default value of all optional arguments.
+.. parsed-literal::
 
-\*. Generated names in the enclosing scope no longer include
-``boost_param_dispatch_0boost_ ## __LINE__ ## name`` or
-``boost_param_dispatch_1boost_ ## __LINE__ ## name``.
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
 
-\*. Expansion of this macro omits all overloads of
-``boost_param_dispatch_0boost_ ## __LINE__ ## name`` and
-``boost_param_dispatch_1boost_ ## __LINE__ ## name`` and stops at the header
-of ``boost_param_impl ## name``.  Therefore, only the |ArgumentPack|_ type
-``Args`` and its object instance ``args`` are available for use within the
-function body.
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal function header.  Enclose the
+return type ``bool`` in parentheses.  For each parameter, also enclose the
+expected value type in parentheses.  Since the value types are mutually
+exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of ``args`` to extract the
+corresponding argument, but at least this doesn't require ``std::forward`` to
+preserve value categories.
+
+.. parsed-literal::
+
+    BOOST_PARAMETER_BASIC_FUNCTION((bool), evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset<1>))
+                (lr, (std::bitset<2>))
+            )
+            (optional
+                (rrc, (std::bitset<3>))
+                (rr, (std::bitset<4>))
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category<0>(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category<1>(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category<2>(
+                args[_rrc0 | rvalue_const_bitset<2>()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category<3>(args[_rr0 | rvalue_bitset<3>()])
+        );
+
+        return true;
+    }
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
 
 The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params\_ ## __LINE__ ## **name**
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params\_ ## __LINE__ ## **name**
+        boost_param_parameters\_ ## __LINE__ ## **name**;
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl ## **name**\ (Args const&);
+
+    template <typename A0, …, typename A ## **n**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
+    {
+        return boost_param_impl ## __LINE__ ## **name**\ (
+            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
+    {
+        return boost_param_impl ## __LINE__ ## **name**\ (
+            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl ## __LINE__ ## **name**\ (Args const& args)
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_BASIC_MEMBER_FUNCTION(result, name, tag_ns, arguments)``
 --------------------------------------------------------------------------
@@ -1863,19 +3601,330 @@ The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_BASIC_FUNCTION``, except that:
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
 
-\*. ``name`` may be qualified by the ``static`` keyword to declare the member
-function and its helpers as not associated with any object of the enclosing
-type.
+.. parsed-literal::
 
-\*. Expansion of this macro omits the forward declaration of the
-implementation function.
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``static`` member function
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of ``args`` to extract the
+corresponding argument, but at least this doesn't require ``std::forward`` to
+preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        BOOST_PARAMETER_BASIC_MEMBER_FUNCTION((bool), static evaluate, kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>))
+                    (rr, (std::bitset<4>))
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc0 | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr0 | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B::evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    B::evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    B::evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    B::evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    B::evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    B::evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    B::evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
 
 The |preprocessor|_ test program demonstrates proper usage of this macro.
 
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.  ``name`` may be qualified by the ``static``
+keyword to declare the member function and its helpers as not associated with
+any object of the enclosing type.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params\_ ## __LINE__ ## **name**
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params\_ ## __LINE__ ## **name**
+        boost_param_parameters\_ ## __LINE__ ## **name**;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
+    {
+        return this->boost_param_impl ## **name**\ (
+            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
+    {
+        return this->boost_param_impl ## **name**\ (
+            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl ## **name**\ (Args const& args)
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION(result, name, tag_ns, args)``
 ---------------------------------------------------------------------------
@@ -1884,13 +3933,2214 @@ The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_BASIC_MEMBER_FUNCTION``, except that the overloaded
-forwarding member functions and their helper methods are ``const``-qualified.
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``const`` member function
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of ``args`` to extract the
+corresponding argument, but at least this doesn't require ``std::forward`` to
+preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        B()
+        {
+        }
+
+        BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION((bool), evaluate, kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>))
+                    (rr, (std::bitset<4>))
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc0 | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr0 | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B const b = B();
+    b.evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    b.evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    b.evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    b.evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    b.evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    b.evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    b.evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
+
+The |preprocessor|_ test program demonstrates proper usage of this macro.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result_const\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params_const\_ ## __LINE__ ## **name**
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params_const\_ ## __LINE__ ## **name**
+        boost_param_parameters_const\_ ## __LINE__ ## **name**;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## **name**\ (
+            boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## **name**\ (
+            boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result_const\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl_const ## __LINE__ ## **name**\ (Args const& args) const
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+
+``BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR(result, tag_ns, arguments)``
+---------------------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``tag`` by default.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(y)
+    |BOOST_PARAMETER_NAME|_(z)
+
+Use the macro as a substitute for a normal function call operator
+header.  Enclose the return type in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  This is especially useful when implementing multiple
+Boost.Parameter-enabled function call operator overloads.
+
+.. parsed-literal::
+
+    class char_reader
+    {
+        int index;
+        char const* key;
+
+     public:
+        explicit char_reader(char const* k) : index(0), key(k)
+        {
+        }
+
+        BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR((void), tag,
+            (deduced
+                (required
+                    (y, (int))
+                    (z, (char const*))
+                )
+            )
+        )
+        {
+            this->index = args[_y];
+            this->key = args[_z];
+        }
+
+        |BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR|_((char), tag,
+            (deduced
+                (required
+                    (y, (bool))
+                    (z, (std::`map`_<char const*,std::`string`_>))
+                )
+            )
+        )
+        {
+            return args[_y] ? (
+                (args[_z].find(this->key)->second)[this->index]
+            ) : this->key[this->index];
+        }
+    };
+
+As with regular argument-dependent lookup, the value types of the arguments
+passed in determine which function call operator overload gets invoked.
+
+.. parsed-literal::
+
+    char const* keys[] = {"foo", "bar", "baz"};
+    std::`map`_<char const*,std::`string`_> k2s;
+    k2s[keys[0]] = std::`string`_("qux");
+    k2s[keys[1]] = std::`string`_("wmb");
+    k2s[keys[2]] = std::`string`_("zxc");
+    char_reader r(keys[0]);
+
+    // positional arguments
+    BOOST_TEST_EQ('q', (r(true, k2s)));
+    BOOST_TEST_EQ('f', (r(false, k2s)));
+
+    // named arguments
+    r(_z = keys[1], _y = 1);
+    BOOST_TEST_EQ('m', (r(_z = k2s, _y = true)));
+    BOOST_TEST_EQ('a', (r(_z = k2s, _y = false)));
+
+    // deduced arguments
+    r(keys[2], 2);
+    BOOST_TEST_EQ('c', (r(k2s, true)));
+    BOOST_TEST_EQ('z', (r(k2s, false)));
+
+The |preprocessor|_ test program demonstrates proper usage of this macro.
+
+.. _`map`: http\://en.cppreference.com/w/cpp/container/map
+.. _`string`: http\://en.cppreference.com/w/cpp/string/basic_string
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function call operator resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params\_ ## __LINE__ ## operator
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params\_ ## __LINE__ ## operator
+        boost_param_parameters\_ ## __LINE__ ## operator;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** operator()(
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## operator::match<
+            A0, …, A ## **n**
+        >::type = boost_param_parameters\_ ## __LINE__ ## operator()
+    )
+    {
+        return this->boost_param_impl ## __LINE__ ## operator(
+            boost_param_parameters\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** operator()(
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## operator::match<
+            A0, …, A ## **m**
+        >::type = boost_param_parameters\_ ## __LINE__ ## operator()
+    )
+    {
+        return this->boost_param_impl ## __LINE__ ## operator(
+            boost_param_parameters\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## operator<Args>::type
+        boost_param_impl ## __LINE__ ## operator(Args const& args)
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function call operator body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+
+``BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR(result, tag_ns, args)``
+----------------------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``const`` function call operator
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of ``args`` to extract the
+corresponding argument, but at least this doesn't require ``std::forward`` to
+preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        B()
+        {
+        }
+
+        BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR((bool), kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>))
+                    (rr, (std::bitset<4>))
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc0 | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr0 | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B const b = B();
+    b(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    b(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    b((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    b(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    b(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    b(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    b(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
 
 The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function call operator resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result_const\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params_const\_ ## __LINE__ ## operator
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params_const\_ ## __LINE__ ## operator
+        boost_param_parameters_const\_ ## __LINE__ ## operator;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** operator()(
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## operator
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## operator()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## operator(
+            boost_param_parameters_const\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** operator()(
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## operator
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## operator()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## operator(
+            boost_param_parameters_const\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result_const\_ ## __LINE__ ## operator<Args>::type
+        boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function call operator body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+
+``BOOST_PARAMETER_NO_SPEC_FUNCTION(result, name)``
+--------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Named parameters are required when invoking the function; however, none of
+their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw0) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw1) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw2) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw3) consume(rr))
+
+Use the macro as a substitute for a variadic function header.  Enclose the
+return type ``bool`` in parentheses.
+
+.. parsed-literal::
+
+    BOOST_PARAMETER_NO_SPEC_FUNCTION((bool), evaluate)
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category<0>(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category<1>(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category<2>(
+                args[_rrc | rvalue_const_bitset<2>()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category<3>(args[_rr | rvalue_bitset<3>()])
+        );
+
+        return true;
+    }
+
+To invoke the function, bind all its arguments to named parameters.
+
+.. parsed-literal::
+
+    evaluate(
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    evaluate(
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+The |preproc_eval_cat_no_spec|_ test program demonstrates proper usage of
+this macro.
+
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated implementation function.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+        );
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result\_ ## __LINE__ ## **name**\ <
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        **name**\ (TaggedArg0 const& arg0, TaggedArgs const&... args)
+    {
+        return boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            static_cast<
+                typename
+                boost_param_no_spec_result\_ ## __LINE__ ## **name**\ <
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+        )
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION(result, name)``
+---------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+When designing a front-end class template whose back-end is configurable via
+parameterized inheritance, it can be useful to omit argument specifiers from
+a named-parameter member function so that the delegate member functions of the
+back-end classes can enforce their own specifications.
+
+.. parsed-literal::
+
+    template <typename B>
+    struct frontend : B
+    {
+        frontend() : B()
+        {
+        }
+
+        BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((void), initialize)
+        {
+            this->initialize_impl(args);
+        }
+    };
+
+Named parameters are required when invoking the member function; however, none
+of their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(a0)
+    |BOOST_PARAMETER_NAME|_(a1)
+    |BOOST_PARAMETER_NAME|_(a2)
+
+For this example, each of the back-end class templates requires its own
+parameter to be present in the argument pack.  In practice, such parameters
+should be optional, with default values.
+
+.. parsed-literal::
+
+    template <typename T>
+    class backend0
+    {
+        T a0;
+
+     public:
+        backend0() : a0()
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->a0;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            this->a0 = args[_a0];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend1 : public B
+    {
+        T a1;
+
+     public:
+        backend1() : B(), a1()
+        {
+        }
+
+        T const& get_a1() const
+        {
+            return this->a1;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->a1 = args[_a1];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend2 : public B
+    {
+        T a2;
+
+     public:
+        backend2() : B(), a2()
+        {
+        }
+
+        T const& get_a2() const
+        {
+            return this->a2;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->a2 = args[_a2];
+        }
+    };
+
+This example shows that while ``backend0`` must always be the root base class
+template and that ``frontend`` must always be the most derived class template,
+the other back-ends can be chained together in different orders.
+
+.. parsed-literal::
+
+    char const* p = "foo";
+    frontend<
+        backend2<backend1<backend0<char const*>, char>, int>
+    > composed_obj0;
+    frontend<
+        backend1<backend2<backend0<char const*>, int>, char>
+    > composed_obj1;
+    composed_obj0.initialize(_a2 = 4, _a1 = ' ', _a0 = p);
+    composed_obj1.initialize(_a0 = p, _a1 = ' ', _a2 = 4);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+
+The |parameterized_inheritance|_ and |preproc_eval_cat_no_spec|_ test programs
+demonstrate proper usage of this macro.
+
+.. |parameterized_inheritance| replace:: parameterized_inheritance.cpp
+.. _parameterized_inheritance: ../../test/parameterized_inheritance.cpp
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated implementation function.  ``name`` may be qualified by the
+``static`` keyword to declare the member function and its helpers as not
+associated with any object of the enclosing type.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result\_ ## __LINE__ ## **name**\ <
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        **name**\ (TaggedArg0 const& arg0, TaggedArgs const&... args)
+    {
+        return this->boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            static_cast<
+                typename
+                boost_param_no_spec_result\_ ## __LINE__ ## **name**\ <
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+        )
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION(result, name)``
+---------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Named parameters are required when invoking the member function; however, none
+of their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw0) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw1) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw2) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw3) consume(rr))
+
+Use the macro as a substitute for a variadic function header.  Enclose the
+return type ``bool`` in parentheses.  The macro will qualify the function with
+the ``const`` keyword.
+
+.. parsed-literal::
+
+    struct D
+    {
+        D()
+        {
+        }
+
+        BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION((bool), evaluate_m)
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+To invoke the member function, bind all its arguments to named parameters.
+
+.. parsed-literal::
+
+    D const d = D();
+    d.evaluate_m(
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    d.evaluate_m(
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+The |preproc_eval_cat_no_spec|_ test program demonstrates proper usage of this
+macro.
+
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated implementation function.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result_const\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result_const\_ ## __LINE__ ## **name**\ <
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        **name**\ (TaggedArg0 const& arg0, TaggedArgs const&... args) const
+    {
+        return this->boost_param_no_spec_impl_const ## __LINE__ ## **name**\ (
+            static_cast<
+                typename
+                boost_param_no_spec_result_const\_ ## __LINE__ ## **name**\ <
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl_const ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+        ) const
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR(result)``
+----------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+When designing a front-end class template whose back-end is configurable via
+parameterized inheritance, it can be useful to omit argument specifiers from
+a named-parameter function call operator so that the delegate member functions
+of the back-end classes can enforce their own specifications.
+
+.. parsed-literal::
+
+    template <typename B>
+    struct frontend : B
+    {
+        frontend() : B()
+        {
+        }
+
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR((void))
+        {
+            this->initialize_impl(args);
+        }
+    };
+
+Named parameters are required when invoking the function call operator;
+however, none of their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(a0)
+    |BOOST_PARAMETER_NAME|_(a1)
+    |BOOST_PARAMETER_NAME|_(a2)
+
+For this example, each of the back-end class templates requires its own
+parameter to be present in the argument pack.  In practice, such parameters
+should be optional, with default values.
+
+.. parsed-literal::
+
+    template <typename T>
+    class backend0
+    {
+        T a0;
+
+     public:
+        backend0() : a0()
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->a0;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            this->a0 = args[_a0];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend1 : public B
+    {
+        T a1;
+
+     public:
+        backend1() : B(), a1()
+        {
+        }
+
+        T const& get_a1() const
+        {
+            return this->a1;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->a1 = args[_a1];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend2 : public B
+    {
+        T a2;
+
+     public:
+        backend2() : B(), a2()
+        {
+        }
+
+        T const& get_a2() const
+        {
+            return this->a2;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->a2 = args[_a2];
+        }
+    };
+
+This example shows that while ``backend0`` must always be the root base class
+template and that ``frontend`` must always be the most derived class template,
+the other back-ends can be chained together in different orders.
+
+.. parsed-literal::
+
+    char const* p = "foo";
+    frontend<
+        backend2<backend1<backend0<char const*>, char>, int>
+    > composed_obj0;
+    frontend<
+        backend1<backend2<backend0<char const*>, int>, char>
+    > composed_obj1;
+    composed_obj0(_a2 = 4, _a1 = ' ', _a0 = p);
+    composed_obj1(_a0 = p, _a1 = ' ', _a2 = 4);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+
+The |parameterized_inheritance|_ and |preproc_eval_cat_no_spec|_ test programs
+demonstrate proper usage of this macro.
+
+.. |parameterized_inheritance| replace:: parameterized_inheritance.cpp
+.. _parameterized_inheritance: ../../test/parameterized_inheritance.cpp
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result\_ ## __LINE__ ## operator<
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        operator()(TaggedArg0 const& arg0, TaggedArgs const&... args)
+    {
+        return this->boost_param_no_spec_impl ## __LINE__ ## operator(
+            static_cast<
+                typename
+                boost_param_no_spec_result\_ ## __LINE__ ## operator<
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+        )
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR(result)``
+----------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Named parameters are required when invoking the function call operator;
+however, none of their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw0) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw1) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw2) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw3) consume(rr))
+
+Use the macro as a substitute for a variadic function call operator
+header.  Enclose the return type ``bool`` in parentheses.  The macro will
+qualify the function with the ``const`` keyword.
+
+.. parsed-literal::
+
+    struct D
+    {
+        D()
+        {
+        }
+
+        BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR((bool))
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+To invoke the function call operator, bind all its arguments to named
+parameters.
+
+.. parsed-literal::
+
+    D const d = D();
+    d(
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    d(
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+The |preproc_eval_cat_no_spec|_ test program demonstrates proper usage of this
+macro.
+
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result_const\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result_const\_ ## __LINE__ ## operator<
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        operator()(
+            TaggedArg0 const& arg0
+          , TaggedArgs const&... args
+        ) const
+    {
+        return this->boost_param_no_spec_impl_const ## __LINE__ ## operator(
+            static_cast<
+                typename
+                boost_param_no_spec_result_const\_ ## __LINE__ ## operator<
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl_const ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+        ) const
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(cls, impl)``
+--------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+When designing a front-end class template whose back-end is configurable via
+parameterized inheritance, it can be useful to omit argument specifiers from
+a named-parameter constructor so that the delegate constructors of the
+back-end classes can enforce their own specifications.
+
+.. parsed-literal::
+
+    template <typename B>
+    struct frontend : B
+    {
+        BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(frontend, (B))
+    };
+
+Named parameters are required when invoking the constructor; however, none of
+their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(a0)
+    |BOOST_PARAMETER_NAME|_(a1)
+    |BOOST_PARAMETER_NAME|_(a2)
+
+For this example, each of the back-end class templates requires its own
+parameter to be present in the argument pack.  In practice, such parameters
+should be optional, with default values.
+
+.. parsed-literal::
+
+    struct _enabler
+    {
+    };
+
+    template <typename T>
+    class backend0
+    {
+        T a0;
+
+     public:
+        template <typename ArgPack>
+        explicit backend0(
+            ArgPack const& args
+          , typename boost::`enable_if`_<
+                |is_argument_pack|_<ArgPack>
+              , _enabler
+            >::type = _enabler()
+        ) : a0(args[_a0])
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->a0;
+        }
+    };
+
+    template <typename B, typename T>
+    class backend1 : public B
+    {
+        T a1;
+
+     public:
+        template <typename ArgPack>
+        explicit backend1(
+            ArgPack const& args
+          , typename boost::`enable_if`_<
+                |is_argument_pack|_<ArgPack>
+              , _enabler
+            >::type = _enabler()
+        ) : B(args), a1(args[_a1])
+        {
+        }
+
+        T const& get_a1() const
+        {
+            return this->a1;
+        }
+    };
+
+    template <typename B, typename T>
+    class backend2 : public B
+    {
+        T a2;
+
+     public:
+        template <typename ArgPack>
+        explicit backend2(
+            ArgPack const& args
+          , typename boost::`enable_if`_<
+                |is_argument_pack|_<ArgPack>
+              , _enabler
+            >::type = _enabler()
+        ) : B(args), a2(args[_a2])
+        {
+        }
+
+        T const& get_a2() const
+        {
+            return this->a2;
+        }
+    };
+
+This example shows that while ``backend0`` must always be the root base class
+template and that ``frontend`` must always be the most derived class template,
+the other back-ends can be chained together in different orders.
+
+.. parsed-literal::
+
+    char const* p = "foo";
+    frontend<
+        backend2<backend1<backend0<char const*>, char>, int>
+    > composed_obj0(_a2 = 4, _a1 = ' ', _a0 = p);
+    frontend<
+        backend1<backend2<backend0<char const*>, int>, char>
+    > composed_obj1(_a0 = p, _a1 = ' ', _a2 = 4);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+
+The |parameterized_inheritance|_ and |preproc_eval_cat_no_spec|_ test programs
+demonstrate proper usage of this macro.
+
+.. |parameterized_inheritance| replace:: parameterized_inheritance.cpp
+.. _parameterized_inheritance: ../../test/parameterized_inheritance.cpp
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``cls`` is the name of the enclosing class.
+\*. ``impl`` is the parenthesized implementation base class for ``cls``.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <
+        typename TaggedArg0
+      , typename ...TaggedArgs
+      , typename = typename boost::`enable_if`_<
+            |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+        >::type
+    >
+    inline explicit **cls**\ (
+        TaggedArg0 const& arg0
+      , TaggedArgs const&... args
+    ) : **impl**\ (|parameters|_<>()(arg0, args...))
+    {
+    }
+
+``BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(cls, impl)``
+----------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following functon templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Named parameters are required when invoking the constructor; however, none of
+their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw0) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw1) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw2) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw3) consume(rr))
+
+Unlike |BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR|, this macro doesn't require a
+base class, only a delegate function to which the generated constructor can
+pass its |ArgumentPack|_.
+
+.. parsed-literal::
+
+    struct D
+    {
+        BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(D, D::_evaluate)
+
+     private:
+        template <typename Args>
+        static bool _evaluate(Args const& args)
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+To invoke the constructor, bind all its arguments to named parameters.
+
+.. parsed-literal::
+
+    D dp0(
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    D dp1(
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+The |preproc_eval_cat_no_spec|_ test program demonstrates proper usage of this
+macro.
+
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``cls`` is the name of the enclosing class.
+\*. ``func`` is a function that takes in the |ArgumentPack|_ that the
+generated constructor passes on.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <
+        typename TaggedArg0
+      , typename ...TaggedArgs
+      , typename = typename boost::`enable_if`_<
+            |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+        >::type
+    >
+    inline explicit **cls**\ (
+        TaggedArg0 const& arg0
+      , TaggedArgs const&... args
+    )
+    {
+        **func**\ (|parameters|_<>()(arg0, args...));
+    }
 
 ``BOOST_PARAMETER_NAME(name)``
 ------------------------------
@@ -2095,8 +6345,6 @@ __ ../../../../boost/parameter/macros.hpp
 :Requires: ``l`` and ``h`` are nonnegative integer tokens
 such that ``l`` < ``h``
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-
 Expands to:
 
 .. parsed-literal::
@@ -2164,109 +6412,6 @@ Expands to:
               , std::`forward`_<A ## **h**>(a ## **h**)
             )
         );
-    }
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-Expands to:
-
-.. parsed-literal::
-
-    template <typename A1, typename A2, …, typename A ## **l**>
-    r
-        name(
-            A1 const& a1, A2 const& a2, …, A ## **l** const& a ## **l**
-          , typename **p**::match<A1, A2, …, A ## **l**>::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(pk(a1, a2, …, a ## **l**));
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A1, typename A2, …, typename A ## **l**>
-    r
-        name(
-            A1& a1, A2& a2, …, A ## **l** & a ## **l**
-          , typename **p**::match<A1, A2, …, A ## **l**>::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(pk(a1, a2, …, a ## **l**));
-    }
-
-    template <
-        typename A1
-      , typename A2
-      , …
-      , typename A ## **l**
-      , typename A ## `BOOST_PP_INC`_\ (**l**)
-    >
-    r
-        name(
-            A1 const& a1, A2 const& a2, …, A ## **l** const& a ## **l**
-          , A ## `BOOST_PP_INC`_\ (**l**) const& a ## `BOOST_PP_INC`_\ (**l**)
-          , typename **p**::match<
-                A1 const, A2 const, …, A ## **l** const
-              , A ## `BOOST_PP_INC`_\ (**l**) const
-            >::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(
-            pk(a1, a2, …, a ## **l**, a ## `BOOST_PP_INC`_\ (**l**))
-        );
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <
-        typename A1
-      , typename A2
-      , …
-      , typename A ## **l**
-      , typename A ## `BOOST_PP_INC`_\ (**l**)
-    >
-    r
-        name(
-            A1& a1, A2& a2, …, A ## **l** & a ## **l**
-          , A ## `BOOST_PP_INC`_\ (**l**) & a ## `BOOST_PP_INC`_\ (**l**)
-          , typename **p**::match<
-                A1, A2, …, A ## **l**, A ## `BOOST_PP_INC`_\ (**l**)
-            >::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(
-            pk(a1, a2, …, a ## **l**, a ## `BOOST_PP_INC`_\ (**l**))
-        );
-    }
-
-    :vellipsis:`⋮`
-
-    template <typename A1, typename A2, …, typename A ## **h**>
-    r
-        name(
-            A1 const& a1, A2 const& a2, …, A ## **h** const& x ## **h**
-          , typename **p**::match<
-                A1 const, A2 const, …, A ## **h** const
-            >::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(pk(a1, a2, …, a ## **h**));
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A1, typename A2, …, typename A ## **h**>
-    r
-        name(
-            A1& a1, A2& a2, …, A ## **h** & x ## **h**
-          , typename **p**::match<A1, A2, …, A ## **h**>::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(pk(a1, a2, …, a ## **h**));
     }
 
 The |macros_cpp|_ and |macros_eval_cat_cpp|_ test programs demonstrate proper

--- a/include/boost/parameter/are_tagged_arguments.hpp
+++ b/include/boost/parameter/are_tagged_arguments.hpp
@@ -1,0 +1,125 @@
+// Copyright Cromwell D. Enage 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_HPP
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_HPP
+
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct are_tagged_arguments;
+}} // namespace boost::parameter
+
+#include <boost/parameter/aux_/is_tagged_argument.hpp>
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0>
+    struct are_tagged_arguments<TaggedArg0>
+      : ::boost::parameter::aux::is_tagged_argument<TaggedArg0>
+    {
+    };
+}} // namespace boost::parameter
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct are_tagged_arguments
+      : ::boost::mpl::if_<
+            ::boost::parameter::aux::is_tagged_argument<TaggedArg0>
+          , ::boost::parameter::are_tagged_arguments<TaggedArgs...>
+          , ::boost::mpl::false_
+        >::type
+    {
+    };
+}} // namespace boost::parameter
+
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z(z, n, false_t) , false_t>
+/**/
+
+#include <boost/parameter/aux_/is_tagged_argument.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/preprocessor/cat.hpp>
+
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_BEGIN_Z(z, n, prefix)           \
+    ::boost::mpl::eval_if<                                                   \
+        ::boost::parameter::aux::is_tagged_argument<BOOST_PP_CAT(prefix, n)>,
+/**/
+
+#include <boost/parameter/aux_/void.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/preprocessor/arithmetic/sub.hpp>
+#include <boost/preprocessor/facilities/intercept.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/repetition/enum_trailing_params.hpp>
+
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_OVERLOADS_Z(z, n, prefix)       \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename prefix)>                 \
+    struct are_tagged_arguments<                                             \
+        BOOST_PP_ENUM_PARAMS_Z(z, n, prefix)                                 \
+        BOOST_PP_ENUM_TRAILING_PARAMS_Z(                                     \
+            z                                                                \
+          , BOOST_PP_SUB(BOOST_PARAMETER_MAX_ARITY, n)                       \
+          , ::boost::parameter::void_ BOOST_PP_INTERCEPT                     \
+        )                                                                    \
+    > : BOOST_PP_CAT(BOOST_PP_REPEAT_, z)(                                   \
+            n                                                                \
+          , BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_BEGIN_Z                     \
+          , prefix                                                           \
+        )                                                                    \
+        ::boost::mpl::true_                                                  \
+        BOOST_PP_CAT(BOOST_PP_REPEAT_, z)(                                   \
+            n                                                                \
+          , BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z                       \
+          , ::boost::mpl::false_                                             \
+        )::type                                                              \
+    {                                                                        \
+    };
+/**/
+
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+
+namespace boost { namespace parameter {
+
+    template <
+        BOOST_PP_ENUM_BINARY_PARAMS(
+            BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)
+          , typename TaggedArg
+          , = ::boost::parameter::void_ BOOST_PP_INTERCEPT
+        )
+    >
+    struct are_tagged_arguments;
+}} // namespace boost::parameter
+
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
+namespace boost { namespace parameter {
+
+    BOOST_PP_REPEAT_FROM_TO(
+        1
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)
+      , BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_OVERLOADS_Z
+      , TaggedArg
+    )
+}} // namespace boost::parameter
+
+#undef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_OVERLOADS_Z
+#undef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_BEGIN_Z
+#undef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z
+
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+#endif  // include guard
+

--- a/include/boost/parameter/aux_/arg_list.hpp
+++ b/include/boost/parameter/aux_/arg_list.hpp
@@ -144,6 +144,7 @@ namespace boost { namespace parameter { namespace aux {
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -153,9 +154,13 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename TaggedArg
       , typename Next = ::boost::parameter::aux::empty_arg_list
+      , typename EmitErrors = ::boost::mpl::true_
     >
-    struct arg_list : Next
+    class arg_list : public Next
     {
+        TaggedArg arg;      // Stores the argument
+
+     public:
         typedef TaggedArg tagged_arg;
         typedef ::boost::parameter::aux::arg_list<TaggedArg,Next> self;
         typedef typename TaggedArg::key_type key_type;
@@ -175,8 +180,6 @@ namespace boost { namespace parameter { namespace aux {
           , reference
           , typename TaggedArg::value_type
         >::type value_type;
-
-        TaggedArg arg;      // Stores the argument
 
         // Create a new list by prepending arg to a copy of tail.  Used when
         // incrementally building this structure with the comma operator.
@@ -276,16 +279,22 @@ namespace boost { namespace parameter { namespace aux {
         static ::boost::parameter::aux::yes_tag has_key(key_type*);
         using Next::has_key;
 
-        BOOST_MPL_ASSERT_MSG(
+     private:
+        typedef ::boost::mpl::bool_<
             sizeof(
                 Next::has_key(
                     static_cast<key_type*>(BOOST_TTI_DETAIL_NULLPTR)
                 )
             ) == sizeof(::boost::parameter::aux::no_tag)
+        > _has_unique_key;
+
+        BOOST_MPL_ASSERT_MSG(
+            !(EmitErrors::value) || (_has_unique_key::value)
           , duplicate_keyword
           , (key_type)
         );
 
+     public:
         //
         // Begin implementation of indexing operators
         // for looking up specific arguments by name.
@@ -356,11 +365,18 @@ namespace boost { namespace parameter { namespace aux {
         // satisfied by TaggedArg.  Used only for compile-time computation
         // and never really called, so a declaration is enough.
         template <typename HasDefault, typename Predicate, typename ArgPack>
-        static typename ::boost::mpl::apply_wrap2<
-            ::boost::parameter::aux
-            ::augment_predicate<Predicate,reference,key_type>
-          , value_type
-          , ArgPack
+        static typename ::boost::lazy_enable_if<
+            typename ::boost::mpl::if_<
+                EmitErrors
+              , ::boost::mpl::true_
+              , _has_unique_key
+            >::type
+          , ::boost::mpl::apply_wrap2<
+                ::boost::parameter::aux
+                ::augment_predicate<Predicate,reference,key_type>
+              , value_type
+              , ArgPack
+            >
         >::type
             satisfies(
                 ::boost::parameter::aux::parameter_requirements<
@@ -524,6 +540,10 @@ namespace boost { namespace parameter { namespace aux {
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 #include <boost/preprocessor/repetition/enum_shifted_params.hpp>
 
+#if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+#include <boost/core/enable_if.hpp>
+#endif
+
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
 #include <boost/tti/detail/dnullptr.hpp>
 #endif
@@ -535,9 +555,13 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename TaggedArg
       , typename Next = ::boost::parameter::aux::empty_arg_list
+      , typename EmitErrors = ::boost::mpl::true_
     >
-    struct arg_list : Next
+    class arg_list : public Next
     {
+        TaggedArg arg;      // Stores the argument
+
+     public:
         typedef TaggedArg tagged_arg;
         typedef ::boost::parameter::aux::arg_list<TaggedArg,Next> self;
         typedef typename TaggedArg::key_type key_type;
@@ -557,8 +581,6 @@ namespace boost { namespace parameter { namespace aux {
           , reference
           , typename TaggedArg::value_type
         >::type value_type;
-
-        TaggedArg arg;      // Stores the argument
 
         // Create a new list by prepending arg to a copy of tail.  Used when
         // incrementally building this structure with the comma operator.
@@ -613,6 +635,7 @@ namespace boost { namespace parameter { namespace aux {
         static ::boost::parameter::aux::yes_tag has_key(key_type*);
         using Next::has_key;
 
+#if defined(BOOST_NO_SFINAE) || BOOST_WORKAROUND(BOOST_MSVC, < 1800)
         BOOST_MPL_ASSERT_MSG(
             sizeof(
                 Next::has_key(
@@ -622,8 +645,25 @@ namespace boost { namespace parameter { namespace aux {
           , duplicate_keyword
           , (key_type)
         );
-#endif
+#else
+     private:
+        typedef ::boost::mpl::bool_<
+            sizeof(
+                Next::has_key(
+                    static_cast<key_type*>(BOOST_TTI_DETAIL_NULLPTR)
+                )
+            ) == sizeof(::boost::parameter::aux::no_tag)
+        > _has_unique_key;
 
+        BOOST_MPL_ASSERT_MSG(
+            !(EmitErrors::value) || (_has_unique_key::value)
+          , duplicate_keyword
+          , (key_type)
+        );
+#endif
+#endif  // Borland workarounds not needed.
+
+     public:
         //
         // Begin implementation of indexing operators
         // for looking up specific arguments by name.
@@ -786,11 +826,23 @@ namespace boost { namespace parameter { namespace aux {
         // satisfied by TaggedArg.  Used only for compile-time computation
         // and never really called, so a declaration is enough.
         template <typename HasDefault, typename Predicate, typename ArgPack>
-        static typename ::boost::mpl::apply_wrap2<
-            ::boost::parameter::aux
-            ::augment_predicate<Predicate,reference,key_type>
-          , value_type
-          , ArgPack
+        static typename
+#if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+        ::boost::lazy_enable_if<
+            typename ::boost::mpl::if_<
+                EmitErrors
+              , ::boost::mpl::true_
+              , _has_unique_key
+            >::type,
+#endif
+            ::boost::mpl::apply_wrap2<
+                ::boost::parameter::aux
+                ::augment_predicate<Predicate,reference,key_type>
+              , value_type
+              , ArgPack
+#if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+           >
+#endif
         >::type
             satisfies(
                 ::boost::parameter::aux::parameter_requirements<

--- a/include/boost/parameter/aux_/arg_list.hpp
+++ b/include/boost/parameter/aux_/arg_list.hpp
@@ -885,8 +885,9 @@ namespace boost { namespace mpl {
     };
 }} // namespace boost::mpl
 
+#include <boost/parameter/value_type.hpp>
 #include <boost/mpl/has_key_fwd.hpp>
-#include <boost/mpl/find.hpp>
+#include <boost/type_traits/is_void.hpp>
 
 namespace boost { namespace mpl {
 
@@ -897,11 +898,9 @@ namespace boost { namespace mpl {
         struct apply
         {
             typedef typename ::boost::mpl::if_<
-                ::boost::is_same<
-                    typename ::boost::mpl::find<ArgList,Keyword>::type
-                  , ::boost::parameter::aux::arg_list_iterator<
-                        ::boost::parameter::aux::empty_arg_list
-                    >
+                ::boost::is_void<
+                    typename ::boost::parameter
+                    ::value_type<ArgList,Keyword,void>::type
                 >
               , ::boost::mpl::false_
               , ::boost::mpl::true_
@@ -922,11 +921,9 @@ namespace boost { namespace mpl {
         struct apply
         {
             typedef typename ::boost::mpl::if_<
-                ::boost::is_same<
-                    typename ::boost::mpl::find<ArgList,Keyword>::type
-                  , ::boost::parameter::aux::arg_list_iterator<
-                        ::boost::parameter::aux::empty_arg_list
-                    >
+                ::boost::is_void<
+                    typename ::boost::parameter
+                    ::value_type<ArgList,Keyword,void>::type
                 >
               , ::boost::mpl::int_<0>
               , ::boost::mpl::int_<1>
@@ -936,6 +933,7 @@ namespace boost { namespace mpl {
 }} // namespace boost::mpl
 
 #include <boost/mpl/key_type_fwd.hpp>
+#include <boost/mpl/identity.hpp>
 
 namespace boost { namespace mpl {
 
@@ -946,11 +944,9 @@ namespace boost { namespace mpl {
         struct apply
         {
             typedef typename ::boost::mpl::eval_if<
-                ::boost::is_same<
-                    typename ::boost::mpl::find<ArgList,Keyword>::type
-                  , ::boost::parameter::aux::arg_list_iterator<
-                        ::boost::parameter::aux::empty_arg_list
-                    >
+                ::boost::is_void<
+                    typename ::boost::parameter
+                    ::value_type<ArgList,Keyword,void>::type
                 >
               , void
               , ::boost::mpl::identity<Keyword>
@@ -983,6 +979,7 @@ namespace boost { namespace mpl {
 
 #include <boost/mpl/order_fwd.hpp>
 #include <boost/mpl/void.hpp>
+#include <boost/mpl/find.hpp>
 #include <boost/mpl/distance.hpp>
 
 namespace boost { namespace mpl {
@@ -995,11 +992,9 @@ namespace boost { namespace mpl {
         {
             typedef typename ::boost::mpl::find<ArgList,Keyword>::type Itr;
             typedef typename ::boost::mpl::eval_if<
-                ::boost::is_same<
-                    Itr
-                  , ::boost::parameter::aux::arg_list_iterator<
-                        ::boost::parameter::aux::empty_arg_list
-                    >
+                ::boost::is_void<
+                    typename ::boost::parameter
+                    ::value_type<ArgList,Keyword,void>::type
                 >
               , ::boost::mpl::identity< ::boost::mpl::void_>
               , ::boost::mpl::distance<

--- a/include/boost/parameter/aux_/pack/deduce_tag.hpp
+++ b/include/boost/parameter/aux_/pack/deduce_tag.hpp
@@ -14,6 +14,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
+      , typename EmitErrors
     >
     struct deduce_tag;
 }}} // namespace boost::parameter::aux
@@ -38,6 +39,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
+      , typename EmitErrors
     >
     struct deduce_tag0
     {
@@ -59,9 +61,13 @@ namespace boost { namespace parameter { namespace aux {
                     UsedArgs
                   , typename ::boost::parameter::aux::tag_type<spec>::type
                 >::type
-              , ::boost::mpl::if_<
+              , ::boost::mpl::eval_if<
                     condition
-                  , ::boost::mpl::false_
+                  , ::boost::mpl::if_<
+                        EmitErrors
+                      , ::boost::mpl::false_
+                      , ::boost::mpl::true_
+                    >
                   , ::boost::mpl::true_
                 >
               , ::boost::mpl::true_
@@ -77,6 +83,7 @@ namespace boost { namespace parameter { namespace aux {
               , typename DeducedArgs::tail
               , UsedArgs
               , TagFn
+              , EmitErrors
             >
         >::type type;
     };
@@ -108,6 +115,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
+      , typename EmitErrors
     >
     struct deduce_tag
       : ::boost::mpl::eval_if<
@@ -119,6 +127,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedArgs
               , UsedArgs
               , TagFn
+              , EmitErrors
             >
         >
     {

--- a/include/boost/parameter/aux_/pack/make_arg_list.hpp
+++ b/include/boost/parameter/aux_/pack/make_arg_list.hpp
@@ -16,6 +16,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename UsedArgs
       , typename ArgumentPack
       , typename Error
+      , typename EmitErrors
     >
     struct make_arg_list_aux;
 }}} // namespace boost::parameter::aux
@@ -54,6 +55,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename argument
 #endif
       , typename Error
+      , typename EmitErrors
     >
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     struct make_arg_list00
@@ -114,6 +116,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedArgs
               , used_args
               , TagFn
+              , EmitErrors
             >
         >::type deduced_data;
 
@@ -147,7 +150,11 @@ namespace boost { namespace parameter { namespace aux {
         typedef typename ::boost::mpl::if_<
             ::boost::is_same<tagged,::boost::parameter::void_>
           , ArgumentPack
+#if defined(BOOST_NO_SFINAE) || BOOST_WORKAROUND(BOOST_MSVC, < 1800)
           , ::boost::parameter::aux::arg_list<tagged,ArgumentPack>
+#else
+          , ::boost::parameter::aux::arg_list<tagged,ArgumentPack,EmitErrors>
+#endif
         >::type argument_pack;
 
         typedef typename ::boost::parameter::aux::make_arg_list_aux<
@@ -158,6 +165,7 @@ namespace boost { namespace parameter { namespace aux {
           , typename deduced_data::second
           , argument_pack
           , error
+          , EmitErrors
         >::type type;
     };
 
@@ -170,6 +178,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename UsedArgs
       , typename ArgumentPack
       , typename Error
+      , typename EmitErrors
     >
     struct make_arg_list0
     {
@@ -184,6 +193,7 @@ namespace boost { namespace parameter { namespace aux {
               , ArgumentPack
               , typename List::arg const
               , Error
+              , EmitErrors
             >
           , ::boost::parameter::aux::make_arg_list00<
                 List
@@ -194,6 +204,7 @@ namespace boost { namespace parameter { namespace aux {
               , ArgumentPack
               , typename List::arg
               , Error
+              , EmitErrors
             >
         >::type type;
     };
@@ -226,6 +237,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedSet
       , typename ArgumentPack
       , typename Error
+      , typename EmitErrors
     >
     struct make_arg_list_aux
       : ::boost::mpl::eval_if<
@@ -239,6 +251,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedSet
               , ArgumentPack
               , Error
+              , EmitErrors
             >
         >
     {
@@ -266,6 +279,7 @@ namespace boost { namespace parameter { namespace aux {
           , ::boost::parameter::aux::set0
           , ::boost::parameter::aux::empty_arg_list
           , ::boost::parameter::void_
+          , EmitErrors
         >
     {
     };

--- a/include/boost/parameter/aux_/preprocessor/impl/forwarding_overloads.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/forwarding_overloads.hpp
@@ -7,9 +7,104 @@
 #ifndef BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_FORWARDING_OVERLOADS_HPP
 #define BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_FORWARDING_OVERLOADS_HPP
 
+#include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
+
+// Defines the no-spec implementation function header.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_HEAD(name, is_const)           \
+    template <typename ResultType, typename Args>                            \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(name) ResultType                  \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(                          \
+            name, is_const                                                   \
+        )(ResultType(*)(), Args const& args)
+/**/
+
 #include <boost/parameter/config.hpp>
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
+
+// Expands to the result metafunction for the specified no-spec function.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, name, is_const)        \
+    template <typename TaggedArg0, typename ...TaggedArgs>                   \
+    struct BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(name, is_const)      \
+    {                                                                        \
+        typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
+    };
+/**/
+
+#include <boost/parameter/parameters.hpp>
+#include <boost/parameter/are_tagged_arguments.hpp>
+#include <boost/core/enable_if.hpp>
+
+// Exapnds to a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The enclosing class must inherit from the
+// specified base class, which in turn must implement a constructor that takes
+// in the argument pack that this one passes on.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(class_, base)                    \
+    template <                                                               \
+        typename TaggedArg0                                                  \
+      , typename ...TaggedArgs                                               \
+      , typename = typename ::boost::enable_if<                              \
+            ::boost::parameter                                               \
+            ::are_tagged_arguments<TaggedArg0,TaggedArgs...>                 \
+        >::type                                                              \
+    > inline explicit                                                        \
+    class_(TaggedArg0 const& arg0, TaggedArgs const&... args)                \
+      : BOOST_PARAMETER_PARENTHESIZED_TYPE(base)(                            \
+            ::boost::parameter::parameters<>()(arg0, args...)                \
+        )                                                                    \
+    {                                                                        \
+    }
+/**/
+
+// Exapnds to a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The specified function must be able to
+// take in the argument pack that this constructor passes on.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(class_, func)            \
+    template <                                                               \
+        typename TaggedArg0                                                  \
+      , typename ...TaggedArgs                                               \
+      , typename = typename ::boost::enable_if<                              \
+            ::boost::parameter                                               \
+            ::are_tagged_arguments<TaggedArg0,TaggedArgs...>                 \
+        >::type                                                              \
+    > inline explicit                                                        \
+    class_(TaggedArg0 const& arg0, TaggedArgs const&... args)                \
+    {                                                                        \
+        func(::boost::parameter::parameters<>()(arg0, args...));             \
+    }
+/**/
+
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/preprocessor/control/expr_if.hpp>
+
+// Exapnds to a variadic function that is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD(name, impl, is_m, c)       \
+    template <typename TaggedArg0, typename ...TaggedArgs>                   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(impl)                             \
+    inline typename ::boost::lazy_enable_if<                                 \
+        ::boost::parameter                                                   \
+        ::are_tagged_arguments<TaggedArg0,TaggedArgs...>                     \
+      , BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(                        \
+            impl, c                                                          \
+        )<TaggedArg0,TaggedArgs...>                                          \
+    >::type BOOST_PARAMETER_MEMBER_FUNCTION_NAME(name)                       \
+    (TaggedArg0 const& arg0, TaggedArgs const&... args)                      \
+    BOOST_PP_EXPR_IF(c, const)                                               \
+    {                                                                        \
+        return BOOST_PP_EXPR_IF(is_m, this->)                                \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(impl, c)(                 \
+            static_cast<                                                     \
+                typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(       \
+                    impl, c                                                  \
+                )<TaggedArg0,TaggedArgs...>::type(*)()                       \
+            >(BOOST_TTI_DETAIL_NULLPTR)                                      \
+          , ::boost::parameter::parameters<>()(arg0, args...)                \
+        );                                                                   \
+    }
+/**/
 
 #include <boost/preprocessor/cat.hpp>
 
@@ -26,7 +121,6 @@
     ::std::forward<BOOST_PP_CAT(type_prefix, n)>(BOOST_PP_CAT(a, n))
 /**/
 
-#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
 
 // Expands to the default constructor, whose job is to pass an empty back to
@@ -41,29 +135,33 @@
 /**/
 
 #include <boost/parameter/aux_/pp_impl/argument_pack.hpp>
-#include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
-#include <boost/preprocessor/control/expr_if.hpp>
 
 // Expands to a 0-arity forwarding function, whose job is to pass an empty
 // pack to the front-end implementation function.
 #define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_0_Z(z, n, data)            \
-    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(3, 1, data))  \
-    inline                                                                   \
-    BOOST_PARAMETER_FUNCTION_RESULT_NAME(BOOST_PP_TUPLE_ELEM(3, 1, data))<   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline BOOST_PARAMETER_FUNCTION_RESULT_NAME(                             \
+        BOOST_PP_TUPLE_ELEM(4, 1, data)                                      \
+      , BOOST_PP_TUPLE_ELEM(4, 3, data)                                      \
+    )<                                                                       \
         ::boost::parameter::aux::argument_pack<                              \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )                                                                \
         >::type                                                              \
     >::type                                                                  \
     BOOST_PARAMETER_MEMBER_FUNCTION_NAME(BOOST_PP_TUPLE_ELEM(3, 0, data))()  \
-    BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(3, 2, data), const)                 \
+    BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)                 \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
-            BOOST_PP_TUPLE_ELEM(3, 1, data)                                  \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                  \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )()()                                                            \
         );                                                                   \
     }
@@ -78,12 +176,15 @@
 // into a pack for the front-end implementation function to take in.
 #define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_1_Z(z, n, data)            \
     template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename ParameterArgumentType)>  \
-    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(3, 1, data))  \
-    inline typename                                                          \
-    BOOST_PARAMETER_FUNCTION_RESULT_NAME(BOOST_PP_TUPLE_ELEM(3, 1, data))<   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(                    \
+        BOOST_PP_TUPLE_ELEM(4, 1, data)                                      \
+      , BOOST_PP_TUPLE_ELEM(4, 3, data)                                      \
+    )<                                                                       \
         typename ::boost::parameter::aux::argument_pack<                     \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )                                                                \
           , BOOST_PP_CAT(BOOST_PP_ENUM_, z)(                                 \
                 n                                                            \
@@ -92,23 +193,27 @@
             )                                                                \
         >::type                                                              \
     >::type                                                                  \
-    BOOST_PARAMETER_MEMBER_FUNCTION_NAME(BOOST_PP_TUPLE_ELEM(3, 0, data))(   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_NAME(BOOST_PP_TUPLE_ELEM(4, 0, data))(   \
         BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, ParameterArgumentType, && a)     \
         BOOST_PARAMETER_FUNCTION_FORWARD_MATCH_Z(                            \
             z                                                                \
           , BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )                                                                \
           , n                                                                \
           , ParameterArgumentType                                            \
         )                                                                    \
-    ) BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(3, 2, data), const)               \
+    ) BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)               \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
-            BOOST_PP_TUPLE_ELEM(3, 1, data)                                  \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                  \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )()(                                                             \
                 BOOST_PP_CAT(BOOST_PP_ENUM_, z)(                             \
                     n                                                        \
@@ -169,12 +274,21 @@
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
 
 // Helper macro for BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(name, impl, range, c) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(nm, impl, r, is_m, c) \
     BOOST_PP_REPEAT_FROM_TO(                                                 \
-        BOOST_PP_TUPLE_ELEM(2, 0, range)                                     \
-      , BOOST_PP_TUPLE_ELEM(2, 1, range)                                     \
+        BOOST_PP_TUPLE_ELEM(2, 0, r)                                         \
+      , BOOST_PP_TUPLE_ELEM(2, 1, r)                                         \
       , BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_Z                          \
-      , (name, impl, c)                                                      \
+      , (                                                                    \
+            nm                                                               \
+          , impl                                                             \
+          , BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_MEMBER_FUNCTION_IS_STATIC(nm)                \
+              , 0                                                            \
+              , is_m                                                         \
+            )                                                                \
+          , c                                                                \
+        )                                                                    \
     )
 /**/
 
@@ -192,9 +306,9 @@
 
 // Expands to the layer of forwarding functions for the function with the
 // specified name, whose arguments determine the range of arities.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, args, const_) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, a, is_m, c)   \
     BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(                          \
-        name, impl, BOOST_PARAMETER_ARITY_RANGE(args), const_                \
+        name, impl, BOOST_PARAMETER_ARITY_RANGE(a), is_m, c                  \
     )
 /**/
 
@@ -208,9 +322,228 @@
 
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 
+#include <boost/parameter/aux_/void.hpp>
 #include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
-#include <boost/preprocessor/seq/seq.hpp>
+#include <boost/preprocessor/facilities/intercept.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+
+// Expands to the result metafunction for the specified no-spec function.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, name, is_const)        \
+    template <                                                               \
+        BOOST_PP_ENUM_BINARY_PARAMS(                                         \
+            BOOST_PARAMETER_MAX_ARITY                                        \
+          , typename TaggedArg                                               \
+          , = ::boost::parameter::void_ BOOST_PP_INTERCEPT                   \
+        )                                                                    \
+    >                                                                        \
+    struct BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(name, is_const)      \
+    {                                                                        \
+        typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
+    };
+/**/
+
+#include <boost/parameter/parameters.hpp>
+#include <boost/preprocessor/comparison/equal.hpp>
+#include <boost/preprocessor/control/expr_if.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
+
+#if defined(BOOST_NO_SFINAE)
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the base class delegate constructor.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR_OVERLOAD_Z(z, n, data)           \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+    ) : BOOST_PARAMETER_PARENTHESIZED_TYPE(BOOST_PP_TUPLE_ELEM(2, 1, data))( \
+            ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        )                                                                    \
+    {                                                                        \
+    }
+/**/
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the delegate function.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR_OVERLOAD_Z(z, n, data)   \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+    )                                                                        \
+    {                                                                        \
+        BOOST_PP_TUPLE_ELEM(2, 1, data)(                                     \
+            ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+#include <boost/tti/detail/dnullptr.hpp>
+
+// Exapnds to a tagged-argument function overload.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD_Z(z, n, data)              \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(            \
+        BOOST_PP_TUPLE_ELEM(4, 1, data)                                      \
+      , BOOST_PP_TUPLE_ELEM(4, 3, data)                                      \
+    )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>::type                         \
+        BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                \
+            BOOST_PP_TUPLE_ELEM(4, 0, data)                                  \
+        )(BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg))        \
+        BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)             \
+    {                                                                        \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(                          \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
+        )(                                                                   \
+            static_cast<                                                     \
+                typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(       \
+                    BOOST_PP_TUPLE_ELEM(4, 1, data)                          \
+                  , BOOST_PP_TUPLE_ELEM(4, 3, data)                          \
+                )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>::type(*)()        \
+            >(BOOST_TTI_DETAIL_NULLPTR)                                      \
+          , ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+#else   // !defined(BOOST_NO_SFINAE)
+
+#include <boost/parameter/are_tagged_arguments.hpp>
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the base class delegate constructor.  This constructor is enabled
+// if and only if all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR_OVERLOAD_Z(z, n, data)           \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+      , typename ::boost::enable_if<                                         \
+            ::boost::parameter::are_tagged_arguments<                        \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)                      \
+            >                                                                \
+        >::type* = BOOST_TTI_DETAIL_NULLPTR                                  \
+    ) : BOOST_PARAMETER_PARENTHESIZED_TYPE(BOOST_PP_TUPLE_ELEM(2, 1, data))( \
+            ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        )                                                                    \
+    {                                                                        \
+    }
+/**/
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the delegate function.  This constructor is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR_OVERLOAD_Z(z, n, data)   \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+      , typename ::boost::enable_if<                                         \
+            ::boost::parameter::are_tagged_arguments<                        \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)                      \
+            >                                                                \
+        >::type* = BOOST_TTI_DETAIL_NULLPTR                                  \
+    )                                                                        \
+    {                                                                        \
+        BOOST_PP_TUPLE_ELEM(2, 1, data)(                                     \
+            ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+// Exapnds to a function overload that is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD_Z(z, n, data)              \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline typename ::boost::lazy_enable_if<                                 \
+        ::boost::parameter                                                   \
+        ::are_tagged_arguments<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>      \
+      , BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(                        \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
+        )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>                           \
+    >::type BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                            \
+        BOOST_PP_TUPLE_ELEM(4, 0, data)                                      \
+    )(BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg))            \
+    BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)                 \
+    {                                                                        \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(                          \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
+        )(                                                                   \
+            static_cast<                                                     \
+                typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(       \
+                    BOOST_PP_TUPLE_ELEM(4, 1, data)                          \
+                  , BOOST_PP_TUPLE_ELEM(4, 3, data)                          \
+                )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>::type(*)()        \
+            >(BOOST_TTI_DETAIL_NULLPTR)                                      \
+          , ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+#endif  // BOOST_NO_SFINAE
+
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
+// Emulates a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The enclosing class must inherit from the
+// specified base class, which in turn must implement a constructor that takes
+// in the argument pack that this one passes on.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(class_, base)                    \
+    BOOST_PP_REPEAT_FROM_TO(                                                 \
+        1                                                                    \
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)                              \
+      , BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR_OVERLOAD_Z                       \
+      , (class_, base)                                                       \
+    )
+/**/
+
+// Emulates a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The specified function must be able to
+// take in the argument pack that this constructor passes on.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(class_, func)            \
+    BOOST_PP_REPEAT_FROM_TO(                                                 \
+        1                                                                    \
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)                              \
+      , BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR_OVERLOAD_Z               \
+      , (class_, func)                                                       \
+    )
+/**/
+
+// Emulates a variadic function that is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD(name, impl, is_m, c)       \
+    BOOST_PP_REPEAT_FROM_TO(                                                 \
+        1                                                                    \
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)                              \
+      , BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD_Z                          \
+      , (name, impl, is_m, c)                                                \
+    )
+/**/
+
+#include <boost/preprocessor/seq/seq.hpp>
 #include <boost/preprocessor/cat.hpp>
 
 // Expands to the default constructor, whose job is to pass an empty argument
@@ -228,49 +561,64 @@
 /**/
 
 #include <boost/parameter/aux_/pp_impl/argument_pack.hpp>
-#include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
-#include <boost/preprocessor/control/expr_if.hpp>
 
 // Expands to a 0-arity forwarding function, whose job is to pass an empty
 // argument pack to the front-end implementation function.
 #define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_0_ARITY(z, n, seq)         \
     BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(                                  \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
     )                                                                        \
     inline BOOST_PARAMETER_FUNCTION_RESULT_NAME(                             \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+        )                                                                    \
+      , BOOST_PP_TUPLE_ELEM(                                                 \
+            4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
     )<                                                                       \
         ::boost::parameter::aux::argument_pack<                              \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
                 BOOST_PP_TUPLE_ELEM(                                         \
-                    3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                    4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                )                                                            \
+              , BOOST_PP_TUPLE_ELEM(                                         \
+                    4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
                 )                                                            \
             )                                                                \
         >::type                                                              \
     >::type                                                                  \
     BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                    \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 0, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 0, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
     )() BOOST_PP_EXPR_IF(                                                    \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 2, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
       , const                                                                \
     )                                                                        \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
+        return BOOST_PP_EXPR_IF(                                             \
             BOOST_PP_TUPLE_ELEM(                                             \
-                3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
+                4, 2, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
+            )                                                                \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                \
+            BOOST_PP_TUPLE_ELEM(                                             \
+                4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
+            )                                                                \
+          , BOOST_PP_TUPLE_ELEM(                                             \
+                4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
             )                                                                \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
                 BOOST_PP_TUPLE_ELEM(                                         \
-                    3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                    4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                )                                                            \
+              , BOOST_PP_TUPLE_ELEM(                                         \
+                    4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
                 )                                                            \
             )()()                                                            \
         );                                                                   \
@@ -279,8 +627,6 @@
 
 #include <boost/parameter/aux_/preprocessor/binary_seq_to_args.hpp>
 #include <boost/parameter/aux_/preprocessor/impl/function_forward_match.hpp>
-#include <boost/preprocessor/comparison/equal.hpp>
-#include <boost/preprocessor/repetition/enum_params.hpp>
 #include <boost/preprocessor/seq/size.hpp>
 
 // Expands to a constructor whose job is to consolidate its arguments into a
@@ -332,14 +678,16 @@
         )                                                                    \
     >                                                                        \
     BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(                                  \
-        BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))                    \
+        BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))                    \
     )                                                                        \
     inline typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(                    \
-        BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))                    \
+        BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))                    \
+      , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))                    \
     )<                                                                       \
         typename ::boost::parameter::aux::argument_pack<                     \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))            \
+                BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))            \
+              , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))            \
             )                                                                \
           , BOOST_PARAMETER_AUX_PP_BINARY_SEQ_TO_ARGS(                       \
                 BOOST_PP_SEQ_TAIL(seq), (ParameterArgumentType)              \
@@ -347,27 +695,33 @@
         >::type                                                              \
     >::type                                                                  \
     BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                    \
-        BOOST_PP_TUPLE_ELEM(3, 0, BOOST_PP_SEQ_HEAD(seq))                    \
+        BOOST_PP_TUPLE_ELEM(4, 0, BOOST_PP_SEQ_HEAD(seq))                    \
     )(                                                                       \
         BOOST_PARAMETER_AUX_PP_BINARY_SEQ_TO_ARGS(                           \
             BOOST_PP_SEQ_TAIL(seq), (ParameterArgumentType)(a)               \
         )                                                                    \
         BOOST_PARAMETER_FUNCTION_FORWARD_MATCH(                              \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))            \
+                BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))            \
+              , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))            \
             )                                                                \
           , BOOST_PP_SEQ_SIZE(BOOST_PP_SEQ_TAIL(seq))                        \
           , ParameterArgumentType                                            \
         )                                                                    \
     ) BOOST_PP_EXPR_IF(                                                      \
-        BOOST_PP_TUPLE_ELEM(3, 2, BOOST_PP_SEQ_HEAD(seq)), const             \
+        BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq)), const             \
     )                                                                        \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
-            BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))                \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PP_TUPLE_ELEM(4, 2, BOOST_PP_SEQ_HEAD(seq))                \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                \
+            BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))                \
+          , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))                \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))            \
+                BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))            \
+              , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))            \
             )()(                                                             \
                 BOOST_PP_ENUM_PARAMS(                                        \
                     BOOST_PP_SEQ_SIZE(BOOST_PP_SEQ_TAIL(seq)), a             \
@@ -402,8 +756,6 @@
     )(z, n, (BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_R)(data))
 /**/
 
-#include <boost/preprocessor/repetition/repeat_from_to.hpp>
-
 // Helper macro for BOOST_PARAMETER_CONSTRUCTOR_OVERLOADS.
 #define BOOST_PARAMETER_CONSTRUCTOR_OVERLOADS_AUX(class_, base, range)       \
     BOOST_PP_REPEAT_FROM_TO(                                                 \
@@ -415,12 +767,21 @@
 /**/
 
 // Helper macro for BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(name, impl, range, c) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(nm, impl, r, is_m, c) \
     BOOST_PP_REPEAT_FROM_TO(                                                 \
-        BOOST_PP_TUPLE_ELEM(2, 0, range)                                     \
-      , BOOST_PP_TUPLE_ELEM(2, 1, range)                                     \
+        BOOST_PP_TUPLE_ELEM(2, 0, r)                                         \
+      , BOOST_PP_TUPLE_ELEM(2, 1, r)                                         \
       , BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_Z                          \
-      , (name, impl, c)                                                      \
+      , (                                                                    \
+            nm                                                               \
+          , impl                                                             \
+          , BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_MEMBER_FUNCTION_IS_STATIC(impl)              \
+              , 0                                                            \
+              , is_m                                                         \
+            )                                                                \
+          , c                                                                \
+        )                                                                    \
     )
 /**/
 
@@ -438,12 +799,13 @@
 
 // Expands to the layer of forwarding functions for the function with the
 // specified name, whose arguments determine the range of arities.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, args, const_) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, a, is_m, c)   \
     BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(                          \
         name                                                                 \
       , impl                                                                 \
-      , BOOST_PARAMETER_ARITY_RANGE(args)                                    \
-      , const_                                                               \
+      , BOOST_PARAMETER_ARITY_RANGE(a)                                       \
+      , is_m                                                                 \
+      , c                                                                    \
     )
 /**/
 

--- a/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_layer.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_layer.hpp
@@ -281,7 +281,10 @@
     BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_TPL(n, x)                         \
     inline BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_PRN(n, x, 0, 0)            \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                      \
             static_cast<ResultType(*)()>(BOOST_TTI_DETAIL_NULLPTR)           \
           , args                                                             \
           , 0L                                                               \
@@ -304,7 +307,10 @@
     BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_TPL(n, x)                         \
     inline BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_PRN(n, x, 1, 0)            \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                      \
             static_cast<ResultType(*)()>(BOOST_TTI_DETAIL_NULLPTR)           \
           , args                                                             \
           , 0L                                                               \
@@ -331,7 +337,10 @@
     BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_TPL(n, x)                         \
     inline BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_PRN(n, x, 0, 1)            \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 1)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 1)(                      \
             static_cast<ResultType(*)()>(BOOST_TTI_DETAIL_NULLPTR)           \
           , (args                                                            \
               , BOOST_PARAMETER_FUNCTION_DISPATCH_DEFAULT(                   \
@@ -357,7 +366,7 @@
 
 // x is a tuple:
 //
-//   (base_name, split_args, is_const, tag_namespace)
+//   (base_name, split_args, is_member, is_const, tag_namespace)
 //
 // Generates all dispatch functions for the function named base_name.  Each
 // dispatch function that takes in n optional parameters passes the default
@@ -391,15 +400,21 @@
         BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
     ) inline typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(                  \
         BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
+      , BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                        \
     )<Args>::type BOOST_PARAMETER_FUNCTION_IMPL_NAME(                        \
         BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
+      , BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                        \
     )(Args const& args)                                                      \
     BOOST_PP_EXPR_IF(BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x), const)   \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                      \
             static_cast<                                                     \
                 typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(               \
                     BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)           \
+                  , BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)            \
                 )<Args>::type(*)()                                           \
             >(BOOST_TTI_DETAIL_NULLPTR)                                      \
           , args                                                             \

--- a/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp
@@ -10,19 +10,23 @@
 
 // Accessor macros for the input tuple to the dispatch macros.
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
-    BOOST_PP_TUPLE_ELEM(4, 0, x)
+    BOOST_PP_TUPLE_ELEM(5, 0, x)
 /**/
 
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_SPLIT_ARGS(x)                      \
-    BOOST_PP_TUPLE_ELEM(4, 1, x)
+    BOOST_PP_TUPLE_ELEM(5, 1, x)
+/**/
+
+#define BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                       \
+    BOOST_PP_TUPLE_ELEM(5, 2, x)
 /**/
 
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                        \
-    BOOST_PP_TUPLE_ELEM(4, 2, x)
+    BOOST_PP_TUPLE_ELEM(5, 3, x)
 /**/
 
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_TAG_NAMESPACE(x)                   \
-    BOOST_PP_TUPLE_ELEM(4, 3, x)
+    BOOST_PP_TUPLE_ELEM(5, 4, x)
 /**/
 
 #endif  // include guard

--- a/include/boost/parameter/aux_/preprocessor/impl/function_name.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_name.hpp
@@ -72,18 +72,64 @@
 /**/
 
 // Produces a name for a parameter specification for the function named base.
-#define BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(base)                    \
+#define BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(base, is_const)          \
     BOOST_PP_CAT(                                                            \
-        BOOST_PP_CAT(boost_param_parameters_, __LINE__)                      \
-      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(name)                           \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_parameters_const_                                \
+              , boost_param_parameters_                                      \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
+    )
+/**/
+
+// Produces a name for a result type metafunction for the no-spec function
+// named base.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(base, is_const)         \
+    BOOST_PP_CAT(                                                            \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_no_spec_result_const_                            \
+              , boost_param_no_spec_result_                                  \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )
 /**/
 
 // Produces a name for a result type metafunction for the function named base.
-#define BOOST_PARAMETER_FUNCTION_RESULT_NAME(base)                           \
+#define BOOST_PARAMETER_FUNCTION_RESULT_NAME(base, is_const)                 \
     BOOST_PP_CAT(                                                            \
-        BOOST_PP_CAT(boost_param_result_, __LINE__)                          \
-      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(name)                           \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_result_const_                                    \
+              , boost_param_result_                                          \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
+    )
+/**/
+
+// Produces a name for the implementation function to which the no-spec
+// function named base forwards its result type and argument pack.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(base, is_const)           \
+    BOOST_PP_CAT(                                                            \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_no_spec_impl_const                               \
+              , boost_param_no_spec_impl                                     \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )
 /**/
 
@@ -92,8 +138,14 @@
 // daniel: what? how is that relevant? the reason for using CAT()
 // is to make sure base is expanded. i'm not sure we need to here,
 // but it's more stable to do it.
-#define BOOST_PARAMETER_FUNCTION_IMPL_NAME(base)                             \
-    BOOST_PP_CAT(boost_param_impl, BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base))
+#define BOOST_PARAMETER_FUNCTION_IMPL_NAME(base, is_const)                   \
+    BOOST_PP_CAT(                                                            \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(is_const, boost_param_impl_const, boost_param_impl)  \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
+    )
 /**/
 
 #include <boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp>
@@ -102,8 +154,12 @@
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, n)                         \
     BOOST_PP_CAT(                                                            \
         BOOST_PP_CAT(                                                        \
-            BOOST_PP_CAT(boost_param_dispatch_, n)                           \
-          , BOOST_PP_CAT(boost_, __LINE__)                                   \
+            BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                \
+              , boost_param_dispatch_const_                                  \
+              , boost_param_dispatch_                                        \
+            )                                                                \
+          , BOOST_PP_CAT(BOOST_PP_CAT(n, boost_), __LINE__)                  \
         )                                                                    \
       , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                \
             BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                   \

--- a/include/boost/parameter/aux_/preprocessor/impl/specification.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/specification.hpp
@@ -67,15 +67,23 @@
 
 #include <boost/parameter/parameters.hpp>
 #include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
+#include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 
 // Expands to a boost::parameter::parameters<> specialization for the
 // function named base.  Used by BOOST_PARAMETER_CONSTRUCTOR_AUX and
 // BOOST_PARAMETER_FUNCTION_HEAD for their respective ParameterSpec models.
-#define BOOST_PARAMETER_SPECIFICATION(tag_ns, base, split_args)              \
+#define BOOST_PARAMETER_SPECIFICATION(tag_ns, base, split_args, is_const)    \
     template <typename BoostParameterDummy>                                  \
     struct BOOST_PP_CAT(                                                     \
-        BOOST_PP_CAT(boost_param_params_, __LINE__)                          \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_params_const_                                    \
+              , boost_param_params_                                          \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
       , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     ) : ::boost::parameter::parameters<                                      \
             BOOST_PP_SEQ_FOR_EACH_I(                                         \
@@ -85,7 +93,14 @@
     {                                                                        \
     };                                                                       \
     typedef BOOST_PP_CAT(                                                    \
-        BOOST_PP_CAT(boost_param_params_, __LINE__)                          \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_params_const_                                    \
+              , boost_param_params_                                          \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
       , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )<int>
 /**/

--- a/include/boost/parameter/aux_/preprocessor/no_perfect_forwarding_begin.hpp
+++ b/include/boost/parameter/aux_/preprocessor/no_perfect_forwarding_begin.hpp
@@ -12,8 +12,47 @@
 #define BOOST_PARAMETER_satisfies_end(z, n, false_t) ,false_t>
 /**/
 
-#include <boost/preprocessor/seq/elem.hpp>
 #include <boost/preprocessor/cat.hpp>
+
+#define BOOST_PARAMETER_make_simple_arg_list_type_prefix(z, n, prefix)       \
+    ::boost::parameter::aux::arg_list<BOOST_PP_CAT(prefix, n)
+/**/
+
+#include <boost/preprocessor/repetition/enum.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+
+#define BOOST_PARAMETER_make_simple_arg_list_type(z, n, prefix)              \
+    BOOST_PP_CAT(BOOST_PP_ENUM_, z)(                                         \
+        n, BOOST_PARAMETER_make_simple_arg_list_type_prefix, prefix          \
+    ) BOOST_PP_CAT(BOOST_PP_REPEAT_, z)(n, BOOST_PARAMETER_right_angle, _)
+/**/
+
+#include <boost/parameter/aux_/void.hpp>
+#include <boost/preprocessor/arithmetic/sub.hpp>
+#include <boost/preprocessor/facilities/intercept.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+#include <boost/preprocessor/repetition/enum_trailing_params.hpp>
+
+#define BOOST_PARAMETER_make_simple_arg_list_function_call_op(z, n, prefix)  \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename prefix)>                 \
+    inline BOOST_PARAMETER_make_simple_arg_list_type(z, n, prefix)           \
+        operator()(                                                          \
+            BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, prefix, const& a)            \
+        ) const                                                              \
+    {                                                                        \
+        return BOOST_PARAMETER_make_simple_arg_list_type(z, n, prefix)(      \
+            BOOST_PP_ENUM_PARAMS_Z(z, n, a)                                  \
+            BOOST_PP_ENUM_TRAILING_PARAMS_Z(                                 \
+                z                                                            \
+              , BOOST_PP_SUB(BOOST_PARAMETER_MAX_ARITY, n)                   \
+              , ::boost::parameter::aux::void_reference() BOOST_PP_INTERCEPT \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+#include <boost/preprocessor/seq/elem.hpp>
 
 // Generates:
 //
@@ -30,9 +69,7 @@
         BOOST_PP_CAT(BOOST_PP_SEQ_ELEM(2, names), n),
 /**/
 
-#include <boost/parameter/aux_/void.hpp>
 #include <boost/mpl/identity.hpp>
-#include <boost/preprocessor/repetition/repeat.hpp>
 
 #define BOOST_PARAMETER_build_arg_list(n, make, param_spec, arg_type)        \
     BOOST_PP_REPEAT(                                                         \
@@ -94,19 +131,12 @@
     >
 /**/
 
-#include <boost/preprocessor/arithmetic/sub.hpp>
-
 #define BOOST_PARAMETER_function_call_arg_pack_init(z, n, limit)             \
     BOOST_PP_CAT(a, BOOST_PP_SUB(limit, n))
 /**/
 
 #include <boost/parameter/aux_/preprocessor/binary_seq_to_args.hpp>
 #include <boost/preprocessor/arithmetic/dec.hpp>
-#include <boost/preprocessor/facilities/intercept.hpp>
-#include <boost/preprocessor/repetition/enum.hpp>
-#include <boost/preprocessor/repetition/enum_params.hpp>
-#include <boost/preprocessor/repetition/enum_binary_params.hpp>
-#include <boost/preprocessor/repetition/enum_trailing_params.hpp>
 #include <boost/preprocessor/seq/seq.hpp>
 
 #define BOOST_PARAMETER_function_call_op_overload_R(r, seq)                  \

--- a/include/boost/parameter/aux_/preprocessor/no_perfect_forwarding_end.hpp
+++ b/include/boost/parameter/aux_/preprocessor/no_perfect_forwarding_end.hpp
@@ -19,6 +19,9 @@
 #undef BOOST_PARAMETER_make_deduced_list
 #undef BOOST_PARAMETER_build_arg_list
 #undef BOOST_PARAMETER_make_arg_list
+#undef BOOST_PARAMETER_make_simple_arg_list_function_call_op
+#undef BOOST_PARAMETER_make_simple_arg_list_type
+#undef BOOST_PARAMETER_make_simple_arg_list_type_prefix
 #undef BOOST_PARAMETER_satisfies_end
 #undef BOOST_PARAMETER_right_angle
 

--- a/include/boost/parameter/config.hpp
+++ b/include/boost/parameter/config.hpp
@@ -17,7 +17,10 @@
 // rvalue references, needed throughout; variadic templates, needed by
 // parameters; and the ability to handle multiple parameter packs, needed by
 // parameters.  Older versions of GCC either don't have the latter ability or
-// cannot disambiguate between keyword's overloaded operators.
+// cannot disambiguate between keyword's overloaded operators.  Older versions
+// of Clang either fail to compile due to differences in length between
+// parameter packs 'Args' and 'args' or fail at runtime due to segmentation
+// faults.
 // -- Cromwell D. Enage
 #if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
     !defined(BOOST_PARAMETER_DISABLE_PERFECT_FORWARDING) && \
@@ -25,8 +28,13 @@
     !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING) && \
     !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
     !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
-    !BOOST_WORKAROUND(BOOST_GCC, < 40900)
+    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && !( \
+        defined(BOOST_CLANG) && (1 == BOOST_CLANG) && ( \
+            (__clang_major__ < 3) || ( \
+                (3 == __clang_major__) && (__clang_minor__ < 2) \
+            ) \
+        ) \
+    ) && !BOOST_WORKAROUND(BOOST_GCC, < 40900)
 #define BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 #endif
 
@@ -42,7 +50,9 @@
 #define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY 0
 #endif
 #if !defined(BOOST_PARAMETER_MAX_ARITY)
-#define BOOST_PARAMETER_MAX_ARITY 8
+// Libraries such as Boost.Log need a higher maximum arity
+// than the old value of 8. -- Cromwell D. Enage
+#define BOOST_PARAMETER_MAX_ARITY 20
 #endif
 #endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 #endif  // include guard

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -81,6 +81,15 @@ alias parameter_standard_tests
         :
             <preserve-target-tests>off
     ]
+    [ run preprocessor_eval_cat_no_spec.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+        :
+        :
+            <preserve-target-tests>off
+    ]
     [ run normalized_argument_types.cpp
         :
         :
@@ -127,6 +136,15 @@ alias parameter_standard_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run parameterized_inheritance.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=3
         :
         :
             <preserve-target-tests>off
@@ -179,11 +197,15 @@ alias parameter_standard_tests
     [ compile function_type_tpl_param.cpp ]
     [ compile-fail duplicates.cpp
         :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
         :
             duplicates_fail
     ]
     [ compile-fail deduced_unmatched_arg.cpp
         :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
         :
             deduced_unmatched_arg_fail
     ]
@@ -217,6 +239,8 @@ alias parameter_standard_tests
     ]
     [ compile-fail deduced.cpp
         :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE
         :
             deduced_fail
@@ -225,6 +249,46 @@ alias parameter_standard_tests
 
 alias parameter_literate_tests
     :
+    [ run literate/building-argumentpacks0.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=2
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=3
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run literate/deduced-parameters0.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=5
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run literate/deduced-template-parameters0.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run literate/default-expression-evaluation0.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=5
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
+        :
+        :
+            <preserve-target-tests>off
+    ]
     [ run literate/extracting-parameter-types0.cpp
         :
         :
@@ -241,27 +305,7 @@ alias parameter_literate_tests
         :
             <preserve-target-tests>off
     ]
-    [ run literate/top-level0.cpp
-        :
-        :
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=3
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=4
-        :
-        :
-            <preserve-target-tests>off
-    ]
-    [ run literate/predicate-requirements0.cpp
-        :
-        :
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=5
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
-        :
-        :
-            <preserve-target-tests>off
-    ]
-    [ run literate/building-argumentpacks0.cpp
+    [ run literate/fine-grained-name-control0.cpp
         :
         :
         :
@@ -337,37 +381,7 @@ alias parameter_literate_tests
         :
             <preserve-target-tests>off
     ]
-    [ run literate/deduced-template-parameters0.cpp
-        :
-        :
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=4
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-        :
-        :
-            <preserve-target-tests>off
-    ]
-    [ run literate/deduced-parameters0.cpp
-        :
-        :
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=5
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
-        :
-        :
-            <preserve-target-tests>off
-    ]
-    [ run literate/default-expression-evaluation0.cpp
-        :
-        :
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=5
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
-        :
-        :
-            <preserve-target-tests>off
-    ]
-    [ run literate/fine-grained-name-control0.cpp
+    [ run literate/parameter-enabled-function-call-operators0.cpp
         :
         :
         :
@@ -377,18 +391,50 @@ alias parameter_literate_tests
         :
             <preserve-target-tests>off
     ]
-    [ compile literate/template-keywords0.cpp ]
-    [ compile literate/template-keywords1.cpp ]
-    [ compile literate/headers-and-namespaces0.cpp ]
-    [ compile literate/handling-out-parameters0.cpp
+    [ run literate/parameter-enabled-member-functions0.cpp
         :
-            <define>BOOST_PARAMETER_MAX_ARITY=5
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=2
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=3
+        :
+        :
+            <preserve-target-tests>off
     ]
-    [ compile literate/writing-the-function0.cpp
+    [ run literate/predicate-requirements0.cpp
+        :
+        :
         :
             <define>BOOST_PARAMETER_MAX_ARITY=5
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run literate/static-member-functions0.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=2
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=3
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run literate/top-level0.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=3
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=4
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ compile literate/class-template-skeleton0.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
     ]
     [ compile literate/defining-the-keywords0.cpp ]
     [ compile literate/defining-the-keywords1.cpp ]
@@ -397,12 +443,18 @@ alias parameter_literate_tests
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
     ]
+    [ compile literate/handling-out-parameters0.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=5
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
+    ]
+    [ compile literate/headers-and-namespaces0.cpp ]
     [ compile literate/optional-parameters0.cpp
         :
             <define>BOOST_PARAMETER_MAX_ARITY=5
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
     ]
-    [ compile literate/static-member-functions0.cpp
+    [ compile literate/parameter-enabled-member-functions1.cpp
         :
             <define>BOOST_PARAMETER_MAX_ARITY=2
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=3
@@ -412,20 +464,12 @@ alias parameter_literate_tests
             <define>BOOST_PARAMETER_MAX_ARITY=2
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=3
     ]
-    [ compile literate/class-template-skeleton0.cpp
+    [ compile literate/template-keywords0.cpp ]
+    [ compile literate/template-keywords1.cpp ]
+    [ compile literate/writing-the-function0.cpp
         :
-            <define>BOOST_PARAMETER_MAX_ARITY=4
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-    ]
-    [ compile literate/parameter-enabled-member-functions0.cpp
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=2
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=3
-    ]
-    [ compile literate/parameter-enabled-member-functions1.cpp
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=2
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=3
+            <define>BOOST_PARAMETER_MAX_ARITY=5
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=6
     ]
     ;
 
@@ -726,11 +770,56 @@ alias parameter_msvc_fail_tests ;
 
 alias parameter_msvc_fail_tests
     :
+    [ compile-fail preprocessor_deduced.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_deduced_msvc08_fail
+    ]
+    :
+        <toolset>msvc
+        <toolset-msvc:version>8.0
+    ;
+
+alias parameter_msvc_fail_tests
+    :
+    [ compile-fail preprocessor_deduced.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_deduced_msvc09_fail
+    ]
+    :
+        <toolset>msvc
+        <toolset-msvc:version>9.0
+    ;
+
+alias parameter_msvc_fail_tests
+    :
+    [ compile-fail preprocessor_deduced.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_deduced_msvc10_fail
+    ]
+    :
+        <toolset>msvc
+        <toolset-msvc:version>10.0
+    ;
+
+alias parameter_msvc_fail_tests
+    :
     [ compile-fail compose.cpp
         :
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
-            compose_msvc11_fail_11
+            compose_msvc11_fail
+    ]
+    [ compile-fail preprocessor_deduced.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_deduced_msvc11_fail
     ]
     :
         <toolset>msvc
@@ -755,6 +844,13 @@ alias parameter_msvc_fail_tests
         :
             preproc_eval_cat_msvc12_fail
     ]
+    [ compile-fail preprocessor_eval_cat_no_spec.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_eval_cat_no_spec_msvc12_fail
+    ]
     :
         <toolset>msvc
         <toolset-msvc:version>12.0
@@ -778,6 +874,13 @@ alias parameter_msvc_fail_tests
         :
             preproc_eval_cat_msvc14_0_fail
     ]
+    [ compile-fail preprocessor_eval_cat_no_spec.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_eval_cat_no_spec_msvc14_0_fail
+    ]
     :
         <toolset>msvc
         <toolset-msvc:version>14.0
@@ -800,6 +903,13 @@ alias parameter_msvc_fail_tests
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
             preproc_eval_cat_msvc14_1_fail
+    ]
+    [ compile-fail preprocessor_eval_cat_no_spec.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_eval_cat_no_spec_msvc14_1_fail
     ]
     :
         <toolset>msvc

--- a/test/basics.hpp
+++ b/test/basics.hpp
@@ -9,14 +9,13 @@
 
 #include <boost/parameter.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #if (BOOST_PARAMETER_MAX_ARITY < 4)
 #error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
 #endif
-#if (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
+#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+    (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
 #error Define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY \
 as 5 or greater.
-#endif
 #endif
 
 #include <boost/mpl/bool.hpp>

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -56,6 +56,15 @@ namespace test {
             BOOST_MPL_ASSERT((boost::parameter::is_argument_pack<ArgPack>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::a0>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::a1>));
+            BOOST_MPL_ASSERT_NOT((
+                boost::mpl::has_key<ArgPack,param::tag::lrc>
+            ));
+            BOOST_MPL_ASSERT_NOT((
+                boost::mpl::has_key<ArgPack,param::tag::lr>
+            ));
+            BOOST_MPL_ASSERT_NOT((
+                boost::mpl::has_key<ArgPack,param::tag::rr>
+            ));
             BOOST_MPL_ASSERT((
                 boost::mpl::equal_to<
                     typename boost::mpl::count<ArgPack,param::tag::a0>::type
@@ -181,6 +190,18 @@ namespace test {
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::rr>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::lr>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::lrc>));
+            BOOST_MPL_ASSERT_NOT((
+                boost::mpl::has_key<ArgPack,param::tag::a0>
+            ));
+            BOOST_MPL_ASSERT_NOT((
+                boost::mpl::has_key<ArgPack,param::tag::a1>
+            ));
+            BOOST_MPL_ASSERT_NOT((
+                boost::mpl::has_key<ArgPack,param::tag::a2>
+            ));
+            BOOST_MPL_ASSERT_NOT((
+                boost::mpl::has_key<ArgPack,param::tag::a3>
+            ));
             BOOST_MPL_ASSERT((
                 boost::mpl::equal_to<
                     typename boost::mpl::count<ArgPack,param::tag::rr>::type

--- a/test/earwicker.cpp
+++ b/test/earwicker.cpp
@@ -5,14 +5,13 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #if (BOOST_PARAMETER_MAX_ARITY < 4)
 #error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
 #endif
-#if (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
+#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+    (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
 #error Define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY \
 as 5 or greater.
-#endif
 #endif
 
 #include <boost/parameter/name.hpp>

--- a/test/evaluate_category.cpp
+++ b/test/evaluate_category.cpp
@@ -5,17 +5,16 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #if (BOOST_PARAMETER_MAX_ARITY < 4)
 #error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
 #endif
-#if (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
+#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+    (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
 #error Define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY \
 as 5 or greater.
 #endif
-#endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -27,6 +26,12 @@ namespace test {
 #else
     BOOST_PARAMETER_NAME((_rr0, keywords) rr0)
 #endif
+} // namespace test
+
+#include <boost/parameter/parameters.hpp>
+#include <boost/parameter/required.hpp>
+
+namespace test {
 
     struct f_parameters
       : boost::parameter::parameters<
@@ -53,11 +58,11 @@ namespace test {
         {
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , A<T>::evaluate_category(args[test::_lrc0])
+              , test::A<T>::evaluate_category(args[test::_lrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , A<T>::evaluate_category(args[test::_lr0])
+              , test::A<T>::evaluate_category(args[test::_lr0])
             );
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 
@@ -65,38 +70,39 @@ namespace test {
             {
                 BOOST_TEST_EQ(
                     test::passed_by_lvalue_reference_to_const
-                  , A<T>::evaluate_category(args[test::_rrc0])
+                  , test::A<T>::evaluate_category(args[test::_rrc0])
                 );
                 BOOST_TEST_EQ(
                     test::passed_by_lvalue_reference_to_const
-                  , A<T>::evaluate_category(args[test::_rr0])
+                  , test::A<T>::evaluate_category(args[test::_rr0])
                 );
             }
             else
             {
                 BOOST_TEST_EQ(
                     test::passed_by_rvalue_reference_to_const
-                  , A<T>::evaluate_category(args[test::_rrc0])
+                  , test::A<T>::evaluate_category(args[test::_rrc0])
                 );
                 BOOST_TEST_EQ(
                     test::passed_by_rvalue_reference
-                  , A<T>::evaluate_category(args[test::_rr0])
+                  , test::A<T>::evaluate_category(args[test::_rr0])
                 );
             }
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , A<T>::evaluate_category(args[test::_rrc0])
+              , test::A<T>::evaluate_category(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , A<T>::evaluate_category(args[test::_rr0])
+              , test::A<T>::evaluate_category(args[test::_rr0])
             );
 #endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
         }
     };
 } // namespace test
 
+#include <boost/parameter/deduced.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/if.hpp>
@@ -131,6 +137,7 @@ namespace test {
     };
 } // namespace test
 
+#include <boost/parameter/value_type.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
 namespace test {

--- a/test/evaluate_category_10.cpp
+++ b/test/evaluate_category_10.cpp
@@ -5,12 +5,11 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_MAX_ARITY < 10)
+#if (BOOST_PARAMETER_MAX_ARITY < 10)
 #error Define BOOST_PARAMETER_MAX_ARITY as 10 or greater.
 #endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -28,6 +27,13 @@ namespace test {
     BOOST_PARAMETER_NAME((_lrc2, keywords) in(lrc2))
     BOOST_PARAMETER_NAME((_lr2, keywords) out(lr2))
     BOOST_PARAMETER_NAME((_rr2, keywords) rr2)
+} // namespace test
+
+#include <boost/parameter/parameters.hpp>
+#include <boost/parameter/required.hpp>
+#include <boost/parameter/optional.hpp>
+
+namespace test {
 
     struct g_parameters
       : boost::parameter::parameters<
@@ -58,67 +64,67 @@ namespace test {
         {
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_lrc0])
+              , test::U::evaluate_category<0>(args[test::_lrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<0>(args[test::_lr0])
+              , test::U::evaluate_category<0>(args[test::_lr0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_lrc1])
+              , test::U::evaluate_category<1>(args[test::_lrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<1>(args[test::_lr1])
+              , test::U::evaluate_category<1>(args[test::_lr1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_lrc2 | test::lvalue_const_bitset<2>()]
                 )
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_lr2 || test::lvalue_bitset_function<2>()]
                 )
             );
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rrc0])
+              , test::U::evaluate_category<0>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference
-              , U::evaluate_category<0>(args[test::_rr0])
+              , test::U::evaluate_category<0>(args[test::_rr0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_rrc1])
+              , test::U::evaluate_category<1>(args[test::_rrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_rr2 || test::rvalue_bitset_function<2>()]
                 )
             );
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rrc0])
+              , test::U::evaluate_category<0>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rr0])
+              , test::U::evaluate_category<0>(args[test::_rr0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_rrc1])
+              , test::U::evaluate_category<1>(args[test::_rrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_rr2 || test::rvalue_bitset_function<2>()]
                 )
             );

--- a/test/evaluate_category_16.cpp
+++ b/test/evaluate_category_16.cpp
@@ -5,12 +5,11 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_MAX_ARITY < 16)
+#if (BOOST_PARAMETER_MAX_ARITY < 16)
 #error Define BOOST_PARAMETER_MAX_ARITY as 16 or greater.
 #endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -30,6 +29,13 @@ namespace test {
     BOOST_PARAMETER_NAME((_rrc5, keywords) in(rrc5))
     BOOST_PARAMETER_NAME((_rrc6, keywords) in(rrc6))
     BOOST_PARAMETER_NAME((_rrc7, keywords) in(rrc7))
+} // namespace test
+
+#include <boost/parameter/parameters.hpp>
+#include <boost/parameter/required.hpp>
+#include <boost/parameter/optional.hpp>
+
+namespace test {
 
     struct h_parameters
       : boost::parameter::parameters<
@@ -66,29 +72,29 @@ namespace test {
         {
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_lrc0])
+              , test::U::evaluate_category<0>(args[test::_lrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<1>(args[test::_lr1])
+              , test::U::evaluate_category<1>(args[test::_lr1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<2>(args[test::_lr2])
+              , test::U::evaluate_category<2>(args[test::_lr2])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<3>(args[test::_lrc3])
+              , test::U::evaluate_category<3>(args[test::_lrc3])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<4>(
+              , test::U::evaluate_category<4>(
                     args[test::_lrc4 | test::lvalue_const_bitset<4>()]
                 )
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<5>(
+              , test::U::evaluate_category<5>(
                     args[
                         test::_lr5 || test::lvalue_bitset_function<5>()
                     ]
@@ -96,13 +102,13 @@ namespace test {
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<6>(
+              , test::U::evaluate_category<6>(
                     args[test::_lr6 | test::lvalue_bitset<6>()]
                 )
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<7>(
+              , test::U::evaluate_category<7>(
                     args[
                         test::_lrc7 || test::lvalue_const_bitset_function<7>()
                     ]
@@ -111,29 +117,29 @@ namespace test {
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rrc0])
+              , test::U::evaluate_category<0>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_rrc1])
+              , test::U::evaluate_category<1>(args[test::_rrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<2>(args[test::_rrc2])
+              , test::U::evaluate_category<2>(args[test::_rrc2])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<3>(args[test::_rrc3])
+              , test::U::evaluate_category<3>(args[test::_rrc3])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<4>(
+              , test::U::evaluate_category<4>(
                     args[test::_rrc4 | test::rvalue_const_bitset<4>()]
                 )
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<5>(
+              , test::U::evaluate_category<5>(
                     args[
                         test::_rrc5 || test::rvalue_const_bitset_function<5>()
                     ]
@@ -141,13 +147,13 @@ namespace test {
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<6>(
+              , test::U::evaluate_category<6>(
                     args[test::_rrc6 | test::rvalue_const_bitset<6>()]
                 )
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<7>(
+              , test::U::evaluate_category<7>(
                     args[
                         test::_rrc7 || test::rvalue_const_bitset_function<7>()
                     ]
@@ -156,29 +162,29 @@ namespace test {
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rrc0])
+              , test::U::evaluate_category<0>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_rrc1])
+              , test::U::evaluate_category<1>(args[test::_rrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(args[test::_rrc2])
+              , test::U::evaluate_category<2>(args[test::_rrc2])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<3>(args[test::_rrc3])
+              , test::U::evaluate_category<3>(args[test::_rrc3])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<4>(
+              , test::U::evaluate_category<4>(
                     args[test::_rrc4 | test::rvalue_const_bitset<4>()]
                 )
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<5>(
+              , test::U::evaluate_category<5>(
                     args[
                         test::_rrc5 || test::rvalue_const_bitset_function<5>()
                     ]
@@ -186,13 +192,13 @@ namespace test {
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<6>(
+              , test::U::evaluate_category<6>(
                     args[test::_rrc6 | test::rvalue_const_bitset<6>()]
                 )
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<7>(
+              , test::U::evaluate_category<7>(
                     args[
                         test::_rrc7 || test::rvalue_const_bitset_function<7>()
                     ]

--- a/test/literate/default-expression-evaluation0.cpp
+++ b/test/literate/default-expression-evaluation0.cpp
@@ -20,11 +20,16 @@ BOOST_PARAMETER_FUNCTION((void), depth_first_search, tag,
     )
 )
 {
-    std::cout << "graph=" << graph << std::endl;
-    std::cout << "visitor=" << visitor << std::endl;
-    std::cout << "root_vertex=" << root_vertex << std::endl;
-    std::cout << "index_map=" << index_map << std::endl;
-    std::cout << "color_map=" << color_map << std::endl;
+    std::cout << "graph=" << graph;
+    std::cout << std::endl;
+    std::cout << "visitor=" << visitor;
+    std::cout << std::endl;
+    std::cout << "root_vertex=" << root_vertex;
+    std::cout << std::endl;
+    std::cout << "index_map=" << index_map;
+    std::cout << std::endl;
+    std::cout << "color_map=" << color_map;
+    std::cout << std::endl;
 }
 
 #include <boost/core/lightweight_test.hpp>

--- a/test/literate/parameter-enabled-function-call-operators0.cpp
+++ b/test/literate/parameter-enabled-function-call-operators0.cpp
@@ -9,8 +9,8 @@ BOOST_PARAMETER_NAME(arg2)
 
 struct callable2
 {
-    BOOST_PARAMETER_CONST_MEMBER_FUNCTION(
-        (void), call, tag, (required (arg1,(int))(arg2,(int)))
+    BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR(
+        (void), tag, (required (arg1,(int))(arg2,(int)))
     )
     {
         std::cout << arg1 << ", " << arg2 << std::endl;
@@ -23,7 +23,7 @@ int main()
 {
     callable2 c2;
     callable2 const& c2_const = c2;
-    c2_const.call(1, 2);
+    c2_const(1, 2);
     return boost::report_errors();
 }
 

--- a/test/literate/static-member-functions0.cpp
+++ b/test/literate/static-member-functions0.cpp
@@ -16,3 +16,12 @@ struct somebody
     }
 };
 
+#include <boost/core/lightweight_test.hpp>
+
+int main()
+{
+    somebody::f();
+    somebody::f(4);
+    return boost::report_errors();
+}
+

--- a/test/macros_eval_category.cpp
+++ b/test/macros_eval_category.cpp
@@ -5,8 +5,7 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_MAX_ARITY < 10)
+#if (BOOST_PARAMETER_MAX_ARITY < 10)
 #error Define BOOST_PARAMETER_MAX_ARITY as 10 or greater.
 #endif
 

--- a/test/normalized_argument_types.cpp
+++ b/test/normalized_argument_types.cpp
@@ -5,17 +5,14 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #if (BOOST_PARAMETER_MAX_ARITY < 2)
 #error Define BOOST_PARAMETER_MAX_ARITY as 2 or greater.
 #endif
-#if (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 3)
+#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+    (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 3)
 #error Define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY \
 as 3 or greater.
 #endif
-#endif
-
-#include <boost/parameter.hpp>
 
 namespace test {
 
@@ -50,11 +47,17 @@ namespace test {
     };
 
     std::size_t count_instances::count = 0;
+} // namespace test
+
+#include <boost/parameter/name.hpp>
+
+namespace test {
 
     BOOST_PARAMETER_NAME(x)
     BOOST_PARAMETER_NAME(y)
 } // namespace test
 
+#include <boost/parameter/preprocessor.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/assert.hpp>

--- a/test/ntp.cpp
+++ b/test/ntp.cpp
@@ -5,8 +5,7 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_MAX_ARITY < 4)
+#if (BOOST_PARAMETER_MAX_ARITY < 4)
 #error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
 #endif
 

--- a/test/optional_deduced_sfinae.cpp
+++ b/test/optional_deduced_sfinae.cpp
@@ -5,14 +5,13 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #if (BOOST_PARAMETER_MAX_ARITY < 2)
 #error Define BOOST_PARAMETER_MAX_ARITY as 2 or greater.
 #endif
-#if (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 2)
+#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+    (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 2)
 #error Define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY \
 as 2 or greater.
-#endif
 #endif
 
 #include <boost/parameter/preprocessor.hpp>

--- a/test/parameterized_inheritance.cpp
+++ b/test/parameterized_inheritance.cpp
@@ -1,0 +1,263 @@
+// Copyright Cromwell D. Enage 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/parameter/config.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 3)
+#error Define BOOST_PARAMETER_MAX_ARITY as 3 or greater.
+#endif
+
+#include <boost/parameter/name.hpp>
+
+namespace test {
+
+    BOOST_PARAMETER_NAME(a0)
+    BOOST_PARAMETER_NAME(a1)
+    BOOST_PARAMETER_NAME(a2)
+}
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/parameter/is_argument_pack.hpp>
+#include <boost/type_traits/is_convertible.hpp>
+#include <boost/core/enable_if.hpp>
+#endif
+
+namespace test {
+
+#if !defined(BOOST_NO_SFINAE)
+    struct _enabler
+    {
+    };
+#endif
+
+    template <typename T>
+    class backend0
+    {
+        T _a0;
+
+     public:
+        template <typename ArgPack>
+        explicit backend0(
+            ArgPack const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::enable_if<
+                boost::parameter::is_argument_pack<ArgPack>
+              , test::_enabler
+            >::type = test::_enabler()
+#endif
+        ) : _a0(args[test::_a0])
+        {
+        }
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename U>
+        backend0(
+            backend0<U> const& copy
+          , typename boost::enable_if<
+                boost::is_convertible<U,T>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : _a0(copy.get_a0())
+        {
+        }
+#endif
+
+        template <typename Iterator>
+        backend0(Iterator itr, Iterator itr_end) : _a0(itr, itr_end)
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->_a0;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            this->_a0 = args[test::_a0];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend1 : public B
+    {
+        T _a1;
+
+     public:
+        template <typename ArgPack>
+        explicit backend1(
+            ArgPack const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::enable_if<
+                boost::parameter::is_argument_pack<ArgPack>
+              , test::_enabler
+            >::type = test::_enabler()
+#endif
+        ) : B(args), _a1(args[test::_a1])
+        {
+        }
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename Derived>
+        backend1(
+            Derived const& copy
+          , typename boost::disable_if<
+                boost::parameter::is_argument_pack<Derived>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : B(copy), _a1(copy.get_a1())
+        {
+        }
+#endif
+
+        T const& get_a1() const
+        {
+            return this->_a1;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->_a1 = args[test::_a1];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend2 : public B
+    {
+        T _a2;
+
+     public:
+        template <typename ArgPack>
+        explicit backend2(
+            ArgPack const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::enable_if<
+                boost::parameter::is_argument_pack<ArgPack>
+              , test::_enabler
+            >::type = test::_enabler()
+#endif
+        ) : B(args), _a2(args[test::_a2])
+        {
+        }
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename Derived>
+        backend2(
+            Derived const& copy
+          , typename boost::disable_if<
+                boost::parameter::is_argument_pack<Derived>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : B(copy), _a2(copy.get_a2())
+        {
+        }
+#endif
+
+        T const& get_a2() const
+        {
+            return this->_a2;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->_a2 = args[test::_a2];
+        }
+    };
+}
+
+#include <boost/parameter/preprocessor.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/parameter/are_tagged_arguments.hpp>
+#endif
+
+namespace test {
+
+    template <typename B>
+    struct frontend : public B
+    {
+        BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(frontend, (B))
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename Iterator>
+        frontend(
+            Iterator itr
+          , Iterator itr_end
+          , typename boost::disable_if<
+                boost::parameter::are_tagged_arguments<Iterator>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : B(itr, itr_end)
+        {
+        }
+
+        template <typename O>
+        frontend(frontend<O> const& copy) : B(copy)
+        {
+        }
+#endif
+
+        BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((void), initialize)
+        {
+            this->initialize_impl(args);
+        }
+
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR((void))
+        {
+            this->initialize_impl(args);
+        }
+    };
+} // namespace test
+
+#include <boost/core/lightweight_test.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <string>
+#endif
+
+int main()
+{
+    char const* p = "foo";
+    char const* q = "bar";
+    test::frontend<
+        test::backend2<test::backend1<test::backend0<char const*>, char>, int>
+    > composed_obj0(test::_a2 = 4, test::_a1 = ' ', test::_a0 = p);
+#if defined(BOOST_NO_SFINAE)
+    test::frontend<
+        test::backend1<test::backend2<test::backend0<char const*>, int>, char>
+    > composed_obj1(test::_a0 = p, test::_a1 = ' ', test::_a2 = 4);
+#else
+    test::frontend<
+        test::backend1<test::backend2<test::backend0<char const*>, int>, char>
+    > composed_obj1(composed_obj0);
+#endif
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+    composed_obj0.initialize(test::_a0 = q, test::_a1 = '!', test::_a2 = 8);
+    composed_obj1.initialize(test::_a2 = 8, test::_a1 = '!', test::_a0 = q);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+    composed_obj0(test::_a2 = 8, test::_a1 = '!', test::_a0 = q);
+    composed_obj1(test::_a0 = q, test::_a1 = '!', test::_a2 = 8);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+#if !defined(BOOST_NO_SFINAE)
+    test::frontend<test::backend0<std::string> > string_wrap(p, p + 3);
+    BOOST_TEST_EQ(string_wrap.get_a0(), std::string(p));
+#endif
+    return boost::report_errors();
+}
+

--- a/test/preprocessor_eval_cat_8.cpp
+++ b/test/preprocessor_eval_cat_8.cpp
@@ -5,12 +5,11 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_MAX_ARITY < 8)
+#if (BOOST_PARAMETER_MAX_ARITY < 8)
 #error Define BOOST_PARAMETER_MAX_ARITY as 8 or greater.
 #endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -28,6 +27,7 @@ namespace test {
     BOOST_PARAMETER_NAME((_rr1, kw) rr1)
 } // namespace test
 
+#include <boost/parameter/preprocessor.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/if.hpp>
@@ -102,54 +102,54 @@ namespace test {
         )
         {
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(lrc0)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<0>(lrc0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference
-              , U::evaluate_category<1>(lr0)
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<1>(lr0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<4>(lrc1)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<4>(lrc1)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference
-              , U::evaluate_category<5>(lr1)
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<5>(lr1)
             );
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference_to_const
-              , U::evaluate_category<2>(std::forward<rrc0_type>(rrc0))
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<2>(std::forward<rrc0_type>(rrc0))
             );
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference
-              , U::evaluate_category<3>(std::forward<rr0_type>(rr0))
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<3>(std::forward<rr0_type>(rr0))
             );
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference_to_const
-              , U::evaluate_category<6>(std::forward<rrc1_type>(rrc1))
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<6>(std::forward<rrc1_type>(rrc1))
             );
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference
-              , U::evaluate_category<7>(std::forward<rr1_type>(rr1))
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<7>(std::forward<rr1_type>(rr1))
             );
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(rrc0)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<2>(rrc0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<3>(rr0)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<3>(rr0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<6>(rrc1)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<6>(rrc1)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<7>(rr1)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<7>(rr1)
             );
 #endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 

--- a/test/preprocessor_eval_cat_no_spec.cpp
+++ b/test/preprocessor_eval_cat_no_spec.cpp
@@ -1,31 +1,30 @@
-// Copyright Cromwell D. Enage 2017.
+// Copyright Cromwell D. Enage 2018.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/parameter/config.hpp>
 
-#if (BOOST_PARAMETER_MAX_ARITY < 4)
-#error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
-#endif
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
-#error Define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY \
-as 5 or greater.
+#if (BOOST_PARAMETER_MAX_ARITY < 8)
+#error Define BOOST_PARAMETER_MAX_ARITY as 8 or greater.
 #endif
 
 #include <boost/parameter/name.hpp>
 
 namespace test {
 
-    BOOST_PARAMETER_NAME((_lrc0, kw) in(lrc0))
-    BOOST_PARAMETER_NAME((_lr0, kw) in_out(lr0))
-    BOOST_PARAMETER_NAME((_rrc0, kw) in(rrc0))
+    BOOST_PARAMETER_NAME((_lrc0, kw0) in(lrc0))
+    BOOST_PARAMETER_NAME((_lr0, kw1) in_out(lr0))
+    BOOST_PARAMETER_NAME((_rrc0, kw2) in(rrc0))
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
-    BOOST_PARAMETER_NAME((_rr0, kw) consume(rr0))
+    BOOST_PARAMETER_NAME((_rr0, kw3) consume(rr0))
 #else
-    BOOST_PARAMETER_NAME((_rr0, kw) rr0)
+    BOOST_PARAMETER_NAME((_rr0, kw3) rr0)
 #endif
+    BOOST_PARAMETER_NAME((_lrc1, kw4) in(lrc1))
+    BOOST_PARAMETER_NAME((_lr1, kw5) out(lr1))
+    BOOST_PARAMETER_NAME((_rrc1, kw6) in(rrc1))
+    BOOST_PARAMETER_NAME((_rr1, kw7) rr1)
 } // namespace test
 
 #include <boost/parameter/preprocessor.hpp>
@@ -33,66 +32,41 @@ namespace test {
 #include <boost/core/lightweight_test.hpp>
 #include <boost/type_traits/is_scalar.hpp>
 #include <boost/type_traits/remove_const.hpp>
-#include <boost/type_traits/remove_reference.hpp>
 #include "evaluate_category.hpp"
-
-#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
-#include <utility>
-#endif
 
 namespace test {
 
-    BOOST_PARAMETER_FUNCTION((bool), evaluate, kw,
-        (required
-            (lrc0, *)
-            (lr0, *)
-            (rrc0, *)
-            (rr0, *)
-        )
-    )
+    BOOST_PARAMETER_NO_SPEC_FUNCTION((bool), evaluate)
     {
         BOOST_TEST((
             test::passed_by_lvalue_reference_to_const == test::A<
                 typename boost::remove_const<
                     typename boost::parameter::value_type<
                         Args
-                      , test::kw::lrc0
+                      , test::kw0::lrc0
                     >::type
                 >::type
             >::evaluate_category(args[test::_lrc0])
         ));
-        BOOST_TEST_EQ(
-            test::passed_by_lvalue_reference_to_const
-          , test::A<
-                typename boost::remove_const<
-                    typename boost::remove_reference<lrc0_type>::type
-                >::type
-            >::evaluate_category(lrc0)
-        );
         BOOST_TEST((
             test::passed_by_lvalue_reference == test::A<
                 typename boost::remove_const<
                     typename boost::parameter::value_type<
                         Args
-                      , test::kw::lr0
+                      , test::kw1::lr0
                     >::type
                 >::type
             >::evaluate_category(args[test::_lr0])
         ));
-        BOOST_TEST_EQ(
-            test::passed_by_lvalue_reference
-          , test::A<
-                typename boost::remove_const<
-                    typename boost::remove_reference<lr0_type>::type
-                >::type
-            >::evaluate_category(lr0)
-        );
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
         if (
             boost::is_scalar<
                 typename boost::remove_const<
-                    typename boost::remove_reference<rrc0_type>::type
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw2::rrc0
+                    >::type
                 >::type
             >::value
         )
@@ -102,37 +76,21 @@ namespace test {
                     typename boost::remove_const<
                         typename boost::parameter::value_type<
                             Args
-                          , test::kw::rrc0
+                          , test::kw2::rrc0
                         >::type
                     >::type
                 >::evaluate_category(args[test::_rrc0])
             ));
-            BOOST_TEST_EQ(
-                test::passed_by_lvalue_reference_to_const
-              , test::A<
-                    typename boost::remove_const<
-                        typename boost::remove_reference<rrc0_type>::type
-                    >::type
-                >::evaluate_category(std::forward<rrc0_type>(rrc0))
-            );
             BOOST_TEST((
                 test::passed_by_lvalue_reference_to_const == test::A<
                     typename boost::remove_const<
                         typename boost::parameter::value_type<
                             Args
-                          , test::kw::rr0
+                          , test::kw3::rr0
                         >::type
                     >::type
                 >::evaluate_category(args[test::_rr0])
             ));
-            BOOST_TEST_EQ(
-                test::passed_by_lvalue_reference_to_const
-              , test::A<
-                    typename boost::remove_const<
-                        typename boost::remove_reference<rr0_type>::type
-                    >::type
-                >::evaluate_category(std::forward<rr0_type>(rr0))
-            );
         }
         else // rrc0's value type isn't scalar
         {
@@ -141,37 +99,21 @@ namespace test {
                     typename boost::remove_const<
                         typename boost::parameter::value_type<
                             Args
-                          , test::kw::rrc0
+                          , test::kw2::rrc0
                         >::type
                     >::type
                 >::evaluate_category(args[test::_rrc0])
             ));
-            BOOST_TEST_EQ(
-                test::passed_by_rvalue_reference_to_const
-              , test::A<
-                    typename boost::remove_const<
-                        typename boost::remove_reference<rrc0_type>::type
-                    >::type
-                >::evaluate_category(std::forward<rrc0_type>(rrc0))
-            );
             BOOST_TEST((
                 test::passed_by_rvalue_reference == test::A<
                     typename boost::remove_const<
                         typename boost::parameter::value_type<
                             Args
-                          , test::kw::rr0
+                          , test::kw3::rr0
                         >::type
                     >::type
                 >::evaluate_category(args[test::_rr0])
             ));
-            BOOST_TEST_EQ(
-                test::passed_by_rvalue_reference
-              , test::A<
-                    typename boost::remove_const<
-                        typename boost::remove_reference<rr0_type>::type
-                    >::type
-                >::evaluate_category(std::forward<rr0_type>(rr0))
-            );
         }
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
         BOOST_TEST((
@@ -179,37 +121,21 @@ namespace test {
                 typename boost::remove_const<
                     typename boost::parameter::value_type<
                         Args
-                      , test::kw::rrc0
+                      , test::kw2::rrc0
                     >::type
                 >::type
             >::evaluate_category(args[test::_rrc0])
         ));
-        BOOST_TEST_EQ(
-            test::passed_by_lvalue_reference_to_const
-          , test::A<
-                typename boost::remove_const<
-                    typename boost::remove_reference<rrc0_type>::type
-                >::type
-            >::evaluate_category(rrc0)
-        );
         BOOST_TEST((
             test::passed_by_lvalue_reference_to_const == test::A<
                 typename boost::remove_const<
                     typename boost::parameter::value_type<
                         Args
-                      , test::kw::rr0
+                      , test::kw3::rr0
                     >::type
                 >::type
             >::evaluate_category(args[test::_rr0])
         ));
-        BOOST_TEST_EQ(
-            test::passed_by_lvalue_reference_to_const
-          , test::A<
-                typename boost::remove_const<
-                    typename boost::remove_reference<rr0_type>::type
-                >::type
-            >::evaluate_category(rr0)
-        );
 #endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 
         return true;
@@ -253,100 +179,47 @@ namespace test {
         )
         {
             test::evaluate(
-                args[test::_lrc0]
-              , args[test::_lr0]
-              , args[test::_rrc0]
-              , args[test::_rr0]
+                test::_lrc0 = args[test::_lrc0]
+              , test::_lr0 = args[test::_lr0]
+              , test::_rrc0 = args[test::_rrc0]
+              , test::_rr0 = args[test::_rr0]
             );
         }
 
-#if BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
-        typedef test::string_predicate<test::kw::lr0> rr0_pred;
-
-        BOOST_PARAMETER_MEMBER_FUNCTION((bool), static evaluate, kw,
-            (required
-                (lrc0, (char))
-            )
-            (deduced
-                (optional
-                    (rrc0, (float), 0.0f)
-                    (lr0, (char const*), test::baz)
-                    (rr0, *(rr0_pred), std::string(lr0))
-                )
-            )
-        )
-#else   // !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
-        BOOST_PARAMETER_MEMBER_FUNCTION((bool), static evaluate, kw,
-            (required
-                (lrc0, (char))
-            )
-            (deduced
-                (optional
-                    (rrc0, (float), 0.0f)
-                    (lr0, (char const*), test::baz)
-                    (rr0
-                      , *(test::string_predicate<test::kw::lr0>)
-                      , std::string(lr0)
-                    )
-                )
-            )
-        )
-#endif  // SunPro CC workarounds needed.
+        BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((bool), static evaluate)
         {
             BOOST_TEST((
                 test::passed_by_lvalue_reference_to_const == test::A<
                     typename boost::remove_const<
                         typename boost::parameter::value_type<
                             Args
-                          , test::kw::lrc0
+                          , test::kw0::lrc0
                         >::type
                     >::type
                 >::evaluate_category(args[test::_lrc0])
             ));
-            BOOST_TEST_EQ(
-                test::passed_by_lvalue_reference_to_const
-              , test::A<
-                    typename boost::remove_const<
-                        typename boost::remove_reference<lrc0_type>::type
-                    >::type
-                >::evaluate_category(lrc0)
-            );
             BOOST_TEST((
                 test::passed_by_lvalue_reference == test::A<
                     typename boost::remove_const<
                         typename boost::parameter::value_type<
                             Args
-                          , test::kw::lr0
+                          , test::kw1::lr0
+                          , char const*
                         >::type
                     >::type
-                >::evaluate_category(args[test::_lr0])
+                >::evaluate_category(args[test::_lr0 | test::baz])
             ));
-            BOOST_TEST_EQ(
-                test::passed_by_lvalue_reference
-              , test::A<
-                    typename boost::remove_const<
-                        typename boost::remove_reference<lr0_type>::type
-                    >::type
-                >::evaluate_category(lr0)
-            );
             BOOST_TEST((
                 test::passed_by_lvalue_reference_to_const == test::A<
                     typename boost::remove_const<
                         typename boost::parameter::value_type<
                             Args
-                          , test::kw::rrc0
+                          , test::kw2::rrc0
+                          , float
                         >::type
                     >::type
-                >::evaluate_category(args[test::_rrc0])
+                >::evaluate_category(args[test::_rrc0 | 0.0f])
             ));
-            BOOST_TEST_EQ(
-                test::passed_by_lvalue_reference_to_const
-              , test::A<
-                    typename boost::remove_const<
-                        typename boost::remove_reference<rrc0_type>::type
-                    >::type
-                >::evaluate_category(rrc0)
-            );
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST((
@@ -354,38 +227,32 @@ namespace test {
                     typename boost::remove_const<
                         typename boost::parameter::value_type<
                             Args
-                          , test::kw::rr0
+                          , test::kw3::rr0
+                          , std::string
                         >::type
                     >::type
-                >::evaluate_category(args[test::_rr0])
+                >::evaluate_category(
+                    args[
+                        test::_rr0 | std::string(args[test::_lr0 | test::baz])
+                    ]
+                )
             ));
-            BOOST_TEST_EQ(
-                test::passed_by_rvalue_reference
-              , test::A<
-                    typename boost::remove_const<
-                        typename boost::remove_reference<rr0_type>::type
-                    >::type
-                >::evaluate_category(std::forward<rr0_type>(rr0))
-            );
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST((
                 test::passed_by_lvalue_reference_to_const == test::A<
                     typename boost::remove_const<
                         typename boost::parameter::value_type<
                             Args
-                          , test::kw::rr0
+                          , test::kw3::rr0
+                          , std::string
                         >::type
                     >::type
-                >::evaluate_category(args[test::_rr0])
+                >::evaluate_category(
+                    args[
+                        test::_rr0 | std::string(args[test::_lr0 | test::baz])
+                    ]
+                )
             ));
-            BOOST_TEST_EQ(
-                test::passed_by_lvalue_reference_to_const
-              , test::A<
-                    typename boost::remove_const<
-                        typename boost::remove_reference<rr0_type>::type
-                    >::type
-                >::evaluate_category(rr0)
-            );
 #endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 
             return true;
@@ -401,37 +268,96 @@ namespace test {
         }
 #endif
 
-        BOOST_PARAMETER_CONSTRUCTOR(C, (B), kw,
-            (required
-                (lrc0, *)
-                (lr0, *)
-                (rrc0, *)
-                (rr0, *)
-            )
-        )
+        BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(C, (B))
+    };
+
+    struct D
+    {
+        BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(D, D::_evaluate)
+
+        BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION((bool), evaluate_m)
+        {
+            return D::_evaluate(args);
+        }
+
+        BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR((bool))
+        {
+            return D::_evaluate(args);
+        }
+
+     private:
+        template <typename Args>
+        static bool _evaluate(Args const& args)
+        {
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<0>(args[test::_lrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<1>(args[test::_lr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<4>(args[test::_lrc1])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<5>(
+                    args[test::_lr1 | test::lvalue_bitset<5>()]
+                )
+            );
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<3>(args[test::_rr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
+            );
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<3>(args[test::_rr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
+            );
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+
+            return true;
+        }
     };
 } // namespace test
 
 int main()
 {
-    test::evaluate(
-        test::lvalue_const_float()
-      , test::lvalue_float()
-      , test::rvalue_const_float()
-      , test::rvalue_float()
-    );
-    test::evaluate(
-        test::lvalue_const_char_ptr()
-      , test::lvalue_char_ptr()
-      , test::rvalue_const_char_ptr()
-      , test::rvalue_char_ptr()
-    );
-    test::evaluate(
-        test::lvalue_const_str()
-      , test::lvalue_str()
-      , test::rvalue_const_str()
-      , test::rvalue_str()
-    );
     test::evaluate(
         test::_lr0 = test::lvalue_float()
       , test::_rrc0 = test::rvalue_const_float()
@@ -451,24 +377,6 @@ int main()
       , test::_lrc0 = test::lvalue_const_str()
     );
 
-    test::C cf0(
-        test::lvalue_const_float()
-      , test::lvalue_float()
-      , test::rvalue_const_float()
-      , test::rvalue_float()
-    );
-    test::C cc0(
-        test::lvalue_const_char_ptr()
-      , test::lvalue_char_ptr()
-      , test::rvalue_const_char_ptr()
-      , test::rvalue_char_ptr()
-    );
-    test::C cs0(
-        test::lvalue_const_str()
-      , test::lvalue_str()
-      , test::rvalue_const_str()
-      , test::rvalue_str()
-    );
     test::C cf1(
         test::_lr0 = test::lvalue_float()
       , test::_rrc0 = test::rvalue_const_float()
@@ -496,17 +404,6 @@ int main()
     // MSVC-12+ treats static_cast<char_arr&&>(baz_arr) as an lvalue.
 #else
     test::evaluate(
-        "q2x"
-      , baz_arr
-#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
-      , static_cast<char_arr const&&>("mos")
-      , static_cast<char_arr&&>(baz_arr)
-#else
-      , "crg"
-      , "uir"
-#endif
-    );
-    test::evaluate(
         test::_lr0 = baz_arr
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
       , test::_rrc0 = static_cast<char_arr const&&>("def")
@@ -518,10 +415,10 @@ int main()
       , test::_lrc0 = "wld"
     );
 #endif  // MSVC-12+
-    test::B::evaluate(test::lvalue_const_str()[0]);
+    test::B::evaluate(test::_lrc0 = test::lvalue_const_str()[0]);
     test::C::evaluate(
-        test::lvalue_const_str()[0]
-      , test::rvalue_const_float()
+        test::_rrc0 = test::rvalue_const_float()
+      , test::_lrc0 = test::lvalue_const_str()[0]
     );
 
 #if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
@@ -531,14 +428,14 @@ int main()
     test::C cp1;
 #else
     test::C cp0(
-        "frd"
-      , baz_arr
+        test::_lrc0 = "frd"
+      , test::_lr0 = baz_arr
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
-      , static_cast<char_arr const&&>("dfs")
-      , static_cast<char_arr&&>(baz_arr)
+      , test::_rrc0 = static_cast<char_arr const&&>("dfs")
+      , test::_rr0 = static_cast<char_arr&&>(baz_arr)
 #else
-      , "plg"
-      , "thd"
+      , test::_rrc0 = "plg"
+      , test::_rr0 = "thd"
 #endif
     );
     test::C cp1(
@@ -555,16 +452,68 @@ int main()
 #endif  // MSVC-12+
 
     cp0.evaluate(
-        test::lvalue_const_str()[0]
-      , test::lvalue_char_ptr()
-      , test::rvalue_str()
-      , test::rvalue_const_float()
+        test::_lrc0 = test::lvalue_const_str()[0]
+      , test::_lr0 = test::lvalue_char_ptr()
+      , test::_rr0 = test::rvalue_str()
+      , test::_rrc0 = test::rvalue_const_float()
     );
     cp1.evaluate(
-        test::lvalue_const_str()[0]
-      , test::rvalue_str()
-      , test::rvalue_const_float()
-      , test::lvalue_char_ptr()
+        test::_lrc0 = test::lvalue_const_str()[0]
+      , test::_rr0 = test::rvalue_str()
+      , test::_rrc0 = test::rvalue_const_float()
+      , test::_lr0 = test::lvalue_char_ptr()
+    );
+
+    test::D dp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    test::D dp1(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+
+    dp0.evaluate_m(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    dp1.evaluate_m(
+        test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+      , test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lr1 = test::lvalue_bitset<5>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_rr1 = test::rvalue_bitset<7>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+    );
+    dp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    dp1(
+        test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+      , test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lr1 = test::lvalue_bitset<5>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_rr1 = test::rvalue_bitset<7>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
     );
     return boost::report_errors();
 }

--- a/test/sfinae.cpp
+++ b/test/sfinae.cpp
@@ -5,14 +5,13 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #if (BOOST_PARAMETER_MAX_ARITY < 2)
 #error Define BOOST_PARAMETER_MAX_ARITY as 2 or greater.
 #endif
-#if (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 3)
+#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+    (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 3)
 #error Define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY \
 as 3 or greater.
-#endif
 #endif
 
 #include <boost/parameter.hpp>

--- a/test/singular.cpp
+++ b/test/singular.cpp
@@ -22,6 +22,7 @@ namespace test {
 
     BOOST_PARAMETER_NAME(x)
     BOOST_PARAMETER_NAME(y)
+    BOOST_PARAMETER_NAME(z)
 } // namespace test
 
 #include <boost/parameter/is_argument_pack.hpp>
@@ -33,6 +34,9 @@ namespace test {
     void check0(ArgumentPack const& p, K const& kw, T const& value)
     {
         BOOST_MPL_ASSERT((boost::parameter::is_argument_pack<ArgumentPack>));
+        BOOST_MPL_ASSERT_NOT((
+            boost::mpl::has_key<ArgumentPack,test::tag::z>
+        ));
         BOOST_TEST_EQ(p[kw], value);
     }
 } // namespace test
@@ -55,6 +59,9 @@ namespace test {
     {
         BOOST_MPL_ASSERT((boost::parameter::is_argument_pack<ArgumentPack>));
         BOOST_MPL_ASSERT((boost::mpl::has_key<ArgumentPack,typename K::tag>));
+        BOOST_MPL_ASSERT_NOT((
+            boost::mpl::has_key<ArgumentPack,test::tag::z>
+        ));
         BOOST_MPL_ASSERT((
             boost::mpl::equal_to<
                 typename boost::mpl::count<ArgumentPack,typename K::tag>::type


### PR DESCRIPTION
* Add variadic metafunction boost::parameter::are_tagged_arguments to help improve overload resolution capabilities.  Used by new BOOST_PARAMETER_NO_SPEC_* code generation macros.
* Add code generation macros BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_NO_SPEC_FUNCTION, BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION, BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION, BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR, and BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR.
* Enable function call operator overloads & overloads of the same name to coexist even with deduced arguments.
* Update .yml scripts as per Peter Dimov's message announcing the merging of CMake into boostorg/develop.
* Add usage examples to & remove unnecessary implementation details from tutorial & reference documentation.