### PR TITLE
 Add are_tagged_arguments, add code generation macros, improve overloading support, upgrade documentation

### DIFF
--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -103,107 +103,148 @@ src="../../../../boost.png" /></a></p>
 >5.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal">lazy_binding</tt></a></li>
 <li><a class="reference internal" href="#value-type" id="id48"
 >5.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal">value_type</tt></a></li>
-<li><a class="reference internal" href="#value-type" id="id49"
+<li><a class="reference internal" href="#are-tagged-arguments" id="id49"
 >5.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>are_tagged_arguments</tt></a></li>
+<li><a class="reference internal" href="#is-argument-pack" id="id50"
+>5.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >is_argument_pack</tt></a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#code-generation-macros" id="id50"
+<li><a class="reference internal" href="#code-generation-macros" id="id51"
 >6&nbsp;&nbsp;&nbsp;Code Generation Macros</a><ul class="auto-toc">
 <li><a class="reference internal"
 href="#boost-parameter-function-result-name-tag-namespace-arguments"
-id="id51">6.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id52">6.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-member-function-result-name-tag-namespace-arguments"
-id="id52">6.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id53">6.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_MEMBER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-c-mem-function-result-name-tag-namespace-arguments"
-id="id53">6.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id54">6.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_CONST_MEMBER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-function-call-op-result-tag-namespace-arguments"
-id="id54">6.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id55">6.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_FUNCTION_CALL_OPERATOR(result, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-const-function-call-op-result-tag-namespace-arguments"
-id="id55">6.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id56">6.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR(result, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-constructor-cls-impl-tag-namespace-arguments"
-id="id56">6.6&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id57">6.6&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_CONSTRUCTOR(cls, impl, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-basic-function-result-name-tag-namespace-arguments"
-id="id57">6.7&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id58">6.7&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_BASIC_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-basic-member-function-result-name-tag-ns-arguments"
-id="id58">6.8&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id59">6.8&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_BASIC_MEMBER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-basic-c-mem-function-result-name-tag-ns-arguments"
-id="id59">6.9&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id60">6.9&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-basic-function-call-op-result-tag-namespace-arguments"
+id="id61">6.10&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR(result, tag_namespace,
+arguments)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-basic-const-function-call-op-result-tag-ns-args"
+id="id62">6.11&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR(result, tag_namespace,
+arguments)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-function-result-name"
+id="id63">6.12&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_FUNCTION(result, name)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-member-function-result-name"
+id="id64">6.13&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION(result, name)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-c-mem-function-result-name"
+id="id65">6.14&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION(result, name)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-function-call-op-result"
+id="id66">6.15&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR(result)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-const-func-call-op-result"
+id="id67">6.16&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR(result)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-constructor-cls-impl"
+id="id68">6.17&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(cls, impl)</tt></a></li>
+<li><a class="reference internal"
+href="#boost-parameter-no-spec-no-base-ctor-cls-func"
+id="id69">6.18&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(cls, func)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-name-name"
-id="id60">6.10&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id70">6.19&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_NAME(name)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-nested-keyword-t-n-a"
-id="id61">6.11&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id71">6.20&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_NESTED_KEYWORD(tag_namespace, name, alias)</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-template-keyword-name"
-id="id62">6.12&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id72">6.21&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_TEMPLATE_KEYWORD(name)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-fun-r-n-l-h-p"
-id="id63">6.13&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id73">6.22&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_FUN(r,n,l,h,p)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-keyword-n-k"
-id="id64">6.14&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id74">6.23&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_KEYWORD(n,k)</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-match-p-a-x"
-id="id65">6.15&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id75">6.24&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_MATCH(p,a,x)</tt></a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#configuration-macros"
-id="id66">7&nbsp;&nbsp;&nbsp;Configuration Macros</a>
+id="id76">7&nbsp;&nbsp;&nbsp;Configuration Macros</a>
 <ul class="auto-toc">
 <li><a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"
-id="id67">7.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id77">7.1&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-disable-perfect-forwarding"
-id="id68">7.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id78">7.2&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_DISABLE_PERFECT_FORWARDING</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-variadic-mpl-sequence"
-id="id69">7.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id79">7.3&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE</tt></a></li>
 <li><a class="reference internal" href="#boost-parameter-has-arity"
-id="id70">7.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id80">7.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_MAX_ARITY</tt></a></li>
 <li><a class="reference internal"
 href="#boost-parameter-exponential-overload-threshold-arity"
-id="id71">7.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+id="id81">7.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY</tt></a></li>
 <li><a class="reference internal" href="#outside-of-this-library"
-id="id72">7.6&nbsp;&nbsp;&nbsp;...Outside Of This Library</a></li>
+id="id82">7.6&nbsp;&nbsp;&nbsp;...Outside Of This Library</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#tutorial"
-id="id73">8&nbsp;&nbsp;&nbsp;Tutorial</a></li>
+id="id83">8&nbsp;&nbsp;&nbsp;Tutorial</a></li>
 </ul>
 </div>
 <hr class="docutils" />
@@ -525,10 +566,6 @@ class="reference external" href="../../../../boost/parameter/keyword.hpp"
 </tr>
 </tbody>
 </table>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <pre class="literal-block">
 template &lt;typename Tag&gt;
 struct keyword
@@ -958,246 +995,6 @@ href="#instance">instance</a>;
 href="#get">get</a>();
 };
 </pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"
-id="id61"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="literal-block">
-template &lt;typename Tag&gt;
-struct keyword
-{
-    typedef Tag tag;
-
-    template &lt;typename T&gt;
-    typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
-        typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-            boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                    typename Tag::qualifier
-                  , boost::parameter::in_reference
-                &gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                    boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                        typename Tag::qualifier
-                      , boost::parameter::forward_reference
-                    &gt;
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-                &gt;
-            &gt;
-        &gt;::type
-      , <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a>
-    &gt;::type constexpr
-        <a class="reference internal"
-href="#operator">operator=</a>(T const&amp; value) const;
-
-    template &lt;typename T&gt;
-    typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
-        typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-            typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                    typename Tag::qualifier
-                  , boost::parameter::out_reference
-                &gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                    boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                        typename Tag::qualifier
-                      , boost::parameter::forward_reference
-                    &gt;
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-                &gt;
-            &gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_const.html"><tt
-class="docutils literal">is_const</tt></a>&lt;T&gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-            &gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-        &gt;::type
-      , <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a>
-    &gt;::type constexpr
-        <a class="reference internal"
-href="#operator">operator=</a>(T&amp; value) const;
-
-    template &lt;typename T&gt;
-    typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
-        typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-            boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                    typename Tag::qualifier
-                  , boost::parameter::in_reference
-                &gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                    boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                        typename Tag::qualifier
-                      , boost::parameter::forward_reference
-                    &gt;
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-                &gt;
-            &gt;
-        &gt;::type
-      , <em>tagged default</em>
-    &gt;::type constexpr
-        <a class="reference internal"
-href="#id9">operator|</a>(T const&amp; x) const;
-
-    template &lt;typename T&gt;
-    typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
-        typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-            typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                    typename Tag::qualifier
-                  , boost::parameter::out_reference
-                &gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                    boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
-                        typename Tag::qualifier
-                      , boost::parameter::forward_reference
-                    &gt;
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-                  , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-                &gt;
-            &gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
-                boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_const.html"><tt
-class="docutils literal">is_const</tt></a>&lt;T&gt;
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-              , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
-            &gt;
-          , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
-        &gt;::type
-      , <em>tagged default</em>
-    &gt;::type constexpr
-        <a class="reference internal"
-href="#id9">operator|</a>(T&amp; x) const;
-
-    template &lt;typename F&gt;
-    <em>tagged lazy default</em> <a class="reference internal"
-href="#id10">operator||</a>(F const&amp;) const;
-
-    template &lt;typename F&gt;
-    <em>tagged lazy default</em> <a class="reference internal"
-href="#id10">operator||</a>(F&amp;) const;
-
-    static keyword&lt;Tag&gt; const&amp; <a class="reference internal"
-href="#instance">instance</a>;
-
-    static keyword&lt;Tag&gt;&amp; <a class="reference internal"
-href="#get">get</a>();
-};
-</pre>
 <dl class="docutils" id="operator">
 <dt><tt class="docutils literal">operator=</tt></dt>
 <dd>
@@ -1208,12 +1005,6 @@ template &lt;typename T&gt; <a class="reference internal" href="#argumentpack"
 template &lt;typename T&gt; <a class="reference internal" href="#argumentpack"
 ><span class="concept">ArgumentPack</span></a
 > operator=(T&amp; value) const;
-</pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="first literal-block">
 template &lt;typename T&gt; <a class="reference internal" href="#argumentpack"
 ><span class="concept">ArgumentPack</span></a
 > operator=(T const&amp;&amp; value) const;
@@ -1278,12 +1069,6 @@ template &lt;typename T&gt; <em
 >tagged default</em> operator|(T const&amp; x) const;
 template &lt;typename T&gt; <em
 >tagged default</em> operator|(T&amp; x) const;
-</pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="first literal-block">
 template &lt;typename T&gt; <em
 >tagged default</em> operator|(T const&amp;&amp; x) const;
 template &lt;typename T&gt; <em
@@ -1465,8 +1250,12 @@ class="docutils literal">parameters</tt></a></h2>
 <cite>forwarding function</cite> into an <span class="concept"
 >ArgumentPack</span>, in which any <a class="reference internal"
 href="#positional">positional</a> arguments will be tagged according to the
-corresponding template argument to
-<tt class="docutils literal">parameters</tt>.</p>
+corresponding template argument to <tt class="docutils literal"
+>parameters</tt>.  If no template arguments are passed into <tt
+class="docutils literal">parameters</tt>, then the interface cannot assemble
+any <a class="reference internal" href="#positional">positional</a> arguments,
+only <a class="reference internal" href="#tagged-reference">tagged
+reference</a> arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -1479,10 +1268,6 @@ href="../../../../boost/parameter/parameters.hpp"
 </tr>
 </tbody>
 </table>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <pre class="literal-block">
 template &lt;typename ...PSpec&gt;
 struct parameters
@@ -1496,7 +1281,23 @@ struct parameters
     template &lt;typename ...Args&gt;
     <a class="reference internal" href="#argumentpack"><span
 class="concept">ArgumentPack</span></a> <a class="reference internal"
-href="#id13">operator()</a>(Args&amp;... args) const;
+href="#id13">operator()</a>(Args&amp;&amp;... args) const;
+};
+
+template &lt;&gt;
+struct parameters&lt;&gt;
+{
+    template &lt;typename ...Args&gt;
+    typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">enable_if</tt></a>&lt;
+        <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;Args...&gt;
+      , <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a>
+    &gt;::type
+        <a class="reference internal"
+href="#id13">operator()</a>(Args const&amp;... args) const;
 };
 </pre>
 <table class="docutils field-list" frame="void" rules="none">
@@ -1567,119 +1368,6 @@ href="#keyword-tag-type">keyword tag type</a>.</div>
 </div>
 </blockquote>
 </div>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="literal-block">
-template &lt;
-    typename P0 = <em>unspecified</em>
-  , typename P1 = <em>unspecified</em>
-  , …
-  , typename P ## β = <em>unspecified</em>
-&gt;
-struct parameters
-{
-    template &lt;
-        typename A0
-      , typename A1 = <em>unspecified</em>
-      , …
-      , typename A ## β = <em>unspecified</em>
-    &gt;
-    struct <a class="reference internal" href="#match">match</a>
-    {
-        typedef … type;
-    };
-
-    template &lt;typename A0&gt;
-    <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a> <a class="reference internal"
-href="#id13">operator()</a>(A0&amp; a0) const;
-
-    template &lt;typename A0, typename A1&gt;
-    <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a> <a class="reference internal"
-href="#id13">operator()</a>(A0&amp; a0, A1&amp; a1) const;
-
-    <span class="vellipsis">⋮</span>
-
-    template &lt;typename A0, typename A1, …, typename A ## β&gt;
-    <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a>
-    <a class="reference internal" href="#id13"
->operator()</a>(A0&amp; a0, A1&amp; a1, …, A ## β &amp; a ## β) const;
-};
-</pre>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
-<tbody valign="top">
-<tr class="field">
-<th class="field-name">Requires:</th>
-<td class="field-body"><tt class="docutils literal">P0</tt>,
-<tt class="docutils literal">P1</tt>, …, <tt class="docutils literal">P</tt>
-## β are models of <a class="reference internal" href="#parameterspec"
-><span class="concept">ParameterSpec</span></a>.</td>
-</tr>
-</tbody>
-</table>
-<div class="note">
-<p class="first admonition-title">Note</p>
-<p>In this section, <tt class="docutils literal">R</tt> ## <em>i</em> and
-<tt class="docutils literal">K</tt> ## <em>i</em> are defined as follows: for
-any argument type <tt class="docutils literal">A</tt> ## <em>i</em>:</p>
-<blockquote class="last">
-<div class="line-block">
-<div class="line">let <tt class="docutils literal">D0</tt> the set [d0, …, d
-## <em>j</em>] of all <strong>deduced</strong> <em>parameter specs</em> in
-[<tt class="docutils literal">P0</tt>, …, <tt class="docutils literal">P</tt>
-## β]</div>
-<div class="line"><tt class="docutils literal">R</tt> ## <em>i</em> is the
-<a class="reference internal" href="#intended-argument-type">intended argument
-type</a> of <tt class="docutils literal">A</tt> ## <em>i</em></div>
-<div class="line"><br /></div>
-<div class="line">if <tt class="docutils literal">A</tt> ## <em>i</em> is a
-result type of <tt class="docutils literal"><span class="pre"
->keyword&lt;T&gt;::</span></tt><a class="reference internal" href="#operator"
-><tt class="docutils literal">operator=</tt></a></div>
-<div class="line">then</div>
-<div class="line-block">
-<div class="line"><tt class="docutils literal">K</tt> ## <em>i</em> is
-<tt class="docutils literal">T</tt></div>
-</div>
-<div class="line">else</div>
-<div class="line-block">
-<div class="line">if some <tt class="docutils literal">A</tt> ## <em>j</em>
-where <em>j</em> ≤ <em>i</em> is a result type of <tt class="docutils literal"
-><span class="pre">keyword&lt;T&gt;::</span></tt><a class="reference internal"
-href="#operator"><tt class="docutils literal">operator=</tt></a></div>
-<div class="line"><em>or</em> some <tt class="docutils literal">P</tt> ##
-<em>j</em> in <em>j</em> ≤ <em>i</em> is <strong>deduced</strong></div>
-<div class="line">then</div>
-<div class="line-block">
-<div class="line">if some <em>parameter spec</em> <tt class="docutils literal"
->d</tt><em>j</em> in <tt class="docutils literal">D</tt> ## <em>i</em> matches
-<tt class="docutils literal">A</tt><em>i</em></div>
-<div class="line">then</div>
-<div class="line-block">
-<div class="line"><tt class="docutils literal">K</tt> ## <em>i</em> is <tt
-class="docutils literal">d</tt> ## <em>j</em>'s <a class="reference internal"
-href="#keyword-tag-type">keyword tag type</a>.</div>
-<div class="line"><tt class="docutils literal">D</tt><sub>i+1</sub> is
-<tt class="docutils literal">D</tt> ## <em>i</em> -
-[<tt class="docutils literal">d</tt> ## <em>j</em>]</div>
-</div>
-</div>
-<div class="line">else</div>
-<div class="line-block">
-<div class="line"><tt class="docutils literal">K</tt> ## <em>i</em> is <tt
-class="docutils literal">P</tt> ## <em>i</em>'s <a class="reference internal"
-href="#keyword-tag-type">keyword tag type</a>.</div>
-</div>
-</div>
-</div>
-</blockquote>
-</div>
 <dl class="docutils" id="match">
 <dt><tt class="docutils literal">match</tt></dt>
 <dd>
@@ -1688,10 +1376,6 @@ href="../../../mpl/doc/refmanual/metafunction.html"><span class="concept"
 >Metafunction</span></a> used to remove a <a class="reference external"
 href="index.html#forwarding-functions">forwarding function</a> from overload
 resolution.</p>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -1741,86 +1425,15 @@ default</li>
 </ul>
 </li>
 </ul>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
-<tbody valign="top">
-<tr class="field">
-<th class="field-name">Returns:</th>
-<td class="field-body">if <tt class="docutils literal">P0</tt>, <tt
-class="docutils literal">P1</tt>, …, <tt class="docutils literal">Pβ</tt> are
-<em>satisfied</em> (see below), then <tt class="docutils literal"><span
-class="pre">parameters&lt;P0,P1,…,Pβ&gt;</span></tt>.  Otherwise,
-<tt class="docutils literal"><span
-class="pre">match&lt;A0,A1,…,Aβ&gt;::type</span></tt> is not defined.</td>
-</tr>
-</tbody>
-</table>
-<p><tt class="docutils literal">P0</tt>, <tt class="docutils literal">P1</tt>,
-…, <tt class="docutils literal">Pβ</tt> are <strong>satisfied</strong> if, for
-every <em>j</em> in 0…β, either:</p>
-<ul class="last simple">
-<li><tt class="docutils literal">P</tt> ## <em>j</em> is the
-<em>unspecified</em> default</li>
-<li><strong>or</strong>, <tt class="docutils literal">P</tt> ## <em>j</em> is
-a <em>keyword tag type</em></li>
-<li><strong>or</strong>, <tt class="docutils literal">P</tt> ## <em>j</em> is
-<a class="reference internal" href="#optional"><tt class="docutils literal"
->optional</tt></a><tt class="docutils literal">&lt;X,F&gt;</tt> and either
-<ul>
-<li><tt class="docutils literal">X</tt> is not <tt class="docutils literal"
->K</tt> ## <em>i</em> for any <em>i</em>,</li>
-<li><strong>or</strong> <tt class="docutils literal">X</tt> is some
-<tt class="docutils literal">K</tt> ## <em>i</em> and
-<tt class="docutils literal"><span class="pre">mpl::apply&lt;F,R</span></tt>
-## <em>i</em><tt class="docutils literal"><span class="pre"
->&gt;::type::value</span></tt> is <tt class="docutils literal">true</tt></li>
-</ul>
-</li>
-<li><strong>or</strong>, <tt class="docutils literal">P</tt> ## <em>j</em> is
-<a class="reference internal" href="#required"><tt class="docutils literal"
->required</tt></a><tt class="docutils literal">&lt;X,F&gt;</tt>, and
-<ul>
-<li><tt class="docutils literal">X</tt> is some <tt class="docutils literal"
->K</tt> ## <em>i</em>, <strong>and</strong></li>
-<li><tt class="docutils literal"><span class="pre"
->mpl::apply&lt;F,R</span></tt> ## <em>i</em><tt class="docutils literal"
-><span class="pre">&gt;::type::value</span></tt> is
-<tt class="docutils literal">true</tt></li>
-</ul>
-</li>
-</ul>
 </dd>
 </dl>
 <dl class="docutils" id="id13">
 <dt><tt class="docutils literal">operator()</tt></dt>
 <dd>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"
-id="id61"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="first literal-block">
-template &lt;typename ...Args&gt; <a class="reference internal"
-href="#argumentpack"><span class="concept"
+\<pre class="first literal-block">
+template &lt;typename ...Args&gt;
+<a class="reference internal" href="#argumentpack"><span class="concept"
 >ArgumentPack</span></a> operator()(Args&amp;&amp;... args) const;
-</pre>
-<p><strong>Else</strong>:</p>
-<pre class="first literal-block">
-template &lt;typename A0&gt; <a class="reference internal"
-href="#argumentpack"><span class="concept"
->ArgumentPack</span></a> operator()(A0 const&amp; a0) const;
-
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## β&gt; <a class="reference internal"
-href="#argumentpack"><span class="concept"
->ArgumentPack</span></a> <a class="reference internal" href="#id13"
->operator()</a>(A0 const&amp; a0, …, A ## β const&amp; a ## β) const;
 </pre>
 <table class="last docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -2073,8 +1686,11 @@ tag type</a> <tt class="docutils literal">K</tt>, if any.  If no such
 <a class="reference internal" href="#tagged-reference">tagged reference</a>
 exists, returns <tt class="docutils literal">D</tt>.  Equivalent to:</p>
 <pre class="literal-block">
-typename remove_reference&lt;
-    typename binding&lt;A, K, D&gt;::type
+typename boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/remove_reference.html"
+><tt class="docutils literal">remove_reference</tt></a>&lt;
+    typename <a class="reference internal" href="#binding"
+>binding</a>&lt;A, K, D&gt;::type
 &gt;::type
 </pre>
 <p class="last">… when <tt class="docutils literal">D</tt> is not a reference
@@ -2084,8 +1700,91 @@ type.</p>
 </tbody>
 </table>
 </div>
-<div class="section" id="is-argument-pack">
+<div class="section" id="are-tagged-arguments">
 <h2><a class="toc-backref" href="#id49">5.4&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">are_tagged_arguments</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/are_tagged_arguments.hpp"
+>boost/parameter/are_tagged_arguments.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<pre class="literal-block">
+template &lt;typename T0, typename ...Pack&gt;
+struct are_tagged_arguments  // : mpl::true_ or mpl::false_
+{
+};
+</pre>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Returns:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body"><tt class="docutils literal"><span class="pre"
+>mpl::true_</span></tt> if <tt class="docutils literal">T0</tt> and all
+elements in parameter pack <tt class="docutils literal">Pack</tt> are
+<a class="reference internal" href="#tagged-reference">tagged reference</a>
+types, <tt class="docutils literal"><span class="pre">mpl::false_</span></tt>
+otherwise.</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">When implementing a Boost.Parameter-enabled constructor for a
+container that conforms to the C++ standard, one needs to remember that the
+standard requires the presence of other constructors that are typically
+defined as templates, such as range constructors.  To avoid overload
+ambiguities between the two constructors, use this metafunction in conjunction
+with <tt class="docutils literal"><span class="pre">disable_if</span></tt> to
+define the range constructor.</p>
+<pre class="first literal-block">
+template &lt;typename B&gt;
+class frontend : public B
+{
+    struct _enabler
+    {
+    };
+
+ public:
+    <a class="reference internal"
+href="#boost-parameter-no-spec-constructor-cls-impl"
+>BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR</a>(frontend, (B))
+
+    template &lt;typename Iterator&gt;
+    frontend(
+        Iterator itr
+      , Iterator itr_end
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">disable_if</tt></a>&lt;
+            are_tagged_arguments&lt;Iterator&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : B(itr, itr_end)
+    {
+    }
+};
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="section" id="is-argument-pack">
+<h2><a class="toc-backref" href="#id50">5.5&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">is_argument_pack</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -2110,13 +1809,74 @@ struct is_argument_pack  // : mpl::true_ or mpl::false_
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field">
-<th class="field-name">Returns:</th>
+<th class="field-name" colspan="2">Returns:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
 <td class="field-body"><tt class="docutils literal"><span class="pre"
 >mpl::true_</span></tt> if <tt class="docutils literal">T</tt> is a model of
 <a class="reference internal" href="#argumentpack"><span class="concept"
 >ArgumentPack</span></a>, <tt class="docutils literal"><span class="pre"
->mpl::false_</span></tt> otherwise.</a>
-exists, returns <tt class="docutils literal">D</tt>.</td>
+>mpl::false_</span></tt> otherwise.</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">To avoid overload ambiguities between a constructor that
+takes in an <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> and a templated conversion
+constructor, use this metafunction in conjunction with
+<tt class="docutils literal"><span class="pre">enable_if</span></tt>.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a0)
+
+template &lt;typename T&gt;
+class backend0
+{
+    struct _enabler
+    {
+    };
+
+    T a0;
+
+ public:
+    template &lt;typename ArgPack&gt;
+    explicit backend0(
+        ArgPack const&amp; args
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            is_argument_pack&lt;ArgPack&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : a0(args[_a0])
+    {
+    }
+
+    template &lt;typename U&gt;
+    backend0(
+        backend0&lt;U&gt; const&amp; copy
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/is_convertible.html"
+>is_convertible</a>&lt;U,T&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : a0(copy.get_a0())
+    {
+    }
+
+    T const&amp; get_a0() const
+    {
+        return this-&gt;a0;
+    }
+};
+</pre>
+</td>
 </tr>
 </tbody>
 </table>
@@ -2124,13 +1884,13 @@ exists, returns <tt class="docutils literal">D</tt>.</td>
 </div>
 <hr class="docutils" />
 <div class="section" id="code-generation-macros">
-<h1><a class="toc-backref" href="#id50">6&nbsp;&nbsp;&nbsp;Code Generation
+<h1><a class="toc-backref" href="#id51">6&nbsp;&nbsp;&nbsp;Code Generation
 Macros</a></h1>
 <p>Macros in this section can be used to ease the writing of code using the
 Parameter libray by eliminating repetitive boilerplate.</p>
 <div class="section"
 id="boost-parameter-function-result-name-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id51">6.1&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id52">6.1&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_FUNCTION(result, name, tag_namespace,
 arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2150,18 +1910,217 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field">
-<th class="field-name" colspan="2">Requires:</th>
+<th class="field-name" colspan="2">Example usage:</th>
 </tr>
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first"><tt class="docutils literal">result</tt> is the parenthesized
-return type of the function.  <tt class="docutils literal">name</tt> is the
-base name of the function, this is the name of the generated forwarding
-functions.  <tt class="docutils literal">tag_namespace</tt> is the namespace
-in which the keywords used by the function
-resides.  <tt class="docutils literal">arguments</tt> is a list of
-<em>argument specifiers</em>, as defined below.</p>
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal function
+header.  Enclose the return type <tt class="docutils literal">bool</tt> in
+parentheses.  For each parameter, also enclose the expected value type in
+parentheses.  Since the value types are mutually exclusive, you can wrap the
+parameters in a <tt class="docutils literal">(deduced …)</tt>
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the
+corresponding argument.  Note that the second method doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+BOOST_PARAMETER_FUNCTION((bool), evaluate, kw,
+    (deduced
+        (required
+            (lrc, (std::bitset&lt;1&gt;))
+            (lr, (std::bitset&lt;2&gt;))
+        )
+        (optional
+            (rrc, (std::bitset&lt;3&gt;), rvalue_const_bitset&lt;2&gt;())
+            (rr, (std::bitset&lt;4&gt;), rvalue_bitset&lt;3&gt;())
+        )
+    )
+)
+{
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference_to_const
+      , U::evaluate_category&lt;0&gt;(lrc)
+    );
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference
+      , U::evaluate_category&lt;1&gt;(lr)
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference_to_const
+      , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference
+      , U::evaluate_category&lt;3&gt;(args[_rr0])
+    );
+
+    return true;
+}
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a>, <a
+class="reference external" href="../../test/preprocessor_deduced.cpp"
+>test/preprocessor_deduced.cpp</a>, and <a class="reference external"
+href="../../test/preprocessor_eval_category.cpp"
+>test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
 </td>
 </tr>
 <tr class="field">
@@ -2248,33 +2207,6 @@ type.</li>
 </tr>
 </tbody>
 </table>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
-<tbody valign="top">
-<tr class="field">
-<th class="field-name" colspan="2">Generated names in enclosing scope:</th>
-</tr>
-<tr>
-<td>&nbsp;</td>
-<td class="field-body">
-<ul class="first last simple">
-<li><tt class="docutils literal">boost_param_result_ ## __LINE__ ##
-name</tt></li>
-<li><tt class="docutils literal">boost_param_params_ ## __LINE__ ##
-name</tt></li>
-<li><tt class="docutils literal">boost_param_parameters_ ## __LINE__ ##
-name</tt></li>
-<li><tt class="docutils literal">boost_param_impl ## name</tt></li>
-<li><tt class="docutils literal">boost_param_dispatch_0boost_ ## __LINE__ ##
-name</tt></li>
-<li><tt class="docutils literal">boost_param_dispatch_1boost_ ## __LINE__ ##
-name</tt></li>
-</ul>
-</td>
-</tr>
-</tbody>
-</table>
 <dl class="docutils">
 <dt>Approximate expansion:</dt>
 <dd>
@@ -2285,10 +2217,6 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 <li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <pre class="last literal-block">
 template &lt;typename T&gt;
 struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
@@ -2297,7 +2225,7 @@ struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
 };
 
 struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
-  : boost::parameter::parameters&lt;
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
         <em>list of parameter specifications, based on arguments</em>
     &gt;
 {
@@ -2308,8 +2236,8 @@ typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
 
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## <strong
->name</strong>&lt;Args&gt;::type
-    boost_param_impl ## <strong>name</strong>(Args const&);
+>name</strong> ## _&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const&);
 
 template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
 <em>result type</em>
@@ -2317,13 +2245,13 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
         A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
 >n</strong>
       , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0, …, A ## <strong>n</strong>
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## <strong
 >name</strong>()
     )
 {
-    return boost_param_impl ## <strong>name</strong>(
+    return boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2345,13 +2273,13 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
         A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
 >m</strong>
       , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0, …, A ## <strong>m</strong>
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## <strong
 >name</strong>()
     )
 {
-    return boost_param_impl ## <strong>name</strong>(
+    return boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2406,10 +2334,15 @@ ResultType
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## <strong
 >name</strong>&lt;Args&gt;::type
-    boost_param_impl ## <strong>name</strong>(Args const& args)
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
 {
     return boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+        static_cast&lt;
+            typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
       , args
       , std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2506,234 +2439,12 @@ ResultType
 >argument name</em> ## <strong>m</strong>
     )
 </pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="last literal-block">
-template &lt;typename T&gt;
-struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
-{
-    typedef <strong>result</strong> type;
-};
-
-struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
-  : boost::parameter::parameters&lt;
-        <em>list of parameter specifications, based on arguments</em>
-    &gt;
-{
-};
-
-typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
-    boost_param_parameters_ ## __LINE__ ## <strong>name</strong>;
-
-template &lt;typename Args&gt;
-typename boost_param_result_ ## __LINE__ ## <strong
->name</strong>&lt;Args&gt;::type
-    boost_param_impl ## <strong>name</strong>(Args const&);
-
-template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>result type</em>
-    <strong>name</strong>(
-        A0 const&amp; a0, …, A ## <strong>n</strong> const&amp; a ## <strong
->n</strong>
-      , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0 const, …, A ## <strong>n</strong> const
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>()
-    )
-{
-    return boost_param_impl ## <strong>name</strong>(
-        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
-            a0, …, a ## <strong>n</strong>
-        )
-    );
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>result type</em>
-    <strong>name</strong>(
-        A0&amp; a0, …, A ## <strong>n</strong> &amp; a ## <strong>n</strong>
-      , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0, …, A ## <strong>n</strong>
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>()
-    )
-{
-    return boost_param_impl ## <strong>name</strong>(
-        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
-            a0, …, a ## <strong>n</strong>
-        )
-    );
-}
-
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>result type</em>
-    <strong>name</strong>(
-        A0 const&amp; a0, …, A ## <strong>m</strong> const&amp ## ; a<strong
->m</strong>
-      , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0 const, …, A ## <strong>m</strong> const
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>()
-    )
-{
-    return boost_param_impl ## <strong>name</strong>(
-        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
-            a0, …, a ## <strong>m</strong>
-        )
-    );
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>result type</em>
-    <strong>name</strong>(
-        A0&amp; a0, …, A ## <strong>m</strong> &amp ## ; a<strong>m</strong>
-      , typename boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>::match&lt;
-            A0, …, A ## <strong>m</strong>
-        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
->name</strong>()
-    )
-{
-    return boost_param_impl ## <strong>name</strong>(
-        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
-            a0, …, a ## <strong>m</strong>
-        )
-    );
-}
-
-template &lt;
-    typename ResultType
-  , typename Args
-  , typename <em>argument name</em> ## <strong>0</strong> ## _type
-  , …
-  , typename <em>argument name</em> ## <strong>n</strong> ## _type
-&gt;
-ResultType
-    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        (ResultType(*)())
-      , Args const&amp; args
-      , <em>argument name</em> ## <strong>0</strong> ## _type&amp; <em
->argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>n</strong> ## _type&amp; <em
->argument name</em> ## <strong>n</strong>
-    );
-
-<span class="vellipsis">⋮</span>
-
-template &lt;
-    typename ResultType
-  , typename Args
-  , typename <em>argument name</em> ## <strong>0</strong> ## _type
-  , …
-  , typename <em>argument name</em> ## <strong>m</strong> ## _type
-&gt;
-ResultType
-    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        (ResultType(*)())
-      , Args const&amp; args
-      , <em>argument name</em> ## <strong>0</strong> ## _type&amp; <em
->argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>m</strong> ## _type&amp; <em
->argument name</em> ## <strong>m</strong>
-    );
-
-template &lt;typename Args&gt;
-typename boost_param_result_ ## __LINE__ ## <strong
->name</strong>&lt;Args&gt;::type
-    boost_param_impl ## <strong>name</strong>(Args const& args)
-{
-    return boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
-      , args
-      , args[ <em>keyword object of required parameter</em> ## <strong
->0</strong>]
-      , …
-      , args[ <em>keyword object of required parameter</em> ## <strong
->n</strong>]
-    );
-}
-
-template &lt;
-    typename ResultType
-  , typename Args
-  , typename <em>argument name</em> ## <strong>0</strong> ## _type
-  , …
-  , typename <em>argument name</em> ## <strong>n</strong> ## _type
-&gt;
-ResultType
-    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        (ResultType(*)())
-      , Args const&amp; args
-      , <em>argument name</em> ## <strong>0</strong> ## _type&amp; <em
->argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>n</strong> ## _type&amp; <em
->argument name</em> ## <strong>n</strong>
-    )
-{
-    return boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
-      , (args, <em>keyword object of optional parameter</em> ## <strong
->n + 1</strong> =
-            <em>default value of optional parameter</em> ## <strong
->n + 1</strong>
-        )
-      , <em>argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>n</strong>
-      , <em>default value of optional parameter</em> ## <strong
->n + 1</strong>
-    );
-}
-
-<span class="vellipsis">⋮</span>
-
-template &lt;
-    typename ResultType
-  , typename Args
-  , typename <em>argument name</em> ## <strong>0</strong> ## _type
-  , …
-  , typename <em>argument name</em> ## <strong>m</strong> ## _type
-&gt;
-ResultType
-    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
-        (ResultType(*)())
-      , Args const&amp; args
-      , <em>argument name</em> ## <strong>0</strong> ## _type&amp; <em
->argument name</em> ## <strong>0</strong>
-      , …
-      , <em>argument name</em> ## <strong>m</strong> ## _type&amp; <em
->argument name</em> ## <strong>m</strong>
-    )
-</pre>
 </dd>
 </dl>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a>, <a class="reference external"
-href="../../test/preprocessor_deduced.cpp">test/preprocessor_deduced.cpp</a>,
-and <a class="reference external"
-href="../../test/preprocessor_eval_category.cpp"
->test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
-usage of this macro.</p>
 </div>
 <div class="section"
 id="boost-parameter-member-function-result-name-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id52">6.2&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id53">6.2&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_MEMBER_FUNCTION(result, name,
 tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2748,26 +2459,506 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_FUNCTION</tt></a>, except:</p>
-<ul>
-<li><tt class="docutils literal">name</tt> may be qualified by the
-<tt class="docutils literal">static</tt> keyword to declare the member
-function and its helpers as not associated with any object of the enclosing
-type.</li>
-<li>Expansion of this macro omits all forward declarations of the front-end
-implementation and dispatch functions.</li>
-</ul>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> and <a class="reference external"
-href="../../test/preprocessor_eval_category.cpp"
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">static</tt> member function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  Also, just as with a normal function, optional parameters
+have default values, whereas required parameters do not.  Within the function
+body, either simply use the parameter name or pass the matching identifier
+with the leading underscore to the bracket operator of <tt
+class="docutils literal">args</tt> to extract the corresponding
+argument.  Note that the second method doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    BOOST_PARAMETER_MEMBER_FUNCTION((bool), static evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;), rvalue_const_bitset&lt;2&gt;())
+                (rr, (std::bitset&lt;4&gt;), rvalue_bitset&lt;3&gt;())
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(lrc)
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(lr)
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(args[_rr0])
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B::evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+B::evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+B::evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+B::evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+B::evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+B::evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+B::evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> and <a
+class="reference external" href="../../test/preprocessor_eval_category.cpp"
 >test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
 usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.  <tt
+class="docutils literal">name</tt> may be qualified by the <tt
+class="docutils literal">static</tt> keyword to declare the member function
+and its helpers as not associated with any object of the enclosing type.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>optional-specifier</em> {<em>optional-specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>required-specifier</em> {<em>required-specifier</em>}
+        '<strong>)</strong>'
+    )
+
+optional-specifier ::=
+    '<strong>(</strong>'
+        <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> '<strong>,</strong>' <em>default-value</em>
+    ')'
+
+required-specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">default-value</tt> is any valid C++
+expression; if necessary, user code can compute it in terms of
+<tt class="docutils literal">previous-name ## _type</tt>, where
+<tt class="docutils literal">previous-name</tt> is the
+<tt class="docutils literal">argument-name</tt> in a previous
+<tt class="docutils literal">specifier-group0</tt> or
+<tt class="docutils literal">specifier-group1</tt>.  <em>This expression will
+be invoked exactly once.</em></li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.  If <tt class="docutils literal"
+>restriction</tt> uses this form, then the type of the generated name <tt
+class="docutils literal">argument-name ## _type</tt> will be computed in terms
+of the <strong>target type</strong>, and the generated reference
+<tt class="docutils literal">argument-name</tt> (but not its corresponding
+entry in <tt class="docutils literal">args</tt>) will be cast to that
+type.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong>name</strong>
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong>name</strong>
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
+{
+    return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## <strong
+>name</strong>(
+        static_cast&lt;
+            typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , args
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>0</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>0</strong>])
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>n</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>n</strong>])
+    );
+}
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>n</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>n</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>n</strong>
+    )
+{
+    return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## <strong
+>name</strong>(
+        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+      , (args, <em>keyword object of optional parameter</em> ## <strong
+>n + 1</strong> =
+            <em>default value of optional parameter</em> ## <strong
+>n + 1</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>0</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>0</strong>
+        )
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>n</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>n</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of optional parameter</em> ## <strong>n + 1</strong>
+            &gt;::type
+        &gt;(<em>default value of optional parameter</em> ## <strong
+>n + 1</strong>)
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>m</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_0boost_ ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>m</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>m</strong>
+    )
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-c-mem-function-result-name-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id53">6.3&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id54">6.3&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_CONST_MEMBER_FUNCTION(result, name,
 tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2782,18 +2973,511 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-member-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_MEMBER_FUNCTION</tt></a>,
-except that the overloaded forwarding member functions and their helper
-methods are <tt class="docutils literal">const</tt>-qualified.</p>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">const</tt> member function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  Also, just as with a normal function, optional parameters
+have default values, whereas required parameters do not.  Within the function
+body, either simply use the parameter name or pass the matching identifier
+with the leading underscore to the bracket operator of <tt
+class="docutils literal">args</tt> to extract the corresponding
+argument.  Note that the second method doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    B()
+    {
+    }
+
+    BOOST_PARAMETER_CONST_MEMBER_FUNCTION((bool), evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;), rvalue_const_bitset&lt;2&gt;())
+                (rr, (std::bitset&lt;4&gt;), rvalue_bitset&lt;3&gt;())
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(lrc)
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(lr)
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(args[_rr0])
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B const b = B();
+b.evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+b.evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+b.evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+b.evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+b.evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+b.evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+b.evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>optional-specifier</em> {<em>optional-specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>required-specifier</em> {<em>required-specifier</em>}
+        '<strong>)</strong>'
+    )
+
+optional-specifier ::=
+    '<strong>(</strong>'
+        <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> '<strong>,</strong>' <em>default-value</em>
+    ')'
+
+required-specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">default-value</tt> is any valid C++
+expression; if necessary, user code can compute it in terms of
+<tt class="docutils literal">previous-name ## _type</tt>, where
+<tt class="docutils literal">previous-name</tt> is the
+<tt class="docutils literal">argument-name</tt> in a previous
+<tt class="docutils literal">specifier-group0</tt> or
+<tt class="docutils literal">specifier-group1</tt>.  <em>This expression will
+be invoked exactly once.</em></li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.  If <tt class="docutils literal"
+>restriction</tt> uses this form, then the type of the generated name <tt
+class="docutils literal">argument-name ## _type</tt> will be computed in terms
+of the <strong>target type</strong>, and the generated reference
+<tt class="docutils literal">argument-name</tt> (but not its corresponding
+entry in <tt class="docutils literal">args</tt>) will be cast to that
+type.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_const_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_const_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_const_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_const_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(Args const& args) const
+{
+    return this-&gt;
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## <strong>name</strong>(
+        static_cast&lt;
+            typename boost_param_result_const_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , args
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>0</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>0</strong>])
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>n</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>n</strong>])
+    );
+}
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>n</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>n</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>n</strong>
+    ) const
+{
+    return this-&gt;
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## <strong>name</strong>(
+        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+      , (args, <em>keyword object of optional parameter</em> ## <strong
+>n + 1</strong> =
+            <em>default value of optional parameter</em> ## <strong
+>n + 1</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>0</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>0</strong>
+        )
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>n</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>n</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of optional parameter</em> ## <strong>n + 1</strong>
+            &gt;::type
+        &gt;(<em>default value of optional parameter</em> ## <strong
+>n + 1</strong>)
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>m</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>m</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>m</strong>
+    ) const
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-function-call-op-result-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id54">6.4&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id55">6.4&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_FUNCTION_CALL_OPERATOR(result,
 tag_ns, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2808,45 +3492,411 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-member-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_MEMBER_FUNCTION</tt></a>,
-except that the name of the forwarding member function overloads is
-<tt class="docutils literal">operator()</tt>.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field">
-<th class="field-name" colspan="2">Generated names in enclosing scope:</th>
+<th class="field-name" colspan="2">Example usage:</th>
 </tr>
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<ul class="first last simple">
-<li><tt class="docutils literal">boost_param_result_ ## __LINE__ ##
-operator</tt></li>
-<li><tt class="docutils literal">boost_param_params_ ## __LINE__ ##
-operator</tt></li>
-<li><tt class="docutils literal">boost_param_parameters_ ## __LINE__ ##
-operator</tt></li>
-<li><tt class="docutils literal">boost_param_impl ## operator</tt></li>
-<li><tt class="docutils literal">boost_param_dispatch_0boost_ ## __LINE__ ##
-operator</tt></li>
-<li><tt class="docutils literal">boost_param_dispatch_1boost_ ## __LINE__ ##
-operator</tt></li>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">tag</tt> by
+default.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(y)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(z)
+</pre>
+<p class="first">Use the macro as a substitute for a normal function call
+operator header.  Enclose the return type in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  This is especially useful
+when implementing multiple Boost.Parameter-enabled function call operator
+overloads.</p>
+<pre class="first literal-block">
+class char_reader
+{
+    int index;
+    char const* key;
+
+ public:
+    explicit char_reader(char const* k) : index(0), key(k)
+    {
+    }
+
+    BOOST_PARAMETER_FUNCTION_CALL_OPERATOR((void), tag,
+        (deduced
+            (required
+                (y, (int))
+                (z, (char const*))
+            )
+        )
+    )
+    {
+        this->index = y;
+        this->key = z;
+    }
+
+    <a class="reference internal"
+href="#boost-parameter-const-function-call-op-result-tag-namespace-arguments"
+>BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR</a>((char), tag,
+        (deduced
+            (required
+                (y, (bool))
+                (z, (std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;))
+            )
+        )
+    )
+    {
+        return y ? (
+            (z.find(this->key)->second)[this->index]
+        ) : this->key[this->index];
+    }
+};
+</pre>
+<p class="first">As with regular argument-dependent lookup, the value types of
+the arguments passed in determine which function call operator overload gets
+invoked.</p>
+<pre class="first literal-block">
+char const* keys[] = {"foo", "bar", "baz"};
+std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt; k2s;
+k2s[keys[0]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("qux");
+k2s[keys[1]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("wmb");
+k2s[keys[2]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("zxc");
+char_reader r(keys[0]);
+
+// positional arguments
+BOOST_TEST_EQ('q', (r(true, k2s)));
+BOOST_TEST_EQ('f', (r(false, k2s)));
+
+// named arguments
+r(_z = keys[1], _y = 1);
+BOOST_TEST_EQ('m', (r(_z = k2s, _y = true)));
+BOOST_TEST_EQ('a', (r(_z = k2s, _y = false)));
+
+// deduced arguments
+r(keys[2], 2);
+BOOST_TEST_EQ('c', (r(k2s, true)));
+BOOST_TEST_EQ('z', (r(k2s, false)));
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> and <a
+class="reference external" href="../../test/preprocessor_deduced.cpp"
+>test/preprocessor_deduced.cpp</a> test programs demonstrate proper usage of
+this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function call operator resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>optional-specifier</em> {<em>optional-specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>required-specifier</em> {<em>required-specifier</em>}
+        '<strong>)</strong>'
+    )
+
+optional-specifier ::=
+    '<strong>(</strong>'
+        <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> '<strong>,</strong>' <em>default-value</em>
+    ')'
+
+required-specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">default-value</tt> is any valid C++
+expression; if necessary, user code can compute it in terms of
+<tt class="docutils literal">previous-name ## _type</tt>, where
+<tt class="docutils literal">previous-name</tt> is the
+<tt class="docutils literal">argument-name</tt> in a previous
+<tt class="docutils literal">specifier-group0</tt> or
+<tt class="docutils literal">specifier-group1</tt>.  <em>This expression will
+be invoked exactly once.</em></li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.  If <tt class="docutils literal"
+>restriction</tt> uses this form, then the type of the generated name <tt
+class="docutils literal">argument-name ## _type</tt> will be computed in terms
+of the <strong>target type</strong>, and the generated reference
+<tt class="docutils literal">argument-name</tt> (but not its corresponding
+entry in <tt class="docutils literal">args</tt>) will be cast to that
+type.</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## operator
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## operator
+    boost_param_parameters_ ## __LINE__ ## operator;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## operator()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## operator(
+        boost_param_parameters_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## operator()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## operator(
+        boost_param_parameters_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## operator&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## operator(Args const& args)
+{
+    return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## operator(
+        static_cast&lt;
+            typename boost_param_result_ ## __LINE__ ## operator&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , args
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>0</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>0</strong>])
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>n</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>n</strong>])
+    );
+}
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>n</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_0boost_ ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>n</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>n</strong>
+    )
+{
+    return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## operator(
+        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+      , (args, <em>keyword object of optional parameter</em> ## <strong
+>n + 1</strong> =
+            <em>default value of optional parameter</em> ## <strong
+>n + 1</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>0</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>0</strong>
+        )
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>n</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>n</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of optional parameter</em> ## <strong>n + 1</strong>
+            &gt;::type
+        &gt;(<em>default value of optional parameter</em> ## <strong
+>n + 1</strong>)
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>m</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_0boost_ ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>m</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>m</strong>
+    )
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-const-function-call-op-result-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id55">6.5&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id56">6.5&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR(result,
 tag_ns, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2861,20 +3911,506 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-function-call-op-result-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_FUNCTION_CALL_OPERATOR</tt></a>,
-except that the overloaded function call operators and their helper methods
-are <tt class="docutils literal">const</tt>-qualified.</p>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> and <a class="reference external"
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">const</tt> function call operator header.  Enclose
+the return type <tt class="docutils literal">bool</tt> in parentheses.  For
+each parameter, also enclose the expected value type in parentheses.  Since
+the value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  Also, just as with a normal function, optional parameters
+have default values, whereas required parameters do not.  Within the function
+body, either simply use the parameter name or pass the matching identifier
+with the leading underscore to the bracket operator of <tt
+class="docutils literal">args</tt> to extract the corresponding
+argument.  Note that the second method doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    B()
+    {
+    }
+
+    BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR((bool), kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;), rvalue_const_bitset&lt;2&gt;())
+                (rr, (std::bitset&lt;4&gt;), rvalue_bitset&lt;3&gt;())
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(lrc)
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(lr)
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(args[_rr0])
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B const b = B();
+b(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+b(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+b((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+b(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+b(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+b(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+b(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a>, <a
+class="reference external" href="../../test/preprocessor_deduced.cpp"
+>test/preprocessor_deduced.cpp</a>, and <a class="reference external"
 href="../../test/preprocessor_eval_cat_8.cpp"
 >test/preprocessor_eval_cat_8.cpp</a> test programs demonstrate proper usage
 of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function call operator resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>optional-specifier</em> {<em>optional-specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>required-specifier</em> {<em>required-specifier</em>}
+        '<strong>)</strong>'
+    )
+
+optional-specifier ::=
+    '<strong>(</strong>'
+        <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> '<strong>,</strong>' <em>default-value</em>
+    ')'
+
+required-specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">default-value</tt> is any valid C++
+expression; if necessary, user code can compute it in terms of
+<tt class="docutils literal">previous-name ## _type</tt>, where
+<tt class="docutils literal">previous-name</tt> is the
+<tt class="docutils literal">argument-name</tt> in a previous
+<tt class="docutils literal">specifier-group0</tt> or
+<tt class="docutils literal">specifier-group1</tt>.  <em>This expression will
+be invoked exactly once.</em></li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.  If <tt class="docutils literal"
+>restriction</tt> uses this form, then the type of the generated name <tt
+class="docutils literal">argument-name ## _type</tt> will be computed in terms
+of the <strong>target type</strong>, and the generated reference
+<tt class="docutils literal">argument-name</tt> (but not its corresponding
+entry in <tt class="docutils literal">args</tt>) will be cast to that
+type.</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_const_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_const_ ## __LINE__ ## operator
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_const_ ## __LINE__ ## operator
+    boost_param_parameters_const_ ## __LINE__ ## operator;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## operator()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
+        boost_param_parameters_const_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## operator()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
+        boost_param_parameters_const_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_const_ ## __LINE__ ## operator&lt;Args&gt;::type
+    boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+{
+    return this-&gt;
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## operator(
+        static_cast&lt;
+            typename boost_param_result_const_ ## __LINE__ ## operator&lt;
+                Args
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , args
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>0</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>0</strong>])
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of required parameter</em> ## <strong>n</strong>
+            &gt;::type
+        &gt;(args[ <em>keyword object of required parameter</em> ## <strong
+>n</strong>])
+    );
+}
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>n</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>n</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>n</strong>
+    ) const
+{
+    return this-&gt;
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## operator(
+        static_cast&lt;ResultType(*)()&gt;(std::nullptr)
+      , (args, <em>keyword object of optional parameter</em> ## <strong
+>n + 1</strong> =
+            <em>default value of optional parameter</em> ## <strong
+>n + 1</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>0</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>0</strong>
+        )
+      , …
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt; <em
+>argument name</em> ## <strong>n</strong> ## _type&gt;(
+            <em>argument name</em> ## <strong>n</strong>
+        )
+      , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;
+            typename boost::parameter::value_type&lt;
+                Args
+              , <em
+>keyword tag type of optional parameter</em> ## <strong>n + 1</strong>
+            &gt;::type
+        &gt;(<em>default value of optional parameter</em> ## <strong
+>n + 1</strong>)
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;
+    typename ResultType
+  , typename Args
+  , typename <em>argument name</em> ## <strong>0</strong> ## _type
+  , …
+  , typename <em>argument name</em> ## <strong>m</strong> ## _type
+&gt;
+ResultType
+    boost_param_dispatch_const_0boost_ ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const&amp; args
+      , <em>argument name</em> ## <strong>0</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>0</strong>
+      , …
+      , <em>argument name</em> ## <strong>m</strong> ## _type&amp;&amp; <em
+>argument name</em> ## <strong>m</strong>
+    ) const
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-constructor-cls-impl-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id56">6.6&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id57">6.6&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_CONSTRUCTOR(cls, impl, tag_namespace,
 arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -2894,36 +4430,215 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field">
-<th class="field-name" colspan="2">Requires:</th>
+<th class="field-name" colspan="2">Example usage:</th>
 </tr>
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first"><tt class="docutils literal">cls</tt> is the name of this
-class.  <tt class="docutils literal">impl</tt> is the parenthesized
-implementation base class for <tt class="docutils literal"
->cls</tt>.  <tt class="docutils literal">tag_namespace</tt> is the namespace
-in which the keywords used by the function resides.  <tt
-class="docutils literal">arguments</tt> is a list of
-<em>argument-specifiers</em>, as defined in <a class="reference internal"
-href="#boost-parameter-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_FUNCTION</tt></a> except that
-<em>optional-specifier</em> no longer includes <em>default-value</em>.  It is
-up to the delegate constructor in <tt class="docutils literal">impl</tt> to
-determine the default value of all optional arguments.</p>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">tag</tt> by
+default.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(y)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(z)
+</pre>
+<p class="first">In the base class, implement a delegate constructor template
+that takes in an <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a>.  You must pass the identifiers with
+leading underscores to <tt class="docutils literal">args</tt> in order to
+extract the corresponding arguments.</p>
+<pre class="first literal-block">
+class char_read_base
+{
+    int index;
+    char const* key;
+
+ public:
+    template &lt;typename Args&gt;
+    explicit char_read_base(Args const& args)
+      : index(args[_y]), key(args[_z])
+    {
+    }
+
+    BOOST_PARAMETER_FUNCTION_CALL_OPERATOR((void), tag,
+        (deduced
+            (required
+                (y, (int))
+                (z, (char const*))
+            )
+        )
+    )
+    {
+        this-&gt;index = y;
+        this-&gt;key = z;
+    }
+
+    <a class="reference internal"
+href="#boost-parameter-const-function-call-op-result-tag-namespace-arguments"
+>BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR</a>((char), tag,
+        (deduced
+            (required
+                (y, (bool))
+                (z, (std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;))
+            )
+        )
+    )
+    {
+        return y ? (
+            (z.find(this-&gt;key)-&gt;second)[this-&gt;index]
+        ) : this-&gt;key[this-&gt;index];
+    }
+};
+</pre>
+<p class="first">Use the macro as a substitute for a normal constructor
+definition.  Note the lack of an explicit body.  Enclose the base type in
+parentheses.  For each parameter, also enclose the expected value type in
+parentheses.  Since the value types are mutually exclusive, you can wrap the
+parameters in a <tt class="docutils literal">(deduced …)</tt> clause.</p>
+<pre class="first literal-block">
+struct char_reader : public char_read_base
+{
+    BOOST_PARAMETER_CONSTRUCTOR(char_reader, (char_read_base), tag,
+        (deduced
+            (required
+                (y, (int))
+                (z, (char const*))
+            )
+        )
+    )
+};
+</pre>
+<p class="first">The following <tt class="docutils literal">char_reader</tt>
+constructor calls are legal.</p>
+<pre class="first literal-block">
+char const* keys[] = {"foo", "bar", "baz"};
+std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt; k2s;
+k2s[keys[0]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("qux");
+k2s[keys[1]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("wmb");
+k2s[keys[2]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("zxc");
+
+// positional arguments
+char_reader r0(0, keys[0]);
+BOOST_TEST_EQ('q', (r0(true, k2s)));
+BOOST_TEST_EQ('f', (r0(false, k2s)));
+
+// named arguments
+char_reader r1(_z = keys[1], _y = 1);
+BOOST_TEST_EQ('m', (r1(_z = k2s, _y = true)));
+BOOST_TEST_EQ('a', (r1(_z = k2s, _y = false)));
+
+// deduced arguments
+char_reader r2(keys[2], 2);
+BOOST_TEST_EQ('c', (r2(k2s, true)));
+BOOST_TEST_EQ('z', (r2(k2s, false)));
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> and <a
+class="reference external" href="../../test/preprocessor_eval_category.cpp"
+>test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
 </td>
 </tr>
 <tr class="field">
-<th class="field-name" colspan="2">Generated names in enclosing scope:</th>
+<th class="field-name" colspan="2">Macro parameters:</th>
 </tr>
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<ul class="first last simple">
-<li><tt class="docutils literal">boost_param_params_ ## __LINE__ ##
-ctor</tt></li>
-<li><tt class="docutils literal">constructor_parameters ## __LINE__</tt></li>
+<ul class="last simple">
+<li><tt class="docutils literal">cls</tt> is the name of the enclosing
+class.</li>
+<li><tt class="docutils literal">impl</tt> is the parenthesized implementation
+base class for <tt class="docutils literal">cls</tt>.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the constructor resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
 </ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the delegate constructor in <tt class="docutils literal">impl</tt> to
+determine the default value of all optional arguments.</p>
 </td>
 </tr>
 </tbody>
@@ -2938,25 +4653,21 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 <li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <pre class="last literal-block">
 struct boost_param_params_ ## __LINE__ ## ctor
-  : boost::parameter::parameters&lt;
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
         <em>list of parameter specifications, based on arguments</em>
     &gt;
 {
 };
 
-typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
+typedef boost_param_params_ ## __LINE__ ## ctor
     constructor_parameters ## __LINE__;
 
 template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>cls</em>(A0&amp;&amp; a0, …, A ## <strong
+<strong>cls</strong>(A0&amp;&amp; a0, …, A ## <strong
 >n</strong> &amp;&amp; a ## <strong>n</strong>)
-  : <em>impl</em>(
+  : <strong>impl</strong>(
         constructor_parameters ## __LINE__(
             std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2974,9 +4685,9 @@ class="docutils literal">forward</tt></a>&lt;A ## <strong
 <span class="vellipsis">⋮</span>
 
 template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>cls</em>(A0&amp;&amp; a0, …, A ## <strong
+<strong>cls</strong>(A0&amp;&amp; a0, …, A ## <strong
 >m</strong>&amp;&amp; a ## <strong>m</strong>)
-  : <em>impl</em>(
+  : <strong>impl</strong>(
         constructor_parameters ## __LINE__(
             std::<a class="reference external"
 href="http://en.cppreference.com/w/cpp/utility/forward"><tt
@@ -2991,72 +4702,12 @@ class="docutils literal">forward</tt></a>&lt;A ## <strong
 {
 }
 </pre>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<pre class="last literal-block">
-struct boost_param_params_ ## __LINE__ ## ctor
-  : boost::parameter::parameters&lt;
-        <em>list of parameter specifications, based on arguments</em>
-    &gt;
-{
-};
-
-typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
-    constructor_parameters ## __LINE__;
-
-template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>cls</em>(A0 const&amp; a0, …, A ## <strong
->n</strong> const&amp; a ## <strong>n</strong>)
-  : <em>impl</em>(constructor_parameters ## __LINE__(a0, …, a ## <strong
->n</strong>))
-{
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
-<em>cls</em>(A0&amp; a0, …, A ## <strong
->n</strong> &amp; a ## <strong>n</strong>)
-  : <em>impl</em>(constructor_parameters ## __LINE__(a0, …, a ## <strong
->n</strong>))
-{
-}
-
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>cls</em>(A0 const&amp; a0, …, A ## <strong
->m</strong> const&amp; a ## <strong>m</strong>)
-  : <em>impl</em>(constructor_parameters ## __LINE__(a0, …, a ## <strong
->m</strong>))
-{
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
-<em>cls</em>(A0&amp; a0, …, A ## <strong
->m</strong> &amp; a ## <strong>m</strong>)
-  : <em>impl</em>(constructor_parameters ## __LINE__(a0, …, a ## <strong
->m</strong>))
-{
-}
-</pre>
 </dd>
 </dl>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> and <a class="reference external"
-href="../../test/preprocessor_eval_category.cpp"
->test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
-usage of this macro.</p>
 </div>
 <div class="section"
 id="boost-parameter-basic-function-result-name-tag-namespace-arguments">
-<h2><a class="toc-backref" href="#id57">6.7&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id58">6.7&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_BASIC_FUNCTION(result, name,
 tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -3071,34 +4722,388 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_FUNCTION</tt></a>, except:</p>
-<ul>
-<li>For the argument specifiers syntax, <em>optional-specifier</em> no longer
-includes <em>default-value</em>.  It is up to the function body to determine
-the default value of all optional arguments.</li>
-<li>Generated names in the enclosing scope no longer include
-<tt class="docutils literal">boost_param_dispatch_0boost_ ## __LINE__ ##
-name</tt> or <tt class="docutils literal">boost_param_dispatch_1boost_ ##
-__LINE__ ## name</tt>.</li>
-<li>Expansion of this macro omits all overloads of <tt
-class="docutils literal">boost_param_dispatch_0boost_ ## __LINE__ ## name</tt>
-and <tt class="docutils literal">boost_param_dispatch_1boost_ ## __LINE__ ##
-name</tt> and stops at the header of <tt class="docutils literal"
->boost_param_impl ## name</tt>.  Therefore, only the <a
-class="reference internal" href="#argumentpack"><span class="concept"
->ArgumentPack</span></a> type <tt class="docutils literal">Args</tt> and its
-object instance <tt class="docutils literal">args</tt> are available for use
-within the function body.</li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal function
+header.  Enclose the return type <tt class="docutils literal">bool</tt> in
+parentheses.  For each parameter, also enclose the expected value type in
+parentheses.  Since the value types are mutually exclusive, you can wrap the
+parameters in a <tt class="docutils literal">(deduced …)</tt>
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of <tt class="docutils literal"
+>args</tt> to extract the corresponding argument, but at least this doesn't
+require <tt class="docutils literal">std::forward</tt> to preserve value
+categories.</p>
+<pre class="first literal-block">
+BOOST_PARAMETER_BASIC_FUNCTION((bool), evaluate, kw,
+    (deduced
+        (required
+            (lrc, (std::bitset&lt;1&gt;))
+            (lr, (std::bitset&lt;2&gt;))
+        )
+        (optional
+            (rrc, (std::bitset&lt;3&gt;))
+            (rr, (std::bitset&lt;4&gt;))
+        )
+    )
+)
+{
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference_to_const
+      , U::evaluate_category&lt;0&gt;(args[_lrc])
+    );
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference
+      , U::evaluate_category&lt;1&gt;(args[_lr])
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference_to_const
+      , U::evaluate_category&lt;2&gt;(
+            args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+        )
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference
+      , U::evaluate_category&lt;3&gt;(args[_rr0 | rvalue_bitset&lt;3&gt;()])
+    );
+
+    return true;
+}
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
 </ul>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const&);
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>n</strong>
+        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>()
+    )
+{
+    return boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>m</strong>
+        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>()
+    )
+{
+    return boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-basic-member-function-result-name-tag-ns-arguments">
-<h2><a class="toc-backref" href="#id58">6.8&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id59">6.8&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_BASIC_MEMBER_FUNCTION(result, name,
 tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -3113,25 +5118,391 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-basic-function-result-name-tag-namespace-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_BASIC_FUNCTION</tt></a>,
-except that:</p>
-<ul>
-<li><tt class="docutils literal">name</tt> may be qualified by the
-<tt class="docutils literal">static</tt> keyword to declare the member
-function and its helpers as not associated with any object of the enclosing
-type.</li>
-<li>Expansion of this macro omits the forward declaration of the
-implementation function.</li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">static</tt> member function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  However, unlike a normal function, default values must be
+specified within the function body.  Also within the function body, you must
+pass the matching identifier with the leading underscore to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the
+corresponding argument, but at least this doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    BOOST_PARAMETER_BASIC_MEMBER_FUNCTION((bool), static evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;))
+                (rr, (std::bitset&lt;4&gt;))
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B::evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+B::evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+B::evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+B::evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+B::evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+B::evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+B::evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.  <tt
+class="docutils literal">name</tt> may be qualified by the <tt
+class="docutils literal">static</tt> keyword to declare the member function
+and its helpers as not associated with any object of the enclosing type.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
 </ul>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>n</strong>
+        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>m</strong>
+        &gt;::type = boost_param_parameters_ ## __LINE__ ## <strong
+>name</strong>()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
+        boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
 </div>
 <div class="section"
 id="boost-parameter-basic-c-mem-function-result-name-tag-ns-arguments">
-<h2><a class="toc-backref" href="#id59">6.9&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id60">6.9&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION(result,
 name, tag_namespace, arguments)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -3146,17 +5517,2693 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
-<p>Same as <a class="reference internal"
-href="#boost-parameter-basic-member-function-result-name-tag-ns-arguments"
-><tt class="docutils literal">BOOST_PARAMETER_BASIC_MEMBER_FUNCTION</tt></a>,
-except that the overloaded forwarding member functions and their helper
-methods are <tt class="docutils literal">const</tt>-qualified.</p>
-<p>The <a class="reference external" href="../../test/preprocessor.cpp"
->test/preprocessor.cpp</a> test program demonstrates proper usage of this
-macro.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">const</tt> member function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  However, unlike a normal function, default values must be
+specified within the function body.  Also within the function body, you must
+pass the matching identifier with the leading underscore to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the
+corresponding argument, but at least this doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    B()
+    {
+    }
+
+    BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION((bool), evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;))
+                (rr, (std::bitset&lt;4&gt;))
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B const b = B();
+b.evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+b.evaluate(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+b.evaluate((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+b.evaluate(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+b.evaluate(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+b.evaluate(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+b.evaluate(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated forwarding functions.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_const_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_const_ ## __LINE__ ## <strong>name</strong>
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_const_ ## __LINE__ ## <strong>name</strong>
+    boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>n</strong>
+        &gt;::type = boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    <strong>name</strong>(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>::match&lt;
+            A0, …, A ## <strong>m</strong>
+        &gt;::type = boost_param_parameters_const_ ## __LINE__ ## <strong
+>name</strong>()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_const_ ## __LINE__ ## <strong
+>name</strong>&lt;Args&gt;::type
+    boost_param_impl_const ## __LINE__ ## <strong
+>name</strong>(Args const& args) const
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section"
+id="boost-parameter-basic-function-call-op-result-tag-namespace-arguments">
+<h2><a class="toc-backref" href="#id61">6.10&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR(result,
+tag_ns, arguments)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">tag</tt> by
+default.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(y)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(z)
+</pre>
+<p class="first">Use the macro as a substitute for a normal function call
+operator header.  Enclose the return type in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  This is especially useful
+when implementing multiple Boost.Parameter-enabled function call operator
+overloads.</p>
+<pre class="first literal-block">
+class char_reader
+{
+    int index;
+    char const* key;
+
+ public:
+    explicit char_reader(char const* k) : index(0), key(k)
+    {
+    }
+
+    BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR((void), tag,
+        (deduced
+            (required
+                (y, (int))
+                (z, (char const*))
+            )
+        )
+    )
+    {
+        this-&gt;index = args[_y];
+        this-&gt;key = args[_z];
+    }
+
+    <a class="reference internal"
+href="#boost-parameter-basic-const-function-call-op-result-tag-ns-args"
+>BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR</a>((char), tag,
+        (deduced
+            (required
+                (y, (bool))
+                (z, (std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;))
+            )
+        )
+    )
+    {
+        return args[_y] ? (
+            (args[_z].find(this-&gt;key)-&gt;second)[this-&gt;index]
+        ) : this-&gt;key[this-&gt;index];
+    }
+};
+</pre>
+<p class="first">As with regular argument-dependent lookup, the value types of
+the arguments passed in determine which function call operator overload gets
+invoked.</p>
+<pre class="first literal-block">
+char const* keys[] = {"foo", "bar", "baz"};
+std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/container/map"><tt
+class="docutils literal">map</tt></a>&lt;char const*,std::<a
+class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt; k2s;
+k2s[keys[0]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("qux");
+k2s[keys[1]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("wmb");
+k2s[keys[2]] = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
+class="docutils literal">string</tt></a>&gt;("zxc");
+char_reader r(keys[0]);
+
+// positional arguments
+BOOST_TEST_EQ('q', (r(true, k2s)));
+BOOST_TEST_EQ('f', (r(false, k2s)));
+
+// named arguments
+r(_z = keys[1], _y = 1);
+BOOST_TEST_EQ('m', (r(_z = k2s, _y = true)));
+BOOST_TEST_EQ('a', (r(_z = k2s, _y = false)));
+
+// deduced arguments
+r(keys[2], 2);
+BOOST_TEST_EQ('c', (r(k2s, true)));
+BOOST_TEST_EQ('z', (r(k2s, false)));
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function call operator resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_ ## __LINE__ ## operator
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_ ## __LINE__ ## operator
+    boost_param_parameters_ ## __LINE__ ## operator;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## operator()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## operator(
+        boost_param_parameters_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_ ## __LINE__ ## operator()
+    )
+{
+    return this-&gt;boost_param_impl ## __LINE__ ## operator(
+        boost_param_parameters_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_ ## __LINE__ ## operator&lt;Args&gt;::type
+    boost_param_impl ## __LINE__ ## operator(Args const& args)
+</pre>
+</dd>
+</dl>
+</div>
+<div class="section"
+id="boost-parameter-basic-const-function-call-op-result-tag-ns-args">
+<h2><a class="toc-backref" href="#id62">6.11&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal"
+>BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR(result, tag_ns,
+args)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Define the named parameters that will comprise the argument
+specification that this macro will use.  Ensure that all their tag types are
+in the same namespace, which is <tt class="docutils literal">kw</tt> in this
+case.  The identifiers with leading underscores can be passed to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the same
+argument to which the corresponding named parameter (without underscores) is
+bound, as will be shown later.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a normal <tt
+class="docutils literal">const</tt> function call operator header.  Enclose
+the return type <tt class="docutils literal">bool</tt> in parentheses.  For
+each parameter, also enclose the expected value type in parentheses.  Since
+the value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  However, unlike a normal function, default values must be
+specified within the function body.  Also within the function body, you must
+pass the matching identifier with the leading underscore to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the
+corresponding argument, but at least this doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
+<pre class="first literal-block">
+struct B
+{
+    B()
+    {
+    }
+
+    BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR((bool), kw,
+        (deduced
+            (required
+                (lrc, (std::bitset&lt;1&gt;))
+                (lr, (std::bitset&lt;2&gt;))
+            )
+            (optional
+                (rrc, (std::bitset&lt;3&gt;))
+                (rr, (std::bitset&lt;4&gt;))
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">The following function calls are legal.</p>
+<pre class="first literal-block">
+B const b = B();
+b(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+  , rvalue_bitset&lt;3&gt;()
+);
+b(  // positional arguments
+    lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+);
+b((  // composed arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+));
+b(  // named arguments
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+b(  // named arguments
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="first">Because the parameters were wrapped in a <tt
+class="docutils literal">(deduced …)</tt> clause, the following function calls
+are also legal.</p>
+<pre class="first literal-block">
+b(  // deduced arguments
+    rvalue_bitset&lt;3&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+  , lvalue_bitset&lt;1&gt;()
+  , rvalue_const_bitset&lt;2&gt;()
+);
+b(  // deduced arguments
+    lvalue_bitset&lt;1&gt;()
+  , lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
+demonstrates proper usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+<li><tt class="docutils literal">tag_namespace</tt> is the namespace in which
+the keywords used by the function call operator resides.</li>
+<li><tt class="docutils literal">arguments</tt> is a list of <em>argument
+specifiers</em>, as defined below.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<pre class="first literal-block">
+argument-specifiers ::= <em>specifier-group0</em> {<em>specifier-group0</em>}
+
+specifier-group0 ::= <em>specifier-group1</em> |
+    (
+        '<strong>(</strong>' '<strong>deduced</strong>'
+            <em>specifier-group1</em> {<em>specifier-group1</em>}
+        '<strong>)</strong>'
+    )
+
+specifier-group1 ::=
+    (
+        '<strong>(</strong>' '<strong>optional</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    ) | (
+        '<strong>(</strong>' '<strong>required</strong>'
+            <em>specifier</em> {<em>specifier</em>}
+        '<strong>)</strong>'
+    )
+
+specifier ::=
+    '<strong>(</strong>' <em>argument-name</em> '<strong>,</strong>' <em
+>restriction</em> ')'
+
+restriction ::=
+    ( '<strong>*</strong>' '<strong>(</strong>' <em>mfc</em> '<strong
+>)</strong>' ) |
+    ( '<strong>(</strong>' <em>typename</em> '<strong>)</strong>' ) |
+    '<strong>*</strong>'
+</pre>
+<ul class="last simple">
+<li><tt class="docutils literal">argument-name</tt> is any valid C++
+identifier.</li>
+<li><tt class="docutils literal">mfc</tt> is an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is a
+<a class="reference external"
+href="../../../mpl/doc/refmanual/integral-constant.html">Boolean Integral
+Concept</a>; however, user code <em>cannot</em> compute
+<tt class="docutils literal">mfc</tt> in terms of
+<tt class="docutils literal">previous-name ## _type</tt>.</li>
+<li><tt class="docutils literal">type-name</tt> is either the name of a
+<strong>target type</strong> or an <a class="reference external"
+href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
+Metafunction Class</a> whose first argument will be the type of the
+corresponding <tt class="docutils literal">argument-name</tt>, whose second
+argument will be the entire <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a>, and whose return type is the
+<strong>target type</strong>.</li>
+</ul>
+<p>Note that <em>specifier</em> does not include <em>default-value</em>.  It
+is up to the function body to determine the default value of all optional
+arguments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<p class="first"><strong>Where</strong>:</p>
+<ul class="simple">
+<li><tt class="docutils literal">n</tt> denotes the <em>minimum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+<li><tt class="docutils literal">m</tt> denotes the <em>maximum</em> arity, as
+determined from <tt class="docutils literal">arguments</tt>.</li>
+</ul>
+<pre class="last literal-block">
+template &lt;typename T&gt;
+struct boost_param_result_const_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+struct boost_param_params_const_ ## __LINE__ ## operator
+  : <a class="reference internal" href="#parameters">parameters</a>&lt;
+        <em>list of parameter specifications, based on arguments</em>
+    &gt;
+{
+};
+
+typedef boost_param_params_const_ ## __LINE__ ## operator
+    boost_param_parameters_const_ ## __LINE__ ## operator;
+
+template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>n</strong> &amp;&amp; a ## <strong
+>n</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>n</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## operator()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
+        boost_param_parameters_const_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>n</strong>&gt;(a ## <strong>n</strong>)
+        )
+    );
+}
+
+<span class="vellipsis">⋮</span>
+
+template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
+<em>result type</em>
+    operator()(
+        A0&amp;&amp; a0, …, A ## <strong>m</strong> &amp;&amp; a ## <strong
+>m</strong>
+      , typename boost_param_parameters_const_ ## __LINE__ ## operator
+        ::match&lt;A0, …, A ## <strong>m</strong>&gt;::type
+        = boost_param_parameters_const_ ## __LINE__ ## operator()
+    ) const
+{
+    return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
+        boost_param_parameters_const_ ## __LINE__ ## operator()(
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+          , …
+          , std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"><tt
+class="docutils literal">forward</tt></a>&lt;A ## <strong
+>m</strong>&gt;(a ## <strong>m</strong>)
+        )
+    );
+}
+
+template &lt;typename Args&gt;
+typename boost_param_result_const_ ## __LINE__ ## operator&lt;Args&gt;::type
+    boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+</pre>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-function-result-name">
+<h2><a class="toc-backref" href="#id63">6.12&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_FUNCTION(result,
+name)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the function;
+however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw1) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw2) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a variadic function
+header.  Enclose the return type <tt class="docutils literal">bool</tt> in
+parentheses.</p>
+<pre class="first literal-block">
+BOOST_PARAMETER_NO_SPEC_FUNCTION((bool), evaluate)
+{
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference_to_const
+      , U::evaluate_category&lt;0&gt;(args[_lrc])
+    );
+    BOOST_TEST_EQ(
+        passed_by_lvalue_reference
+      , U::evaluate_category&lt;1&gt;(args[_lr])
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference_to_const
+      , U::evaluate_category&lt;2&gt;(
+            args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+        )
+    );
+    BOOST_TEST_EQ(
+        passed_by_rvalue_reference
+      , U::evaluate_category&lt;3&gt;(args[_rr0 | rvalue_bitset&lt;3&gt;()])
+    );
+
+    return true;
+}
+</pre>
+<p class="first">To invoke the function, bind all its arguments to named
+parameters.</p>
+<pre class="first literal-block">
+evaluate(
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+evaluate(
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated implementation function.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const& args
+    );
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    <strong>name</strong
+>(TaggedArg0 const&amp; arg0, TaggedArgs const&amp;... args)
+{
+    return boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const& args
+    )
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-member-function-result-name">
+<h2><a class="toc-backref" href="#id64">6.13&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION(result,
+name)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">When designing a front-end class template whose back-end is
+configurable via parameterized inheritance, it can be useful to omit argument
+specifiers from a named-parameter member function so that the delegate member
+functions of the back-end classes can enforce their own specifications.</p>
+<pre class="first literal-block">
+template &lt;typename B&gt;
+struct frontend : B
+{
+    frontend() : B()
+    {
+    }
+
+    BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((void), initialize)
+    {
+        this-&gt;initialize_impl(args);
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the member
+function; however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a0)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a1)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a2)
+</pre>
+<p class="first">For this example, each of the back-end class templates
+requires its own parameter to be present in the argument pack.  In practice,
+such parameters should be optional, with default values.</p>
+<pre class="first literal-block">
+template &lt;typename T&gt;
+class backend0
+{
+    T a0;
+
+ public:
+    backend0() : a0()
+    {
+    }
+
+    T const&amp; get_a0() const
+    {
+        return this-&gt;a0;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        this-&gt;a0 = args[_a0];
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend1 : public B
+{
+    T a1;
+
+ public:
+    backend1() : B(), a1()
+    {
+    }
+
+    T const&amp; get_a1() const
+    {
+        return this-&gt;a1;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        B::initialize_impl(args);
+        this-&gt;a1 = args[_a1];
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend2 : public B
+{
+    T a2;
+
+ public:
+    backend2() : B(), a2()
+    {
+    }
+
+    T const&amp; get_a2() const
+    {
+        return this-&gt;a2;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        B::initialize_impl(args);
+        this-&gt;a2 = args[_a2];
+    }
+};
+</pre>
+<p class="first">This example shows that while <tt class="docutils literal"
+>backend0</tt> must always be the root base class template and that <tt
+class="docutils literal">frontend</tt> must always be the most derived class
+template, the other back-ends can be chained together in different orders.</p>
+<pre class="first literal-block">
+char const* p = "foo";
+frontend&lt;
+    backend2&lt;backend1&lt;backend0&lt;char const*&gt;, char&gt;, int&gt;
+&gt; composed_obj0;
+frontend&lt;
+    backend1&lt;backend2&lt;backend0&lt;char const*&gt;, int&gt;, char&gt;
+&gt; composed_obj1;
+composed_obj0.initialize(_a2 = 4, _a1 = ' ', _a0 = p);
+composed_obj1.initialize(_a0 = p, _a1 = ' ', _a2 = 4);
+BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/parameterized_inheritance.cpp"
+>test/parameterized_inheritance.cpp</a> and <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated implementation function.  <tt
+class="docutils literal">name</tt> may be qualified by the <tt
+class="docutils literal">static</tt> keyword to declare the member function
+and its helpers as not associated with any object of the enclosing type.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    <strong>name</strong
+>(TaggedArg0 const&amp; arg0, TaggedArgs const&amp;... args)
+{
+    return this-&gt;boost_param_no_spec_impl ## __LINE__ ## <strong
+>name</strong>(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const& args
+    )
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-c-mem-function-result-name">
+<h2><a class="toc-backref" href="#id65">6.14&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION(result,
+name)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the member
+function; however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw1) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw2) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a variadic function
+header.  Enclose the return type <tt class="docutils literal">bool</tt> in
+parentheses.  The macro will qualify the function with the <tt
+class="docutils literal">const</tt> keyword.</p>
+<pre class="first literal-block">
+struct D
+{
+    D()
+    {
+    }
+
+    BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION((bool), evaluate_m)
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">To invoke the member function, bind all its arguments to
+named parameters.</p>
+<pre class="first literal-block">
+D const d = D();
+d.evaluate_m(
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+d.evaluate_m(
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function.</li>
+<li><tt class="docutils literal">name</tt> is the base name of the function;
+it determines the name of the generated implementation function.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_const_ ## __LINE__ ## <strong>name</strong>
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_const_ ## __LINE__ ## <strong>name</strong>&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    <strong>name</strong
+>(TaggedArg0 const&amp; arg0, TaggedArgs const&amp;... args) const
+{
+    return this-&gt;boost_param_no_spec_impl_const ## __LINE__ ## <strong
+>name</strong>(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_const_ ## __LINE__ ## <strong
+>name</strong>&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl_const ## __LINE__ ## <strong>name</strong>(
+        (ResultType(*)())
+      , Args const& args
+    ) const
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-function-call-op-result">
+<h2><a class="toc-backref" href="#id66">6.15&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR(result)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">When designing a front-end class template whose back-end is
+configurable via parameterized inheritance, it can be useful to omit argument
+specifiers from a named-parameter function call operator so that the delegate
+member functions of the back-end classes can enforce their own
+specifications.</p>
+<pre class="first literal-block">
+template &lt;typename B&gt;
+struct frontend : B
+{
+    frontend() : B()
+    {
+    }
+
+    BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR((void))
+    {
+        this-&gt;initialize_impl(args);
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the function call
+operator; however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a0)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a1)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a2)
+</pre>
+<p class="first">For this example, each of the back-end class templates
+requires its own parameter to be present in the argument pack.  In practice,
+such parameters should be optional, with default values.</p>
+<pre class="first literal-block">
+template &lt;typename T&gt;
+class backend0
+{
+    T a0;
+
+ public:
+    backend0() : a0()
+    {
+    }
+
+    T const&amp; get_a0() const
+    {
+        return this-&gt;a0;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        this-&gt;a0 = args[_a0];
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend1 : public B
+{
+    T a1;
+
+ public:
+    backend1() : B(), a1()
+    {
+    }
+
+    T const&amp; get_a1() const
+    {
+        return this-&gt;a1;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        B::initialize_impl(args);
+        this-&gt;a1 = args[_a1];
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend2 : public B
+{
+    T a2;
+
+ public:
+    backend2() : B(), a2()
+    {
+    }
+
+    T const&amp; get_a2() const
+    {
+        return this-&gt;a2;
+    }
+
+ protected:
+    template &lt;typename ArgPack&gt;
+    void initialize_impl(ArgPack const&amp; args)
+    {
+        B::initialize_impl(args);
+        this-&gt;a2 = args[_a2];
+    }
+};
+</pre>
+<p class="first">This example shows that while <tt class="docutils literal"
+>backend0</tt> must always be the root base class template and that <tt
+class="docutils literal">frontend</tt> must always be the most derived class
+template, the other back-ends can be chained together in different orders.</p>
+<pre class="first literal-block">
+char const* p = "foo";
+frontend&lt;
+    backend2&lt;backend1&lt;backend0&lt;char const*&gt;, char&gt;, int&gt;
+&gt; composed_obj0;
+frontend&lt;
+    backend1&lt;backend2&lt;backend0&lt;char const*&gt;, int&gt;, char&gt;
+&gt; composed_obj1;
+composed_obj0(_a2 = 4, _a1 = ' ', _a0 = p);
+composed_obj1(_a0 = p, _a1 = ' ', _a2 = 4);
+BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/parameterized_inheritance.cpp"
+>test/parameterized_inheritance.cpp</a> and <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_ ## __LINE__ ## operator&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    operator()(TaggedArg0 const&amp; arg0, TaggedArgs const&amp;... args)
+{
+    return this-&gt;boost_param_no_spec_impl ## __LINE__ ## operator(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_ ## __LINE__ ## operator&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const& args
+    )
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-const-func-call-op-result">
+<h2><a class="toc-backref" href="#id67">6.16&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal"
+>BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR(result)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following function templates
+falls under a different value category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+value category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the function call
+operator; however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw1) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw2) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
+</pre>
+<p class="first">Use the macro as a substitute for a variadic function call
+operator header.  Enclose the return type <tt class="docutils literal"
+>bool</tt> in parentheses.  The macro will qualify the function with the <tt
+class="docutils literal">const</tt> keyword.</p>
+<pre class="first literal-block">
+struct D
+{
+    D()
+    {
+    }
+
+    BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR((bool))
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">To invoke the function call operator, bind all its arguments
+to named parameters.</p>
+<pre class="first literal-block">
+D const d = D();
+d(
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+d(
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">result</tt> is the parenthesized return type
+of the function call operator.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+struct boost_param_no_spec_result_const_ ## __LINE__ ## operator
+{
+    typedef <strong>result</strong> type;
+};
+
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+inline typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"><tt
+class="docutils literal">lazy_enable_if</tt></a>&lt;
+    <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+  , boost_param_no_spec_result_const_ ## __LINE__ ## operator&lt;
+        TaggedArg0
+      , TaggedArgs...
+    &gt;
+&gt;::type
+    operator()(
+        TaggedArg0 const&amp; arg0
+      , TaggedArgs const&amp;... args
+    ) const
+{
+    return this-&gt;boost_param_no_spec_impl_const ## __LINE__ ## operator(
+        static_cast&lt;
+            typename
+            boost_param_no_spec_result_const_ ## __LINE__ ## operator&lt;
+                TaggedArg0
+              , TaggedArgs...
+            &gt;::type(*)()
+        &gt;(std::nullptr)
+      , <a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...)
+    );
+}
+
+template &lt;typename ResultType, typename Args&gt;
+ResultType
+    boost_param_no_spec_impl_const ## __LINE__ ## operator(
+        (ResultType(*)())
+      , Args const& args
+    ) const
+</pre>
+<p>Only the <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
+>Args</tt> and its object instance <tt class="docutils literal">args</tt> are
+available for use within the function body.</p>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-constructor-cls-impl">
+<h2><a class="toc-backref" href="#id68">6.17&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(cls,
+impl)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">When designing a front-end class template whose back-end is
+configurable via parameterized inheritance, it can be useful to omit argument
+specifiers from a named-parameter constructor so that the delegate
+constructors of the back-end classes can enforce their own specifications.</p>
+<pre class="first literal-block">
+template &lt;typename B&gt;
+struct frontend : B
+{
+    BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(frontend, (B))
+};
+</pre>
+<p class="first">Named parameters are required when invoking the constructor;
+however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a0)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a1)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a2)
+</pre>
+<p class="first">For this example, each of the back-end class templates
+requires its own parameter to be present in the argument pack.  In practice,
+such parameters should be optional, with default values.</p>
+<pre class="first literal-block">
+struct _enabler
+{
+};
+
+template &lt;typename T&gt;
+class backend0
+{
+    T a0;
+
+ public:
+    template &lt;typename ArgPack&gt;
+    explicit backend0(
+        ArgPack const&amp; args
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#is-argument-pack"
+>is_argument_pack</a>&lt;ArgPack&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : a0(args[_a0])
+    {
+    }
+
+    T const&amp; get_a0() const
+    {
+        return this-&gt;a0;
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend1 : public B
+{
+    T a1;
+
+ public:
+    template &lt;typename ArgPack&gt;
+    explicit backend1(
+        ArgPack const&amp; args
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#is-argument-pack"
+>is_argument_pack</a>&lt;ArgPack&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : B(args), a1(args[_a1])
+    {
+    }
+
+    T const&amp; get_a1() const
+    {
+        return this-&gt;a1;
+    }
+};
+
+template &lt;typename B, typename T&gt;
+class backend2 : public B
+{
+    T a2;
+
+ public:
+    template &lt;typename ArgPack&gt;
+    explicit backend2(
+        ArgPack const&amp; args
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#is-argument-pack"
+>is_argument_pack</a>&lt;ArgPack&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : B(args), a2(args[_a2])
+    {
+    }
+
+    T const&amp; get_a2() const
+    {
+        return this-&gt;a2;
+    }
+};
+</pre>
+<p class="first">This example shows that while <tt class="docutils literal"
+>backend0</tt> must always be the root base class template and that <tt
+class="docutils literal">frontend</tt> must always be the most derived class
+template, the other back-ends can be chained together in different orders.</p>
+<pre class="first literal-block">
+char const* p = "foo";
+frontend&lt;
+    backend2&lt;backend1&lt;backend0&lt;char const*&gt;, char&gt;, int&gt;
+&gt; composed_obj0(_a2 = 4, _a1 = ' ', _a0 = p);
+frontend&lt;
+    backend1&lt;backend2&lt;backend0&lt;char const*&gt;, int&gt;, char&gt;
+&gt; composed_obj1(_a0 = p, _a1 = ' ', _a2 = 4);
+BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/parameterized_inheritance.cpp"
+>test/parameterized_inheritance.cpp</a> and <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">cls</tt> is the name of the enclosing
+class.</li>
+<li><tt class="docutils literal">impl</tt> is the parenthesized implementation
+base class for <tt class="docutils literal">cls</tt>.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;
+    template <
+        typename TaggedArg0
+      , typename ...TaggedArgs
+      , typename = typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+        &gt;::type
+&gt;
+inline explicit <strong>cls</strong>(
+    TaggedArg0 const&amp; arg0
+  , TaggedArgs const&amp;... args
+) : <strong>impl</strong>(<a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...))
+{
+}
+</pre>
+</dd>
+</dl>
+</div>
+<div class="section" id="boost-parameter-no-spec-no-base-ctor-cls-func">
+<h2><a class="toc-backref" href="#id69">6.18&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(cls,
+func)</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/preprocessor.hpp"
+>boost/parameter/preprocessor.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">The return type of each of the following functon templates
+falls under a different reference category.</p>
+<pre class="first literal-block">
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; rvalue_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const rvalue_const_bitset()
+{
+    return std::bitset&lt;N + 1&gt;();
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt;&amp; lvalue_bitset()
+{
+    static std::bitset&lt;N + 1&gt; lset = std::bitset&lt;N + 1&gt;();
+    return lset;
+}
+
+template &lt;std::size_t N&gt;
+std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
+{
+    static std::bitset&lt;N + 1&gt; const clset = std::bitset&lt;N + 1&gt;();
+    return clset;
+}
+</pre>
+<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
+static member function template has a simple job: to return the correct
+reference category when passed in an object returned by one of the functions
+defined above.  Assume that <a class="reference internal"
+href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
+>BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
+<pre class="first literal-block">
+enum invoked
+{
+    passed_by_lvalue_reference_to_const
+  , passed_by_lvalue_reference
+  , passed_by_rvalue_reference_to_const
+  , passed_by_rvalue_reference
+};
+
+struct U
+{
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;)
+    {
+        return passed_by_lvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;)
+    {
+        return passed_by_lvalue_reference;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt; const&amp;&amp;)
+    {
+        return passed_by_rvalue_reference_to_const;
+    }
+
+    template &lt;std::size_t N&gt;
+    static invoked evaluate_category(std::bitset&lt;N + 1&gt;&amp;&amp;)
+    {
+        return passed_by_rvalue_reference;
+    }
+};
+</pre>
+<p class="first">Named parameters are required when invoking the constructor;
+however, none of their tags need to be in the same namespace.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_lr, kw1) in_out(lr))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rrc, kw2) in(rrc))
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
+</pre>
+<p class="first">Unlike <a class="reference internal"
+href="#boost-parameter-no-spec-constructor-cls-impl"><tt
+class="docutils literal">BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR</tt></a>, this
+macro doesn't require a base class, only a delegate function to which the
+generated constructor can pass its <a class="reference internal"
+href="#argumentpack"><span class="concept">ArgumentPack</span></a>.</p>
+<pre class="first literal-block">
+struct D
+{
+    BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(D, D::_evaluate)
+    {
+    }
+
+ private:
+    template &lt;typename Args&gt;
+    static bool _evaluate(Args const&amp; args)
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category&lt;0&gt;(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category&lt;1&gt;(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category&lt;2&gt;(
+                args[_rrc0 | rvalue_const_bitset&lt;2&gt;()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category&lt;3&gt;(
+                args[_rr0 | rvalue_bitset&lt;3&gt;()]
+            )
+        );
+
+        return true;
+    }
+};
+</pre>
+<p class="first">To invoke the constructor, bind all its arguments to named
+parameters.</p>
+<pre class="first literal-block">
+D dp0(
+    _rr0 = rvalue_bitset&lt;3&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+  , _lr0 = lvalue_bitset&lt;1&gt;()
+  , _rrc0 = rvalue_const_bitset&lt;2&gt;()
+);
+D dp1(
+    _lr0 = lvalue_bitset&lt;1&gt;()
+  , _lrc0 = lvalue_const_bitset&lt;0&gt;()
+);
+</pre>
+<p class="last">The <a class="reference external"
+href="../../test/preprocessor_eval_cat_no_spec.cpp"
+>test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
+usage of this macro.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Macro parameters:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<ul class="last simple">
+<li><tt class="docutils literal">cls</tt> is the name of the enclosing
+class.</li>
+<li><tt class="docutils literal">func</tt> is a function that takes in the
+<a class="reference internal" href="#argumentpack"><span class="concept"
+>ArgumentPack</span></a> that the generated constructor passes on.</li>
+</ul>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Argument specifiers syntax:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">None.</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Approximate expansion:</dt>
+<dd>
+<pre class="last literal-block">
+template &lt;
+    template <
+        typename TaggedArg0
+      , typename ...TaggedArgs
+      , typename = typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
+        &gt;::type
+&gt;
+inline explicit <strong>cls</strong>(
+    TaggedArg0 const&amp; arg0
+  , TaggedArgs const&amp;... args
+)
+{
+    <strong>func</strong>(<a class="reference internal" href="#parameters"
+>parameters</a>&lt;&gt;()(arg0, args...));
+}
+</pre>
+</dd>
+</dl>
 </div>
 <div class="section" id="boost-parameter-name-name">
-<h2><a class="toc-backref" href="#id60">6.10&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id70">6.19&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_NAME(name)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -3273,7 +8320,7 @@ forward(<em>tag-name</em>)
 </pre>
 </div>
 <div class="section" id="boost-parameter-nested-keyword-t-n-a">
-<h2><a class="toc-backref" href="#id61">6.11&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id71">6.20&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_NESTED_KEYWORD(tag_namespace, name,
 alias)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
@@ -3345,7 +8392,7 @@ forward(<em>tag-name</em>)
 </pre>
 </div>
 <div class="section" id="boost-parameter-template-keyword-name">
-<h2><a class="toc-backref" href="#id62">6.12&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id72">6.21&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_TEMPLATE_KEYWORD(name)</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -3383,7 +8430,7 @@ href="../../test/function_type_tpl_param.cpp"
 of this macro.</p>
 </div>
 <div class="section" id="boost-parameter-fun-r-n-l-h-p">
-<h2><a class="toc-backref" href="#id63">6.13&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id73">6.22&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_FUN(r, n, l, h, p)</tt></a></h2>
 <div class="admonition-deprecated admonition">
 <p class="first admonition-title">Deprecated</p>
@@ -3423,10 +8470,6 @@ class="docutils literal">l</tt> &lt; <tt class="docutils literal">h</tt></td>
 </tr>
 </tbody>
 </table>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
 <dl class="docutils">
 <dt>Expands to:</dt>
 <dd>
@@ -3534,148 +8577,13 @@ class="docutils literal">forward</tt></a>&lt;A ## <strong
 </pre>
 </dd>
 </dl>
-<p><strong>If</strong> <a class="reference internal"
-href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
->BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is <strong>not</strong>
-<tt class="docutils literal">#defined</tt>, <strong>then</strong>:</p>
-<dl class="docutils">
-<dt>Expands to:</dt>
-<dd>
-<pre class="first last literal-block">
-template &lt;typename A1, typename A2, …, typename A ## <strong>l</strong>&gt;
-r
-    name(
-        A1 const&amp; a1, A2 const&amp; a2, …, A ## <strong
->l</strong> const&amp; a ## <strong>l</strong>
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A ## <strong
->l</strong>&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(pk(a1, a2, …, a ## <strong
->l</strong>));
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A1, typename A2, …, typename A ## <strong>l</strong>&gt;
-r
-    name(
-        A1&amp; a1, A2&amp; a2, …, A ## <strong
->l</strong> &amp; a ## <strong>l</strong>
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A ## <strong
->l</strong>&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(pk(a1, a2, …, a ## <strong
->l</strong>));
-}
-
-template &lt;
-    typename A1
-  , typename A2
-  , …
-  , typename A ## <strong>l</strong>
-  , typename A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)
-&gt;
-r
-    name(
-        A1 const&amp; a1, A2 const&amp; a2, …, A ## <strong
->l</strong> const&amp; a ## <strong>l</strong>
-      , A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>) const&amp; a ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A<strong
->l</strong>, A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(
-        pk(a1, a2, …, a ## <strong>l</strong>, a ## <a
-class="reference external" href="../../../preprocessor/doc/ref/inc.html"
->BOOST_PP_INC</a>(<strong>l</strong>))
-    );
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;
-    typename A1
-  , typename A2
-  , …
-  , typename A ## <strong>l</strong>
-  , typename A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)
-&gt;
-r
-    name(
-        A1&amp; a1, A2&amp; a2, …, A ## <strong
->l</strong> &amp; a ## <strong>l</strong>
-      , A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>) &amp; a ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A<strong
->l</strong>, A ## <a class="reference external"
-href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
->l</strong>)&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(
-        pk(a1, a2, …, a ## <strong>l</strong>, a ## <a
-class="reference external" href="../../../preprocessor/doc/ref/inc.html"
->BOOST_PP_INC</a>(<strong>l</strong>))
-    );
-}
-
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A1, typename A2, …, typename A ## <strong>h</strong>&gt;
-r
-    name(
-        A1 const&amp; a1, A2 const&amp; a2, …, A ## <strong
->h</strong> const&amp; a ## <strong>h</strong>
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A ## <strong
->h</strong>&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(pk(a1, a2, …, a ## <strong
->h</strong>));
-}
-
-<em>… exponential number of overloads …</em>
-<span class="vellipsis">⋮</span>
-
-template &lt;typename A1, typename A2, …, typename A ## <strong>h</strong>&gt;
-r
-    name(
-        A1&amp; a1, A2&amp; a2, …, A ## <strong
->h</strong>&amp; a ## <strong>h</strong>
-      , typename <strong>p</strong>::match&lt;A1, A2, …, A ## <strong
->h</strong>&gt;::type pk = <strong>p</strong>()
-    )
-{
-    return <strong>name</strong>_with_named_params(pk(a1, a2, …, a ## <strong
->h</strong>));
-}
-</pre>
-</dd>
-</dl>
 <p>The <a class="reference external" href="../../test/macros.cpp"
 >test/macros.cpp</a> and <a class="reference external"
 href="../../test/macros_eval_category.cpp">test/macros_eval_category.cpp</a>
 test programs demonstrate proper usage of this macro.</p>
 </div>
 <div class="section" id="boost-parameter-keyword-n-k">
-<h2><a class="toc-backref" href="#id64">6.14&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id74">6.23&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_KEYWORD(n, k)</tt></a></h2>
 <div class="admonition-deprecated admonition">
 <p class="first admonition-title">Deprecated</p>
@@ -3724,7 +8632,7 @@ namespace {
 </dl>
 </div>
 <div class="section" id="boost-parameter-match-p-a-x">
-<h2><a class="toc-backref" href="#id65">6.15&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id75">6.24&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_MATCH(p, a, x)</tt></a></h2>
 <p>Generates a defaulted parameter declaration for a
 <a class="reference external"
@@ -3771,10 +8679,10 @@ href="../../../../boost/parameter/match.hpp"
 </div>
 </div>
 <div class="section" id="configuration-macros">
-<h1><a class="toc-backref" href="#id66">7&nbsp;&nbsp;&nbsp;Configuration
+<h1><a class="toc-backref" href="#id76">7&nbsp;&nbsp;&nbsp;Configuration
 Macros</a></h1>
 <div class="section" id="boost-parameter-has-perfect-forwarding">
-<h2><a class="toc-backref" href="#id67">7.1&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id77">7.1&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a></h2>
 <p>Determines whether or not the library supports perfect forwarding, or the
 preservation of parameter value categories.  Users can manually disable this
@@ -3811,7 +8719,7 @@ href="../../../../boost/parameter/config.hpp"
 </table>
 </div>
 <div class="section" id="boost-parameter-disable-perfect-forwarding">
-<h2><a class="toc-backref" href="#id68">7.2&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id78">7.2&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_DISABLE_PERFECT_FORWARDING</tt></a
 ></h2>
 <p>It may be necessary to test user code in case perfect forwarding support is
@@ -3822,7 +8730,7 @@ href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> undefined.</p>
 </div>
 <div class="section" id="boost-parameter-variadic-mpl-sequence">
-<h2><a class="toc-backref" href="#id69">7.3&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id79">7.3&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE</tt></a></h2>
 <p>If <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
@@ -3877,7 +8785,7 @@ href="../../../../boost/parameter/parameters.hpp"
 </table>
 </div>
 <div class="section" id="boost-parameter-max-arity">
-<h2><a class="toc-backref" href="#id70">7.4&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id80">7.4&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">BOOST_PARAMETER_MAX_ARITY</tt></a></h2>
 <p>Determines the maximum number of arguments supported by the library.</p>
 <p>If <a class="reference internal"
@@ -3945,7 +8853,7 @@ href="../../../mpl/doc/refmanual/limit-vector-size.html"
 ><tt class="docutils literal">BOOST_MPL_LIMIT_VECTOR_SIZE</tt></a> (defined by
 <a class="reference external" href="../../../mpl/doc/index.html"
 >Boost.MPL</a>) if perfect forwarding is supported,
-<tt class="docutils literal">8</tt> otherwise.</td>
+<tt class="docutils literal">20</tt> otherwise.</td>
 </tr>
 <tr class="field">
 <th class="field-name">Minimum Value:</th>
@@ -3955,7 +8863,7 @@ href="../../../mpl/doc/refmanual/limit-vector-size.html"
 </table>
 </div>
 <div class="section" id="boost-parameter-exponential-overload-threshold-arity"
-><h2><a class="toc-backref" href="#id71">7.5&nbsp;&nbsp;&nbsp;<tt
+><h2><a class="toc-backref" href="#id81">7.5&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal"
 >BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY</tt></a></h2>
 <p>If this library does <strong>not</strong> support perfect forwarding,
@@ -3997,7 +8905,7 @@ href="../../../../boost/parameter/config.hpp"
 </table>
 </div>
 <div class="section" id="outside-of-this-library"
-><h2><a class="toc-backref" href="#id72">7.6&nbsp;&nbsp;&nbsp;...Outside Of
+><h2><a class="toc-backref" href="#id82">7.6&nbsp;&nbsp;&nbsp;...Outside Of
 This Library</a></h2>
 <ol>
 <li>If <a class="reference external"
@@ -4089,7 +8997,7 @@ href="#boost-parameter-max-arity"><tt class="docutils literal"
 </div>
 </div>
 <div class="section" id="tutorial">
-<h1><a class="toc-backref" href="#id73">8&nbsp;&nbsp;&nbsp;Tutorial</a></h1>
+<h1><a class="toc-backref" href="#id83">8&nbsp;&nbsp;&nbsp;Tutorial</a></h1>
 <p>Follow <a class="reference external" href="index.html#tutorial">this
 link</a> to the Boost.Parameter tutorial documentation.</p>
 <hr class="docutils" />

--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -407,8 +407,7 @@ default</a> with <a class="reference internal" href="#tag-type">tag type</a>
 <li><tt class="docutils literal">z</tt> is an <span class="concept"
 >ArgumentPack</span> containing a single element (as created by <a
 class="reference internal" href="#keyword"><tt class="docutils literal"
->keyword</tt></a><tt class="docutils literal"><span class="pre"
->&lt;…&gt;::operator=</span></tt>)</li>
+>keyword</tt></a><tt class="docutils literal">&lt;…&gt;::operator=</tt>)</li>
 </ul>
 <p>Any exceptions are thrown from the invocation of
 <tt class="docutils literal">w</tt>'s <em>value</em>
@@ -432,8 +431,7 @@ will be propagated to the caller.</p>
 <tbody valign="top">
 <tr>
 <td><tt class="docutils literal">x[u]</tt></td>
-<td><tt class="docutils literal"><span
-class="pre">binding&lt;A,K&gt;::type</span></tt></td>
+<td><tt class="docutils literal">binding&lt;A,K&gt;::type</tt></td>
 <td><tt class="docutils literal">x</tt> contains an element <em>b</em> whose
 <a class="reference internal" href="#kw">keyword</a> is
 <tt class="docutils literal">K</tt></td>
@@ -441,8 +439,7 @@ class="pre">binding&lt;A,K&gt;::type</span></tt></td>
 </tr>
 <tr>
 <td><tt class="docutils literal">x[u]</tt></td>
-<td><tt class="docutils literal"><span
-class="pre">binding&lt;A,L,D&gt;::type</span></tt></td>
+<td><tt class="docutils literal">binding&lt;A,L,D&gt;::type</tt></td>
 <td><em>none</em></td>
 <td>If <tt class="docutils literal">x</tt> contains an element <em>b</em>
 whose <a class="reference internal" href="#kw">keyword</a> is the same as
@@ -451,8 +448,7 @@ reference).  Otherwise, returns <tt class="docutils literal">u</tt>'s
 <em>value</em>.</td>
 </tr>
 <tr><td><tt class="docutils literal">x[w]</tt></td>
-<td><tt class="docutils literal"><span
-class="pre">lazy_binding&lt;A,M,E&gt;::type</span></tt></td>
+<td><tt class="docutils literal">lazy_binding&lt;A,M,E&gt;::type</tt></td>
 <td><em>none</em></td>
 <td>If <tt class="docutils literal">x</tt> contains an element <em>b</em>
 whose <a class="reference internal" href="#kw">keyword</a> is the same as
@@ -574,44 +570,36 @@ struct keyword
 
     template &lt;typename T&gt;
     typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
         typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
             boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
+href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"
+>is_scalar</a>&lt;T&gt;
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                     typename Tag::qualifier
                   , boost::parameter::in_reference
                 &gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
+href="../../../mpl/doc/refmanual/if.html">if_</a>&lt;
                     boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                         typename Tag::qualifier
                       , boost::parameter::forward_reference
                     &gt;
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
                 &gt;
             &gt;
         &gt;::type
@@ -623,56 +611,45 @@ href="#operator">operator=</a>(T const&amp; value) const;
 
     template &lt;typename T&gt;
     typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
         typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
             typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                     typename Tag::qualifier
                   , boost::parameter::out_reference
                 &gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
+href="../../../mpl/doc/refmanual/if.html">if_</a>&lt;
                     boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                         typename Tag::qualifier
                       , boost::parameter::forward_reference
                     &gt;
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
                 &gt;
             &gt;
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
+href="../../../mpl/doc/refmanual/if.html">if_</a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_const.html"><tt
-class="docutils literal">is_const</tt></a>&lt;T&gt;
+href="../../../type_traits/doc/html/boost_typetraits/is_const.html"
+>is_const</a>&lt;T&gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
             &gt;
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
         &gt;::type
       , <a class="reference internal" href="#argumentpack"><span
 class="concept">ArgumentPack</span></a>
@@ -682,44 +659,36 @@ href="#operator">operator=</a>(T&amp; value) const;
 
     template &lt;typename T&gt;
     typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
         typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
             boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
+href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"
+>is_scalar</a>&lt;T&gt;
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                     typename Tag::qualifier
                   , boost::parameter::in_reference
                 &gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
+href="../../../mpl/doc/refmanual/if.html">if_</a>&lt;
                     boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                         typename Tag::qualifier
                       , boost::parameter::forward_reference
                     &gt;
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
                 &gt;
             &gt;
         &gt;::type
@@ -731,44 +700,36 @@ href="#operator">operator=</a>(T const&amp;&amp; value) const;
 
     template &lt;typename T&gt;
     typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
         typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
             boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
+href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"
+>is_scalar</a>&lt;T&gt;
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                     typename Tag::qualifier
                   , boost::parameter::consume_reference
                 &gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
+href="../../../mpl/doc/refmanual/if.html">if_</a>&lt;
                     boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                         typename Tag::qualifier
                       , boost::parameter::forward_reference
                     &gt;
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
                 &gt;
             &gt;
         &gt;::type
@@ -780,44 +741,36 @@ href="#operator">operator=</a>(T&amp;&amp; value) const;
 
     template &lt;typename T&gt;
     typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
         typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
             boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
+href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"
+>is_scalar</a>&lt;T&gt;
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                     typename Tag::qualifier
                   , boost::parameter::in_reference
                 &gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
+href="../../../mpl/doc/refmanual/if.html">if_</a>&lt;
                     boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                         typename Tag::qualifier
                       , boost::parameter::forward_reference
                     &gt;
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
                 &gt;
             &gt;
         &gt;::type
@@ -828,56 +781,46 @@ href="#id9">operator|</a>(T const&amp; x) const;
 
     template &lt;typename T&gt;
     typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
         typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
             typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                     typename Tag::qualifier
                   , boost::parameter::out_reference
                 &gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
+href="../../../mpl/doc/refmanual/if.html">if_</a>&lt;
                     boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                         typename Tag::qualifier
                       , boost::parameter::forward_reference
                     &gt;
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
                 &gt;
             &gt;
           , boost::mpl::<a class="reference external"
 href="../../../mpl/doc/refmanual/if.html"><tt
 class="docutils literal">if_</tt></a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_const.html"><tt
-class="docutils literal">is_const</tt></a>&lt;T&gt;
+href="../../../type_traits/doc/html/boost_typetraits/is_const.html"
+>is_const</a>&lt;T&gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
             &gt;
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
         &gt;::type
       , <em>tagged default</em>
     &gt;::type constexpr
@@ -886,44 +829,36 @@ href="#id9">operator|</a>(T&amp; x) const;
 
     template &lt;typename T&gt;
     typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
         typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
             boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
+href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"
+>is_scalar</a>&lt;T&gt;
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                     typename Tag::qualifier
                   , boost::parameter::in_reference
                 &gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
+href="../../../mpl/doc/refmanual/if.html">if_</a>&lt;
                     boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                         typename Tag::qualifier
                       , boost::parameter::forward_reference
                     &gt;
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
                 &gt;
             &gt;
         &gt;::type
@@ -934,44 +869,36 @@ href="#id9">operator|</a>(T const&amp;&amp; x) const;
 
     template &lt;typename T&gt;
     typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
         typename boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
             boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"><tt
-class="docutils literal">is_scalar</tt></a>&lt;T&gt;
+href="../../../type_traits/doc/html/boost_typetraits/is_scalar.html"
+>is_scalar</a>&lt;T&gt;
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
           , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/eval-if.html"><tt
-class="docutils literal">eval_if</tt></a>&lt;
+href="../../../mpl/doc/refmanual/eval-if.html">eval_if</a>&lt;
                 boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                     typename Tag::qualifier
                   , boost::parameter::consume_reference
                 &gt;
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
               , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/if.html"><tt
-class="docutils literal">if_</tt></a>&lt;
+href="../../../mpl/doc/refmanual/if.html">if_</a>&lt;
                     boost::<a class="reference external"
-href="../../../type_traits/doc/html/boost_typetraits/is_same.html"><tt
-class="docutils literal">is_same</tt></a>&lt;
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
                         typename Tag::qualifier
                       , boost::parameter::forward_reference
                     &gt;
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">true_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">true_</a>
                   , boost::mpl::<a class="reference external"
-href="../../../mpl/doc/refmanual/bool.html"><tt
-class="docutils literal">false_</tt></a>
+href="../../../mpl/doc/refmanual/bool.html">false_</a>
                 &gt;
             &gt;
         &gt;::type
@@ -1498,8 +1425,8 @@ struct required;
 <p>The default value of <tt class="docutils literal">Predicate</tt> is an
 unspecified <a class="reference external"
 href="../../../mpl/doc/refmanual/metafunction-class.html">MPL Binary
-Metafunction Class</a> that returns <tt class="docutils literal"><span
-class="pre">mpl::true_</span></tt> for any argument.</p>
+Metafunction Class</a> that returns <tt class="docutils literal"
+>mpl::true_</tt> for any argument.</p>
 </div>
 <div class="section" id="deduced">
 <h2><a class="toc-backref" href="#id44">4.5&nbsp;&nbsp;&nbsp;<tt
@@ -1688,7 +1615,7 @@ exists, returns <tt class="docutils literal">D</tt>.  Equivalent to:</p>
 <pre class="literal-block">
 typename boost::<a class="reference external"
 href="../../../type_traits/doc/html/boost_typetraits/remove_reference.html"
-><tt class="docutils literal">remove_reference</tt></a>&lt;
+>remove_reference</a>&lt;
     typename <a class="reference internal" href="#binding"
 >binding</a>&lt;A, K, D&gt;::type
 &gt;::type
@@ -1730,12 +1657,11 @@ struct are_tagged_arguments  // : mpl::true_ or mpl::false_
 </tr>
 <tr>
 <td>&nbsp;</td>
-<td class="field-body"><tt class="docutils literal"><span class="pre"
->mpl::true_</span></tt> if <tt class="docutils literal">T0</tt> and all
-elements in parameter pack <tt class="docutils literal">Pack</tt> are
-<a class="reference internal" href="#tagged-reference">tagged reference</a>
-types, <tt class="docutils literal"><span class="pre">mpl::false_</span></tt>
-otherwise.</td>
+<td class="field-body"><tt class="docutils literal">mpl::true_</tt> if <tt
+class="docutils literal">T0</tt> and all elements in parameter pack <tt
+class="docutils literal">Pack</tt> are <a class="reference internal"
+href="#tagged-reference">tagged reference</a> types, <tt
+class="docutils literal">mpl::false_</tt> otherwise.</td>
 </tr>
 <tr class="field">
 <th class="field-name" colspan="2">Example usage:</th>
@@ -1748,8 +1674,8 @@ container that conforms to the C++ standard, one needs to remember that the
 standard requires the presence of other constructors that are typically
 defined as templates, such as range constructors.  To avoid overload
 ambiguities between the two constructors, use this metafunction in conjunction
-with <tt class="docutils literal"><span class="pre">disable_if</span></tt> to
-define the range constructor.</p>
+with <tt class="docutils literal">disable_if</tt> to define the range
+constructor.</p>
 <pre class="first literal-block">
 template &lt;typename B&gt;
 class frontend : public B
@@ -1768,8 +1694,7 @@ href="#boost-parameter-no-spec-constructor-cls-impl"
         Iterator itr
       , Iterator itr_end
       , typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">disable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>&lt;
             are_tagged_arguments&lt;Iterator&gt;
           , _enabler
         &gt;::type = _enabler()
@@ -1813,11 +1738,10 @@ struct is_argument_pack  // : mpl::true_ or mpl::false_
 </tr>
 <tr>
 <td>&nbsp;</td>
-<td class="field-body"><tt class="docutils literal"><span class="pre"
->mpl::true_</span></tt> if <tt class="docutils literal">T</tt> is a model of
-<a class="reference internal" href="#argumentpack"><span class="concept"
->ArgumentPack</span></a>, <tt class="docutils literal"><span class="pre"
->mpl::false_</span></tt> otherwise.</td>
+<td class="field-body"><tt class="docutils literal">mpl::true_</tt> if <tt
+class="docutils literal">T</tt> is a model of <a class="reference internal"
+href="#argumentpack"><span class="concept">ArgumentPack</span></a>, <tt
+class="docutils literal">mpl::false_</tt> otherwise.</td>
 </tr>
 <tr class="field">
 <th class="field-name" colspan="2">Example usage:</th>
@@ -1828,8 +1752,8 @@ struct is_argument_pack  // : mpl::true_ or mpl::false_
 <p class="first">To avoid overload ambiguities between a constructor that
 takes in an <a class="reference internal" href="#argumentpack"><span
 class="concept">ArgumentPack</span></a> and a templated conversion
-constructor, use this metafunction in conjunction with
-<tt class="docutils literal"><span class="pre">enable_if</span></tt>.</p>
+constructor, use this metafunction in conjunction with <tt
+class="docutils literal">enable_if</tt>.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(a0)
@@ -1905,6 +1829,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -1915,8 +1841,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -1944,10 +1870,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -1986,13 +1912,13 @@ struct U
     }
 };
 </pre>
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">kw</tt> in this
-case.  The identifiers with leading underscores can be passed to the bracket
-operator of <tt class="docutils literal">args</tt> to extract the same
-argument to which the corresponding named parameter (without underscores) is
-bound, as will be shown later.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">kw</tt> in this case.  The
+identifiers with leading underscores can be passed to the bracket operator of
+<tt class="docutils literal">args</tt> to extract the same argument to which
+the corresponding named parameter (without underscores) is bound, as will be
+shown later.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
@@ -2003,18 +1929,18 @@ bound, as will be shown later.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a normal function
-header.  Enclose the return type <tt class="docutils literal">bool</tt> in
-parentheses.  For each parameter, also enclose the expected value type in
-parentheses.  Since the value types are mutually exclusive, you can wrap the
-parameters in a <tt class="docutils literal">(deduced …)</tt>
-clause.  Otherwise, just as with a normal function, the order in which you
-specify the parameters determines their position.  Also, just as with a normal
-function, optional parameters have default values, whereas required parameters
-do not.  Within the function body, either simply use the parameter name or
-pass the matching identifier with the leading underscore to the bracket
-operator of <tt class="docutils literal">args</tt> to extract the
-corresponding argument.  Note that the second method doesn't require <tt
+<p>Use the macro as a substitute for a normal function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  Also, just as with a normal function, optional parameters
+have default values, whereas required parameters do not.  Within the function
+body, either simply use the parameter name or pass the matching identifier
+with the leading underscore to the bracket operator of <tt
+class="docutils literal">args</tt> to extract the corresponding
+argument.  Note that the second method doesn't require <tt
 class="docutils literal">std::forward</tt> to preserve value categories.</p>
 <pre class="first literal-block">
 BOOST_PARAMETER_FUNCTION((bool), evaluate, kw,
@@ -2041,8 +1967,8 @@ BOOST_PARAMETER_FUNCTION((bool), evaluate, kw,
     BOOST_TEST_EQ(
         passed_by_rvalue_reference_to_const
       , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;rrc0_type&gt;(rrc0))
     );
     BOOST_TEST_EQ(
         passed_by_rvalue_reference
@@ -2052,7 +1978,7 @@ class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
     return true;
 }
 </pre>
-<p class="first">The following function calls are legal.</p>
+<p>The following function calls are legal.</p>
 <pre class="first literal-block">
 evaluate(  // positional arguments
     lvalue_const_bitset&lt;0&gt;()
@@ -2081,9 +2007,8 @@ evaluate(  // named arguments
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="first">Because the parameters were wrapped in a <tt
-class="docutils literal">(deduced …)</tt> clause, the following function calls
-are also legal.</p>
+<p>Because the parameters were wrapped in a <tt class="docutils literal"
+>(deduced …)</tt> clause, the following function calls are also legal.</p>
 <pre class="first literal-block">
 evaluate(  // deduced arguments
     rvalue_bitset&lt;3&gt;()
@@ -2096,10 +2021,10 @@ evaluate(  // deduced arguments
   , lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a>, <a
-class="reference external" href="../../test/preprocessor_deduced.cpp"
->test/preprocessor_deduced.cpp</a>, and <a class="reference external"
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a>, <a class="reference external"
+href="../../test/preprocessor_deduced.cpp">test/preprocessor_deduced.cpp</a>,
+and <a class="reference external"
 href="../../test/preprocessor_eval_category.cpp"
 >test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
 usage of this macro.</p>
@@ -2237,7 +2162,7 @@ typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## <strong
 >name</strong> ## _&lt;Args&gt;::type
-    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const&);
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const&amp;);
 
 template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
 <em>result type</em>
@@ -2254,13 +2179,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
     return boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -2282,13 +2206,12 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
     return boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
@@ -2345,8 +2268,7 @@ typename boost_param_result_ ## __LINE__ ## <strong
         &gt;(std::nullptr)
       , args
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -2356,8 +2278,7 @@ class="docutils literal">forward</tt></a>&lt;
 >0</strong>])
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -2394,21 +2315,18 @@ ResultType
 >n + 1</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>0</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>0</strong>
         )
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>n</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>n</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -2459,6 +2377,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a member function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -2469,8 +2389,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -2498,10 +2418,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -2540,13 +2460,13 @@ struct U
     }
 };
 </pre>
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">kw</tt> in this
-case.  The identifiers with leading underscores can be passed to the bracket
-operator of <tt class="docutils literal">args</tt> to extract the same
-argument to which the corresponding named parameter (without underscores) is
-bound, as will be shown later.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">kw</tt> in this case.  The
+identifiers with leading underscores can be passed to the bracket operator of
+<tt class="docutils literal">args</tt> to extract the same argument to which
+the corresponding named parameter (without underscores) is bound, as will be
+shown later.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
@@ -2557,11 +2477,11 @@ bound, as will be shown later.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a normal <tt
-class="docutils literal">static</tt> member function header.  Enclose the
-return type <tt class="docutils literal">bool</tt> in parentheses.  For each
-parameter, also enclose the expected value type in parentheses.  Since the
-value types are mutually exclusive, you can wrap the parameters in a <tt
+<p>Use the macro as a substitute for a normal <tt class="docutils literal"
+>static</tt> member function header.  Enclose the return type <tt
+class="docutils literal">bool</tt> in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a <tt
 class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
 normal function, the order in which you specify the parameters determines
 their position.  Also, just as with a normal function, optional parameters
@@ -2598,8 +2518,8 @@ struct B
         BOOST_TEST_EQ(
             passed_by_rvalue_reference_to_const
           , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;rrc0_type&gt;(rrc0))
         );
         BOOST_TEST_EQ(
             passed_by_rvalue_reference
@@ -2610,7 +2530,7 @@ class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
     }
 };
 </pre>
-<p class="first">The following function calls are legal.</p>
+<p>The following function calls are legal.</p>
 <pre class="first literal-block">
 B::evaluate(  // positional arguments
     lvalue_const_bitset&lt;0&gt;()
@@ -2639,9 +2559,8 @@ B::evaluate(  // named arguments
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="first">Because the parameters were wrapped in a <tt
-class="docutils literal">(deduced …)</tt> clause, the following function calls
-are also legal.</p>
+<p>Because the parameters were wrapped in a <tt class="docutils literal"
+>(deduced …)</tt> clause, the following function calls are also legal.</p>
 <pre class="first literal-block">
 B::evaluate(  // deduced arguments
     rvalue_bitset&lt;3&gt;()
@@ -2654,9 +2573,9 @@ B::evaluate(  // deduced arguments
   , lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> and <a
-class="reference external" href="../../test/preprocessor_eval_category.cpp"
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a> and <a class="reference external"
+href="../../test/preprocessor_eval_category.cpp"
 >test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
 usage of this macro.</p>
 </td>
@@ -2806,13 +2725,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
     return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -2832,13 +2750,12 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
     return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
@@ -2846,7 +2763,8 @@ class="docutils literal">forward</tt></a>&lt;A ## <strong
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## <strong
 >name</strong>&lt;Args&gt;::type
-    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
+    boost_param_impl ## __LINE__ ## <strong
+>name</strong>(Args const&amp; args)
 {
     return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## <strong
 >name</strong>(
@@ -2858,8 +2776,7 @@ typename boost_param_result_ ## __LINE__ ## <strong
         &gt;(std::nullptr)
       , args
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -2869,8 +2786,7 @@ class="docutils literal">forward</tt></a>&lt;
 >0</strong>])
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -2908,21 +2824,18 @@ ResultType
 >n + 1</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>0</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>0</strong>
         )
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>n</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>n</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -2973,6 +2886,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a member function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -2983,8 +2898,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -3012,10 +2927,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -3054,13 +2969,13 @@ struct U
     }
 };
 </pre>
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">kw</tt> in this
-case.  The identifiers with leading underscores can be passed to the bracket
-operator of <tt class="docutils literal">args</tt> to extract the same
-argument to which the corresponding named parameter (without underscores) is
-bound, as will be shown later.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">kw</tt> in this case.  The
+identifiers with leading underscores can be passed to the bracket operator of
+<tt class="docutils literal">args</tt> to extract the same argument to which
+the corresponding named parameter (without underscores) is bound, as will be
+shown later.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
@@ -3071,11 +2986,11 @@ bound, as will be shown later.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a normal <tt
-class="docutils literal">const</tt> member function header.  Enclose the
-return type <tt class="docutils literal">bool</tt> in parentheses.  For each
-parameter, also enclose the expected value type in parentheses.  Since the
-value types are mutually exclusive, you can wrap the parameters in a <tt
+<p>Use the macro as a substitute for a normal <tt class="docutils literal"
+>const</tt> member function header.  Enclose the return type <tt
+class="docutils literal">bool</tt> in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a <tt
 class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
 normal function, the order in which you specify the parameters determines
 their position.  Also, just as with a normal function, optional parameters
@@ -3116,8 +3031,8 @@ struct B
         BOOST_TEST_EQ(
             passed_by_rvalue_reference_to_const
           , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;rrc0_type&gt;(rrc0))
         );
         BOOST_TEST_EQ(
             passed_by_rvalue_reference
@@ -3128,7 +3043,7 @@ class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
     }
 };
 </pre>
-<p class="first">The following function calls are legal.</p>
+<p>The following function calls are legal.</p>
 <pre class="first literal-block">
 B const b = B();
 b.evaluate(  // positional arguments
@@ -3158,9 +3073,8 @@ b.evaluate(  // named arguments
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="first">Because the parameters were wrapped in a <tt
-class="docutils literal">(deduced …)</tt> clause, the following function calls
-are also legal.</p>
+<p>Because the parameters were wrapped in a <tt class="docutils literal"
+>(deduced …)</tt> clause, the following function calls are also legal.</p>
 <pre class="first literal-block">
 b.evaluate(  // deduced arguments
     rvalue_bitset&lt;3&gt;()
@@ -3173,9 +3087,9 @@ b.evaluate(  // deduced arguments
   , lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
-demonstrates proper usage of this macro.</p>
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a> test program demonstrates proper usage of this
+macro.</p>
 </td>
 </tr>
 <tr class="field">
@@ -3322,13 +3236,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
 >name</strong>(
         boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -3350,13 +3263,12 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
 >name</strong>(
         boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
@@ -3365,7 +3277,7 @@ template &lt;typename Args&gt;
 typename boost_param_result_const_ ## __LINE__ ## <strong
 >name</strong>&lt;Args&gt;::type
     boost_param_impl_const ## __LINE__ ## <strong
->name</strong>(Args const& args) const
+>name</strong>(Args const&amp; args) const
 {
     return this-&gt;
     boost_param_dispatch_const_0boost_ ## __LINE__ ## <strong>name</strong>(
@@ -3377,8 +3289,7 @@ typename boost_param_result_const_ ## __LINE__ ## <strong
         &gt;(std::nullptr)
       , args
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -3388,8 +3299,7 @@ class="docutils literal">forward</tt></a>&lt;
 >0</strong>])
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -3427,21 +3337,18 @@ ResultType
 >n + 1</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>0</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>0</strong>
         )
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>n</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>n</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -3492,6 +3399,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a function call operator that can take in positional arguments,
+composed arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -3502,20 +3411,19 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">tag</tt> by
-default.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">tag</tt> by default.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(y)
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(z)
 </pre>
-<p class="first">Use the macro as a substitute for a normal function call
-operator header.  Enclose the return type in parentheses.  For each parameter,
-also enclose the expected value type in parentheses.  Since the value types
-are mutually exclusive, you can wrap the parameters in a <tt
+<p>Use the macro as a substitute for a normal function call operator
+header.  Enclose the return type in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a <tt
 class="docutils literal">(deduced …)</tt> clause.  This is especially useful
 when implementing multiple Boost.Parameter-enabled function call operator
 overloads.</p>
@@ -3539,8 +3447,8 @@ class char_reader
         )
     )
     {
-        this->index = y;
-        this->key = z;
+        this-&gt;index = y;
+        this-&gt;key = z;
     }
 
     <a class="reference internal"
@@ -3550,41 +3458,37 @@ href="#boost-parameter-const-function-call-op-result-tag-namespace-arguments"
             (required
                 (y, (bool))
                 (z, (std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/container/map"><tt
-class="docutils literal">map</tt></a>&lt;char const*,std::<a
-class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;))
+href="http://en.cppreference.com/w/cpp/container/map"
+>map</a>&lt;char const*,std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string">string</a>&gt;))
             )
         )
     )
     {
         return y ? (
-            (z.find(this->key)->second)[this->index]
-        ) : this->key[this->index];
+            (z.find(this-&gt;key)-&gt;second)[this-&gt;index]
+        ) : this-&gt;key[this-&gt;index];
     }
 };
 </pre>
-<p class="first">As with regular argument-dependent lookup, the value types of
-the arguments passed in determine which function call operator overload gets
-invoked.</p>
+<p>As with regular argument-dependent lookup, the value types of the arguments
+passed in determine which function call operator overload gets invoked.</p>
 <pre class="first literal-block">
 char const* keys[] = {"foo", "bar", "baz"};
 std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/container/map"><tt
-class="docutils literal">map</tt></a>&lt;char const*,std::<a
-class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt; k2s;
+href="http://en.cppreference.com/w/cpp/container/map"
+>map</a>&lt;char const*,std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt; k2s;
 k2s[keys[0]] = std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;("qux");
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;("qux");
 k2s[keys[1]] = std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;("wmb");
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;("wmb");
 k2s[keys[2]] = std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;("zxc");
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;("zxc");
 char_reader r(keys[0]);
 
 // positional arguments
@@ -3601,11 +3505,10 @@ r(keys[2], 2);
 BOOST_TEST_EQ('c', (r(k2s, true)));
 BOOST_TEST_EQ('z', (r(k2s, false)));
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> and <a
-class="reference external" href="../../test/preprocessor_deduced.cpp"
->test/preprocessor_deduced.cpp</a> test programs demonstrate proper usage of
-this macro.</p>
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a> and <a class="reference external"
+href="../../test/preprocessor_deduced.cpp">test/preprocessor_deduced.cpp</a>
+test programs demonstrate proper usage of this macro.</p>
 </td>
 </tr>
 <tr class="field">
@@ -3748,13 +3651,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
     return this-&gt;boost_param_impl ## __LINE__ ## operator(
         boost_param_parameters_ ## __LINE__ ## operator()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -3774,20 +3676,19 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
     return this-&gt;boost_param_impl ## __LINE__ ## operator(
         boost_param_parameters_ ## __LINE__ ## operator()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
 
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## operator&lt;Args&gt;::type
-    boost_param_impl ## __LINE__ ## operator(Args const& args)
+    boost_param_impl ## __LINE__ ## operator(Args const&amp; args)
 {
     return this-&gt;boost_param_dispatch_0boost_ ## __LINE__ ## operator(
         static_cast&lt;
@@ -3797,8 +3698,7 @@ typename boost_param_result_ ## __LINE__ ## operator&lt;Args&gt;::type
         &gt;(std::nullptr)
       , args
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -3808,8 +3708,7 @@ class="docutils literal">forward</tt></a>&lt;
 >0</strong>])
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -3846,21 +3745,18 @@ ResultType
 >n + 1</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>0</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>0</strong>
         )
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>n</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>n</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -3911,6 +3807,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a function call operator that can take in positional arguments,
+composed arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -3921,8 +3819,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -3950,10 +3848,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -3992,13 +3890,13 @@ struct U
     }
 };
 </pre>
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">kw</tt> in this
-case.  The identifiers with leading underscores can be passed to the bracket
-operator of <tt class="docutils literal">args</tt> to extract the same
-argument to which the corresponding named parameter (without underscores) is
-bound, as will be shown later.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">kw</tt> in this case.  The
+identifiers with leading underscores can be passed to the bracket operator of
+<tt class="docutils literal">args</tt> to extract the same argument to which
+the corresponding named parameter (without underscores) is bound, as will be
+shown later.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
@@ -4009,11 +3907,11 @@ bound, as will be shown later.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a normal <tt
-class="docutils literal">const</tt> function call operator header.  Enclose
-the return type <tt class="docutils literal">bool</tt> in parentheses.  For
-each parameter, also enclose the expected value type in parentheses.  Since
-the value types are mutually exclusive, you can wrap the parameters in a <tt
+<p>Use the macro as a substitute for a normal <tt class="docutils literal"
+>const</tt> function call operator header.  Enclose the return type <tt
+class="docutils literal">bool</tt> in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a <tt
 class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
 normal function, the order in which you specify the parameters determines
 their position.  Also, just as with a normal function, optional parameters
@@ -4054,8 +3952,8 @@ struct B
         BOOST_TEST_EQ(
             passed_by_rvalue_reference_to_const
           , U::evaluate_category&lt;2&gt;(std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;rrc0_type&gt;(rrc0))
         );
         BOOST_TEST_EQ(
             passed_by_rvalue_reference
@@ -4066,7 +3964,7 @@ class="docutils literal">forward</tt></a>&lt;rrc0_type&gt;(rrc0))
     }
 };
 </pre>
-<p class="first">The following function calls are legal.</p>
+<p>The following function calls are legal.</p>
 <pre class="first literal-block">
 B const b = B();
 b(  // positional arguments
@@ -4096,9 +3994,8 @@ b(  // named arguments
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="first">Because the parameters were wrapped in a <tt
-class="docutils literal">(deduced …)</tt> clause, the following function calls
-are also legal.</p>
+<p>Because the parameters were wrapped in a <tt class="docutils literal"
+>(deduced …)</tt> clause, the following function calls are also legal.</p>
 <pre class="first literal-block">
 b(  // deduced arguments
     rvalue_bitset&lt;3&gt;()
@@ -4111,10 +4008,10 @@ b(  // deduced arguments
   , lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a>, <a
-class="reference external" href="../../test/preprocessor_deduced.cpp"
->test/preprocessor_deduced.cpp</a>, and <a class="reference external"
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a>, <a class="reference external"
+href="../../test/preprocessor_deduced.cpp">test/preprocessor_deduced.cpp</a>,
+and <a class="reference external"
 href="../../test/preprocessor_eval_cat_8.cpp"
 >test/preprocessor_eval_cat_8.cpp</a> test programs demonstrate proper usage
 of this macro.</p>
@@ -4260,13 +4157,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
     return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
         boost_param_parameters_const_ ## __LINE__ ## operator()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -4286,20 +4182,19 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
     return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
         boost_param_parameters_const_ ## __LINE__ ## operator()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
 
 template &lt;typename Args&gt;
 typename boost_param_result_const_ ## __LINE__ ## operator&lt;Args&gt;::type
-    boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+    boost_param_impl_const ## __LINE__ ## operator(Args const&amp; args) const
 {
     return this-&gt;
     boost_param_dispatch_const_0boost_ ## __LINE__ ## operator(
@@ -4310,8 +4205,7 @@ typename boost_param_result_const_ ## __LINE__ ## operator&lt;Args&gt;::type
         &gt;(std::nullptr)
       , args
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -4321,8 +4215,7 @@ class="docutils literal">forward</tt></a>&lt;
 >0</strong>])
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -4360,21 +4253,18 @@ ResultType
 >n + 1</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>0</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>0</strong>
         )
       , …
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt; <em
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt; <em
 >argument name</em> ## <strong>n</strong> ## _type&gt;(
             <em>argument name</em> ## <strong>n</strong>
         )
       , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;
+href="http://en.cppreference.com/w/cpp/utility/forward">forward</a>&lt;
             typename boost::parameter::value_type&lt;
                 Args
               , <em
@@ -4425,6 +4315,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a constructor that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -4435,21 +4327,20 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">tag</tt> by
-default.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">tag</tt> by default.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(y)
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(z)
 </pre>
-<p class="first">In the base class, implement a delegate constructor template
-that takes in an <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a>.  You must pass the identifiers with
-leading underscores to <tt class="docutils literal">args</tt> in order to
-extract the corresponding arguments.</p>
+<p>In the base class, implement a delegate constructor template that takes in
+an <a class="reference internal" href="#argumentpack"><span class="concept"
+>ArgumentPack</span></a>.  You must pass the identifiers with leading
+underscores to <tt class="docutils literal">args</tt> in order to extract the
+corresponding arguments.</p>
 <pre class="first literal-block">
 class char_read_base
 {
@@ -4458,7 +4349,7 @@ class char_read_base
 
  public:
     template &lt;typename Args&gt;
-    explicit char_read_base(Args const& args)
+    explicit char_read_base(Args const&amp; args)
       : index(args[_y]), key(args[_z])
     {
     }
@@ -4483,11 +4374,10 @@ href="#boost-parameter-const-function-call-op-result-tag-namespace-arguments"
             (required
                 (y, (bool))
                 (z, (std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/container/map"><tt
-class="docutils literal">map</tt></a>&lt;char const*,std::<a
-class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;))
+href="http://en.cppreference.com/w/cpp/container/map"
+>map</a>&lt;char const*,std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;))
             )
         )
     )
@@ -4498,11 +4388,11 @@ class="docutils literal">string</tt></a>&gt;))
     }
 };
 </pre>
-<p class="first">Use the macro as a substitute for a normal constructor
-definition.  Note the lack of an explicit body.  Enclose the base type in
-parentheses.  For each parameter, also enclose the expected value type in
-parentheses.  Since the value types are mutually exclusive, you can wrap the
-parameters in a <tt class="docutils literal">(deduced …)</tt> clause.</p>
+<p>Use the macro as a substitute for a normal constructor definition.  Note
+the lack of an explicit body.  Enclose the base type in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.</p>
 <pre class="first literal-block">
 struct char_reader : public char_read_base
 {
@@ -4516,25 +4406,24 @@ struct char_reader : public char_read_base
     )
 };
 </pre>
-<p class="first">The following <tt class="docutils literal">char_reader</tt>
-constructor calls are legal.</p>
+<p>The following <tt class="docutils literal">char_reader</tt> constructor
+calls are legal.</p>
 <pre class="first literal-block">
 char const* keys[] = {"foo", "bar", "baz"};
 std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/container/map"><tt
-class="docutils literal">map</tt></a>&lt;char const*,std::<a
-class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt; k2s;
+href="http://en.cppreference.com/w/cpp/container/map"
+>map</a>&lt;char const*,std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt; k2s;
 k2s[keys[0]] = std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;("qux");
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;("qux");
 k2s[keys[1]] = std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;("wmb");
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;("wmb");
 k2s[keys[2]] = std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;("zxc");
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;("zxc");
 
 // positional arguments
 char_reader r0(0, keys[0]);
@@ -4551,9 +4440,9 @@ char_reader r2(keys[2], 2);
 BOOST_TEST_EQ('c', (r2(k2s, true)));
 BOOST_TEST_EQ('z', (r2(k2s, false)));
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> and <a
-class="reference external" href="../../test/preprocessor_eval_category.cpp"
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a> and <a class="reference external"
+href="../../test/preprocessor_eval_category.cpp"
 >test/preprocessor_eval_category.cpp</a> test programs demonstrate proper
 usage of this macro.</p>
 </td>
@@ -4670,13 +4559,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
   : <strong>impl</strong>(
         constructor_parameters ## __LINE__(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     )
 {
@@ -4690,13 +4578,12 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
   : <strong>impl</strong>(
         constructor_parameters ## __LINE__(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     )
 {
@@ -4722,6 +4609,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -4732,8 +4621,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -4761,10 +4650,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -4803,13 +4692,13 @@ struct U
     }
 };
 </pre>
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">kw</tt> in this
-case.  The identifiers with leading underscores can be passed to the bracket
-operator of <tt class="docutils literal">args</tt> to extract the same
-argument to which the corresponding named parameter (without underscores) is
-bound, as will be shown later.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">kw</tt> in this case.  The
+identifiers with leading underscores can be passed to the bracket operator of
+<tt class="docutils literal">args</tt> to extract the same argument to which
+the corresponding named parameter (without underscores) is bound, as will be
+shown later.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
@@ -4820,19 +4709,18 @@ bound, as will be shown later.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a normal function
-header.  Enclose the return type <tt class="docutils literal">bool</tt> in
-parentheses.  For each parameter, also enclose the expected value type in
-parentheses.  Since the value types are mutually exclusive, you can wrap the
-parameters in a <tt class="docutils literal">(deduced …)</tt>
-clause.  Otherwise, just as with a normal function, the order in which you
-specify the parameters determines their position.  However, unlike a normal
-function, default values must be specified within the function body.  Also
-within the function body, you must pass the matching identifier with the
-leading underscore to the bracket operator of <tt class="docutils literal"
->args</tt> to extract the corresponding argument, but at least this doesn't
-require <tt class="docutils literal">std::forward</tt> to preserve value
-categories.</p>
+<p>Use the macro as a substitute for a normal function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a <tt
+class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
+normal function, the order in which you specify the parameters determines
+their position.  However, unlike a normal function, default values must be
+specified within the function body.  Also within the function body, you must
+pass the matching identifier with the leading underscore to the bracket
+operator of <tt class="docutils literal">args</tt> to extract the
+corresponding argument, but at least this doesn't require <tt
+class="docutils literal">std::forward</tt> to preserve value categories.</p>
 <pre class="first literal-block">
 BOOST_PARAMETER_BASIC_FUNCTION((bool), evaluate, kw,
     (deduced
@@ -4869,7 +4757,7 @@ BOOST_PARAMETER_BASIC_FUNCTION((bool), evaluate, kw,
     return true;
 }
 </pre>
-<p class="first">The following function calls are legal.</p>
+<p>The following function calls are legal.</p>
 <pre class="first literal-block">
 evaluate(  // positional arguments
     lvalue_const_bitset&lt;0&gt;()
@@ -4898,9 +4786,8 @@ evaluate(  // named arguments
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="first">Because the parameters were wrapped in a <tt
-class="docutils literal">(deduced …)</tt> clause, the following function calls
-are also legal.</p>
+<p>Because the parameters were wrapped in a <tt class="docutils literal"
+>(deduced …)</tt> clause, the following function calls are also legal.</p>
 <pre class="first literal-block">
 evaluate(  // deduced arguments
     rvalue_bitset&lt;3&gt;()
@@ -4913,9 +4800,9 @@ evaluate(  // deduced arguments
   , lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
-demonstrates proper usage of this macro.</p>
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a> test program demonstrates proper usage of this
+macro.</p>
 </td>
 </tr>
 <tr class="field">
@@ -5033,7 +4920,7 @@ typedef boost_param_params_ ## __LINE__ ## <strong>name</strong>
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## <strong
 >name</strong>&lt;Args&gt;::type
-    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const&);
+    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const&amp;);
 
 template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
 <em>result type</em>
@@ -5050,13 +4937,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
     return boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -5078,13 +4964,12 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
     return boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
@@ -5092,7 +4977,8 @@ class="docutils literal">forward</tt></a>&lt;A ## <strong
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## <strong
 >name</strong>&lt;Args&gt;::type
-    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
+    boost_param_impl ## __LINE__ ## <strong
+>name</strong>(Args const&amp; args)
 </pre>
 <p>Only the <a class="reference internal" href="#argumentpack"><span
 class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
@@ -5118,6 +5004,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a member function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -5128,8 +5016,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -5157,10 +5045,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -5199,13 +5087,13 @@ struct U
     }
 };
 </pre>
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">kw</tt> in this
-case.  The identifiers with leading underscores can be passed to the bracket
-operator of <tt class="docutils literal">args</tt> to extract the same
-argument to which the corresponding named parameter (without underscores) is
-bound, as will be shown later.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">kw</tt> in this case.  The
+identifiers with leading underscores can be passed to the bracket operator of
+<tt class="docutils literal">args</tt> to extract the same argument to which
+the corresponding named parameter (without underscores) is bound, as will be
+shown later.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
@@ -5216,11 +5104,11 @@ bound, as will be shown later.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a normal <tt
-class="docutils literal">static</tt> member function header.  Enclose the
-return type <tt class="docutils literal">bool</tt> in parentheses.  For each
-parameter, also enclose the expected value type in parentheses.  Since the
-value types are mutually exclusive, you can wrap the parameters in a <tt
+<p>Use the macro as a substitute for a normal <tt class="docutils literal"
+>static</tt> member function header.  Enclose the return type <tt
+class="docutils literal">bool</tt> in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a <tt
 class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
 normal function, the order in which you specify the parameters determines
 their position.  However, unlike a normal function, default values must be
@@ -5270,7 +5158,7 @@ struct B
     }
 };
 </pre>
-<p class="first">The following function calls are legal.</p>
+<p>The following function calls are legal.</p>
 <pre class="first literal-block">
 B::evaluate(  // positional arguments
     lvalue_const_bitset&lt;0&gt;()
@@ -5299,9 +5187,8 @@ B::evaluate(  // named arguments
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="first">Because the parameters were wrapped in a <tt
-class="docutils literal">(deduced …)</tt> clause, the following function calls
-are also legal.</p>
+<p>Because the parameters were wrapped in a <tt class="docutils literal"
+>(deduced …)</tt> clause, the following function calls are also legal.</p>
 <pre class="first literal-block">
 B::evaluate(  // deduced arguments
     rvalue_bitset&lt;3&gt;()
@@ -5314,9 +5201,9 @@ B::evaluate(  // deduced arguments
   , lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
-demonstrates proper usage of this macro.</p>
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a> test program demonstrates proper usage of this
+macro.</p>
 </td>
 </tr>
 <tr class="field">
@@ -5449,13 +5336,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
     return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -5477,13 +5363,12 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
     return this-&gt;boost_param_impl ## __LINE__ ## <strong>name</strong>(
         boost_param_parameters_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
@@ -5491,7 +5376,8 @@ class="docutils literal">forward</tt></a>&lt;A ## <strong
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## <strong
 >name</strong>&lt;Args&gt;::type
-    boost_param_impl ## __LINE__ ## <strong>name</strong>(Args const& args)
+    boost_param_impl ## __LINE__ ## <strong
+>name</strong>(Args const&amp; args)
 </pre>
 <p>Only the <a class="reference internal" href="#argumentpack"><span
 class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
@@ -5517,6 +5403,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a member function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -5527,8 +5415,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -5556,10 +5444,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -5598,13 +5486,13 @@ struct U
     }
 };
 </pre>
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">kw</tt> in this
-case.  The identifiers with leading underscores can be passed to the bracket
-operator of <tt class="docutils literal">args</tt> to extract the same
-argument to which the corresponding named parameter (without underscores) is
-bound, as will be shown later.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">kw</tt> in this case.  The
+identifiers with leading underscores can be passed to the bracket operator of
+<tt class="docutils literal">args</tt> to extract the same argument to which
+the corresponding named parameter (without underscores) is bound, as will b
+shown later.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
@@ -5615,11 +5503,11 @@ bound, as will be shown later.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a normal <tt
-class="docutils literal">const</tt> member function header.  Enclose the
-return type <tt class="docutils literal">bool</tt> in parentheses.  For each
-parameter, also enclose the expected value type in parentheses.  Since the
-value types are mutually exclusive, you can wrap the parameters in a <tt
+<p>Use the macro as a substitute for a normal <tt class="docutils literal"
+>const</tt> member function header.  Enclose the return type <tt
+class="docutils literal">bool</tt> in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a <tt
 class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
 normal function, the order in which you specify the parameters determines
 their position.  However, unlike a normal function, default values must be
@@ -5673,7 +5561,7 @@ struct B
     }
 };
 </pre>
-<p class="first">The following function calls are legal.</p>
+<p>The following function calls are legal.</p>
 <pre class="first literal-block">
 B const b = B();
 b.evaluate(  // positional arguments
@@ -5703,9 +5591,8 @@ b.evaluate(  // named arguments
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="first">Because the parameters were wrapped in a <tt
-class="docutils literal">(deduced …)</tt> clause, the following function calls
-are also legal.</p>
+<p>Because the parameters were wrapped in a <tt class="docutils literal"
+>(deduced …)</tt> clause, the following function calls are also legal.</p>
 <pre class="first literal-block">
 b.evaluate(  // deduced arguments
     rvalue_bitset&lt;3&gt;()
@@ -5718,9 +5605,9 @@ b.evaluate(  // deduced arguments
   , lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
-demonstrates proper usage of this macro.</p>
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a> test program demonstrates proper usage of this
+macro.</p>
 </td>
 </tr>
 <tr class="field">
@@ -5851,13 +5738,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
 >name</strong>(
         boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -5880,13 +5766,12 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
 >name</strong>(
         boost_param_parameters_const_ ## __LINE__ ## <strong>name</strong>()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
@@ -5895,7 +5780,7 @@ template &lt;typename Args&gt;
 typename boost_param_result_const_ ## __LINE__ ## <strong
 >name</strong>&lt;Args&gt;::type
     boost_param_impl_const ## __LINE__ ## <strong
->name</strong>(Args const& args) const
+>name</strong>(Args const&amp; args) const
 </pre>
 <p>Only the <a class="reference internal" href="#argumentpack"><span
 class="concept">ArgumentPack</span></a> type <tt class="docutils literal"
@@ -5921,6 +5806,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a function call operator that can take in positional arguments,
+composed arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -5931,20 +5818,19 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">tag</tt> by
-default.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">tag</tt> by default.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(y)
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(z)
 </pre>
-<p class="first">Use the macro as a substitute for a normal function call
-operator header.  Enclose the return type in parentheses.  For each parameter,
-also enclose the expected value type in parentheses.  Since the value types
-are mutually exclusive, you can wrap the parameters in a <tt
+<p>Use the macro as a substitute for a normal function call operator
+header.  Enclose the return type in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a <tt
 class="docutils literal">(deduced …)</tt> clause.  This is especially useful
 when implementing multiple Boost.Parameter-enabled function call operator
 overloads.</p>
@@ -5979,11 +5865,9 @@ href="#boost-parameter-basic-const-function-call-op-result-tag-ns-args"
             (required
                 (y, (bool))
                 (z, (std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/container/map"><tt
-class="docutils literal">map</tt></a>&lt;char const*,std::<a
-class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;))
+href="http://en.cppreference.com/w/cpp/container/map"
+>map</a>&lt;char const*,std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string">string</a>&gt;))
             )
         )
     )
@@ -5994,26 +5878,24 @@ class="docutils literal">string</tt></a>&gt;))
     }
 };
 </pre>
-<p class="first">As with regular argument-dependent lookup, the value types of
-the arguments passed in determine which function call operator overload gets
-invoked.</p>
+<p>As with regular argument-dependent lookup, the value types of the arguments
+passed in determine which function call operator overload gets invoked.</p>
 <pre class="first literal-block">
 char const* keys[] = {"foo", "bar", "baz"};
 std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/container/map"><tt
-class="docutils literal">map</tt></a>&lt;char const*,std::<a
-class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt; k2s;
+href="http://en.cppreference.com/w/cpp/container/map"
+>map</a>&lt;char const*,std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt; k2s;
 k2s[keys[0]] = std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;("qux");
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;("qux");
 k2s[keys[1]] = std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;("wmb");
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;("wmb");
 k2s[keys[2]] = std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/string/basic_string"><tt
-class="docutils literal">string</tt></a>&gt;("zxc");
+href="http://en.cppreference.com/w/cpp/string/basic_string"
+>string</a>&gt;("zxc");
 char_reader r(keys[0]);
 
 // positional arguments
@@ -6030,9 +5912,9 @@ r(keys[2], 2);
 BOOST_TEST_EQ('c', (r(k2s, true)));
 BOOST_TEST_EQ('z', (r(k2s, false)));
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
-demonstrates proper usage of this macro.</p>
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a> test program demonstrates proper usage of this
+macro.</p>
 </td>
 </tr>
 <tr class="field">
@@ -6158,13 +6040,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
     return this-&gt;boost_param_impl ## __LINE__ ## operator(
         boost_param_parameters_ ## __LINE__ ## operator()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -6184,20 +6065,19 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
     return this-&gt;boost_param_impl ## __LINE__ ## operator(
         boost_param_parameters_ ## __LINE__ ## operator()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
 
 template &lt;typename Args&gt;
 typename boost_param_result_ ## __LINE__ ## operator&lt;Args&gt;::type
-    boost_param_impl ## __LINE__ ## operator(Args const& args)
+    boost_param_impl ## __LINE__ ## operator(Args const&amp; args)
 </pre>
 </dd>
 </dl>
@@ -6220,6 +6100,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a function call operator that can take in positional arguments,
+composed arguments, named arguments, and deduced arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -6230,8 +6112,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -6259,10 +6141,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -6301,13 +6183,13 @@ struct U
     }
 };
 </pre>
-<p class="first">Define the named parameters that will comprise the argument
-specification that this macro will use.  Ensure that all their tag types are
-in the same namespace, which is <tt class="docutils literal">kw</tt> in this
-case.  The identifiers with leading underscores can be passed to the bracket
-operator of <tt class="docutils literal">args</tt> to extract the same
-argument to which the corresponding named parameter (without underscores) is
-bound, as will be shown later.</p>
+<p>Define the named parameters that will comprise the argument specification
+that this macro will use.  Ensure that all their tag types are in the same
+namespace, which is <tt class="docutils literal">kw</tt> in this case.  The
+identifiers with leading underscores can be passed to the bracket operator of
+<tt class="docutils literal">args</tt> to extract the same argument to which
+the corresponding named parameter (without underscores) is bound, as will be
+shown later.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw) in(lrc))
@@ -6318,11 +6200,11 @@ bound, as will be shown later.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a normal <tt
-class="docutils literal">const</tt> function call operator header.  Enclose
-the return type <tt class="docutils literal">bool</tt> in parentheses.  For
-each parameter, also enclose the expected value type in parentheses.  Since
-the value types are mutually exclusive, you can wrap the parameters in a <tt
+<p>Use the macro as a substitute for a normal <tt class="docutils literal"
+>const</tt> function call operator header.  Enclose the return type <tt
+class="docutils literal">bool</tt> in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a <tt
 class="docutils literal">(deduced …)</tt> clause.  Otherwise, just as with a
 normal function, the order in which you specify the parameters determines
 their position.  However, unlike a normal function, default values must be
@@ -6376,7 +6258,7 @@ struct B
     }
 };
 </pre>
-<p class="first">The following function calls are legal.</p>
+<p>The following function calls are legal.</p>
 <pre class="first literal-block">
 B const b = B();
 b(  // positional arguments
@@ -6406,9 +6288,8 @@ b(  // named arguments
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="first">Because the parameters were wrapped in a <tt
-class="docutils literal">(deduced …)</tt> clause, the following function calls
-are also legal.</p>
+<p>Because the parameters were wrapped in a <tt class="docutils literal"
+>(deduced …)</tt> clause, the following function calls are also legal.</p>
 <pre class="first literal-block">
 b(  // deduced arguments
     rvalue_bitset&lt;3&gt;()
@@ -6421,9 +6302,9 @@ b(  // deduced arguments
   , lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
-href="../../test/preprocessor.cpp">test/preprocessor.cpp</a> test program
-demonstrates proper usage of this macro.</p>
+<p>The <a class="reference external" href="../../test/preprocessor.cpp"
+>test/preprocessor.cpp</a> test program demonstrates proper usage of this
+macro.</p>
 </td>
 </tr>
 <tr class="field">
@@ -6549,13 +6430,12 @@ template &lt;typename A0, …, typename A ## <strong>n</strong>&gt;
     return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
         boost_param_parameters_const_ ## __LINE__ ## operator()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->n</strong>&gt;(a ## <strong>n</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>n</strong>&gt;(a ## <strong>n</strong>)
         )
     );
 }
@@ -6575,20 +6455,19 @@ template &lt;typename A0, …, typename A ## <strong>m</strong>&gt;
     return this-&gt;boost_param_impl_const ## __LINE__ ## operator(
         boost_param_parameters_const_ ## __LINE__ ## operator()(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A0&gt;(a0)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A0&gt;(a0)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->m</strong>&gt;(a ## <strong>m</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>m</strong>&gt;(a ## <strong>m</strong>)
         )
     );
 }
 
 template &lt;typename Args&gt;
 typename boost_param_result_const_ ## __LINE__ ## operator&lt;Args&gt;::type
-    boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+    boost_param_impl_const ## __LINE__ ## operator(Args const&amp; args) const
 </pre>
 </dd>
 </dl>
@@ -6609,6 +6488,7 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a function that can take in named arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -6619,8 +6499,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -6648,10 +6528,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -6690,8 +6570,8 @@ struct U
     }
 };
 </pre>
-<p class="first">Named parameters are required when invoking the function;
-however, none of their tags need to be in the same namespace.</p>
+<p>Named parameters are required when invoking the function; however, none of
+their tags need to be in the same namespace.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
@@ -6702,9 +6582,8 @@ however, none of their tags need to be in the same namespace.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a variadic function
-header.  Enclose the return type <tt class="docutils literal">bool</tt> in
-parentheses.</p>
+<p>Use the macro as a substitute for a variadic function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.</p>
 <pre class="first literal-block">
 BOOST_PARAMETER_NO_SPEC_FUNCTION((bool), evaluate)
 {
@@ -6730,8 +6609,7 @@ BOOST_PARAMETER_NO_SPEC_FUNCTION((bool), evaluate)
     return true;
 }
 </pre>
-<p class="first">To invoke the function, bind all its arguments to named
-parameters.</p>
+<p>To invoke the function, bind all its arguments to named parameters.</p>
 <pre class="first literal-block">
 evaluate(
     _rr0 = rvalue_bitset&lt;3&gt;()
@@ -6744,7 +6622,7 @@ evaluate(
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
+<p>The <a class="reference external"
 href="../../test/preprocessor_eval_cat_no_spec.cpp"
 >test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
 usage of this macro.</p>
@@ -6787,13 +6665,12 @@ template &lt;typename ResultType, typename Args&gt;
 ResultType
     boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
         (ResultType(*)())
-      , Args const& args
+      , Args const&amp; args
     );
 
 template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
 inline typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">lazy_enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>&lt;
     <a class="reference internal" href="#are-tagged-arguments"
 >are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
   , boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>&lt;
@@ -6822,7 +6699,7 @@ template &lt;typename ResultType, typename Args&gt;
 ResultType
     boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
         (ResultType(*)())
-      , Args const& args
+      , Args const&amp; args
     )
 </pre>
 <p>Only the <a class="reference internal" href="#argumentpack"><span
@@ -6848,6 +6725,7 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a member function that can take in named arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -6858,10 +6736,10 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">When designing a front-end class template whose back-end is
-configurable via parameterized inheritance, it can be useful to omit argument
-specifiers from a named-parameter member function so that the delegate member
-functions of the back-end classes can enforce their own specifications.</p>
+<p>When designing a front-end class template whose back-end is configurable
+via parameterized inheritance, it can be useful to omit argument specifiers
+from a named-parameter member function so that the delegate member functions
+of the back-end classes can enforce their own specifications.</p>
 <pre class="first literal-block">
 template &lt;typename B&gt;
 struct frontend : B
@@ -6876,8 +6754,8 @@ struct frontend : B
     }
 };
 </pre>
-<p class="first">Named parameters are required when invoking the member
-function; however, none of their tags need to be in the same namespace.</p>
+<p>Named parameters are required when invoking the member function; however,
+none of their tags need to be in the same namespace.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(a0)
@@ -6886,9 +6764,9 @@ function; however, none of their tags need to be in the same namespace.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(a2)
 </pre>
-<p class="first">For this example, each of the back-end class templates
-requires its own parameter to be present in the argument pack.  In practice,
-such parameters should be optional, with default values.</p>
+<p>For this example, each of the back-end class templates requires its own
+parameter to be present in the argument pack.  In practice, such parameters
+should be optional, with default values.</p>
 <pre class="first literal-block">
 template &lt;typename T&gt;
 class backend0
@@ -6961,8 +6839,8 @@ class backend2 : public B
     }
 };
 </pre>
-<p class="first">This example shows that while <tt class="docutils literal"
->backend0</tt> must always be the root base class template and that <tt
+<p>This example shows that while <tt class="docutils literal">backend0</tt>
+must always be the root base class template and that <tt
 class="docutils literal">frontend</tt> must always be the most derived class
 template, the other back-ends can be chained together in different orders.</p>
 <pre class="first literal-block">
@@ -6979,7 +6857,7 @@ BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
 BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
 BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
 </pre>
-<p class="last">The <a class="reference external"
+<p>The <a class="reference external"
 href="../../test/parameterized_inheritance.cpp"
 >test/parameterized_inheritance.cpp</a> and <a class="reference external"
 href="../../test/preprocessor_eval_cat_no_spec.cpp"
@@ -7025,8 +6903,7 @@ struct boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>
 
 template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
 inline typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">lazy_enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>&lt;
     <a class="reference internal" href="#are-tagged-arguments"
 >are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
   , boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>&lt;
@@ -7056,7 +6933,7 @@ template &lt;typename ResultType, typename Args&gt;
 ResultType
     boost_param_no_spec_impl ## __LINE__ ## <strong>name</strong>(
         (ResultType(*)())
-      , Args const& args
+      , Args const&amp; args
     )
 </pre>
 <p>Only the <a class="reference internal" href="#argumentpack"><span
@@ -7082,6 +6959,7 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a member function that can take in named arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -7092,8 +6970,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -7121,10 +6999,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -7163,8 +7041,8 @@ struct U
     }
 };
 </pre>
-<p class="first">Named parameters are required when invoking the member
-function; however, none of their tags need to be in the same namespace.</p>
+<p>Named parameters are required when invoking the member function; however,
+none of their tags need to be in the same namespace.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
@@ -7175,10 +7053,10 @@ function; however, none of their tags need to be in the same namespace.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a variadic function
-header.  Enclose the return type <tt class="docutils literal">bool</tt> in
-parentheses.  The macro will qualify the function with the <tt
-class="docutils literal">const</tt> keyword.</p>
+<p>Use the macro as a substitute for a variadic function header.  Enclose the
+return type <tt class="docutils literal">bool</tt> in parentheses.  The macro
+will qualify the function with the <tt class="docutils literal">const</tt>
+keyword.</p>
 <pre class="first literal-block">
 struct D
 {
@@ -7213,8 +7091,8 @@ struct D
     }
 };
 </pre>
-<p class="first">To invoke the member function, bind all its arguments to
-named parameters.</p>
+<p>To invoke the member function, bind all its arguments to named
+parameters.</p>
 <pre class="first literal-block">
 D const d = D();
 d.evaluate_m(
@@ -7228,7 +7106,7 @@ d.evaluate_m(
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
+<p>The <a class="reference external"
 href="../../test/preprocessor_eval_cat_no_spec.cpp"
 >test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
 usage of this macro.</p>
@@ -7300,7 +7178,7 @@ template &lt;typename ResultType, typename Args&gt;
 ResultType
     boost_param_no_spec_impl_const ## __LINE__ ## <strong>name</strong>(
         (ResultType(*)())
-      , Args const& args
+      , Args const&amp; args
     ) const
 </pre>
 <p>Only the <a class="reference internal" href="#argumentpack"><span
@@ -7326,6 +7204,7 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a function call operator that can take in named arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -7336,11 +7215,10 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">When designing a front-end class template whose back-end is
-configurable via parameterized inheritance, it can be useful to omit argument
-specifiers from a named-parameter function call operator so that the delegate
-member functions of the back-end classes can enforce their own
-specifications.</p>
+<p>When designing a front-end class template whose back-end is configurable
+via parameterized inheritance, it can be useful to omit argument specifiers
+from a named-parameter function call operator so that the delegate member
+functions of the back-end classes can enforce their own specifications.</p>
 <pre class="first literal-block">
 template &lt;typename B&gt;
 struct frontend : B
@@ -7355,8 +7233,8 @@ struct frontend : B
     }
 };
 </pre>
-<p class="first">Named parameters are required when invoking the function call
-operator; however, none of their tags need to be in the same namespace.</p>
+<p>Named parameters are required when invoking the function call operator;
+however, none of their tags need to be in the same namespace.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(a0)
@@ -7365,9 +7243,9 @@ operator; however, none of their tags need to be in the same namespace.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(a2)
 </pre>
-<p class="first">For this example, each of the back-end class templates
-requires its own parameter to be present in the argument pack.  In practice,
-such parameters should be optional, with default values.</p>
+<p>For this example, each of the back-end class templates requires its own
+parameter to be present in the argument pack.  In practice, such parameters
+should be optional, with default values.</p>
 <pre class="first literal-block">
 template &lt;typename T&gt;
 class backend0
@@ -7440,8 +7318,8 @@ class backend2 : public B
     }
 };
 </pre>
-<p class="first">This example shows that while <tt class="docutils literal"
->backend0</tt> must always be the root base class template and that <tt
+<p>This example shows that while <tt class="docutils literal">backend0</tt>
+must always be the root base class template and that <tt
 class="docutils literal">frontend</tt> must always be the most derived class
 template, the other back-ends can be chained together in different orders.</p>
 <pre class="first literal-block">
@@ -7458,7 +7336,7 @@ BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
 BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
 BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
 </pre>
-<p class="last">The <a class="reference external"
+<p>The <a class="reference external"
 href="../../test/parameterized_inheritance.cpp"
 >test/parameterized_inheritance.cpp</a> and <a class="reference external"
 href="../../test/preprocessor_eval_cat_no_spec.cpp"
@@ -7499,8 +7377,7 @@ struct boost_param_no_spec_result_ ## __LINE__ ## operator
 
 template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
 inline typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">lazy_enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>&lt;
     <a class="reference internal" href="#are-tagged-arguments"
 >are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
   , boost_param_no_spec_result_ ## __LINE__ ## operator&lt;
@@ -7527,7 +7404,7 @@ template &lt;typename ResultType, typename Args&gt;
 ResultType
     boost_param_no_spec_impl ## __LINE__ ## operator(
         (ResultType(*)())
-      , Args const& args
+      , Args const&amp; args
     )
 </pre>
 <p>Only the <a class="reference internal" href="#argumentpack"><span
@@ -7553,6 +7430,7 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a function call operator that can take in named arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -7563,8 +7441,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following function templates
-falls under a different value category.</p>
+<p>The return type of each of the following function templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -7592,10 +7470,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-value category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -7634,8 +7512,8 @@ struct U
     }
 };
 </pre>
-<p class="first">Named parameters are required when invoking the function call
-operator; however, none of their tags need to be in the same namespace.</p>
+<p>Named parameters are required when invoking the function call operator;
+however, none of their tags need to be in the same namespace.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
@@ -7646,9 +7524,9 @@ operator; however, none of their tags need to be in the same namespace.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
 </pre>
-<p class="first">Use the macro as a substitute for a variadic function call
-operator header.  Enclose the return type <tt class="docutils literal"
->bool</tt> in parentheses.  The macro will qualify the function with the <tt
+<p>Use the macro as a substitute for a variadic function call operator
+header.  Enclose the return type <tt class="docutils literal">bool</tt> in
+parentheses.  The macro will qualify the function with the <tt
 class="docutils literal">const</tt> keyword.</p>
 <pre class="first literal-block">
 struct D
@@ -7684,8 +7562,8 @@ struct D
     }
 };
 </pre>
-<p class="first">To invoke the function call operator, bind all its arguments
-to named parameters.</p>
+<p>To invoke the function call operator, bind all its arguments to named
+parameters.</p>
 <pre class="first literal-block">
 D const d = D();
 d(
@@ -7699,7 +7577,7 @@ d(
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
+<p>The <a class="reference external"
 href="../../test/preprocessor_eval_cat_no_spec.cpp"
 >test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
 usage of this macro.</p>
@@ -7738,8 +7616,7 @@ struct boost_param_no_spec_result_const_ ## __LINE__ ## operator
 
 template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
 inline typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html"><tt
-class="docutils literal">lazy_enable_if</tt></a>&lt;
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>&lt;
     <a class="reference internal" href="#are-tagged-arguments"
 >are_tagged_arguments</a>&lt;TaggedArg0,TaggedArgs...&gt;
   , boost_param_no_spec_result_const_ ## __LINE__ ## operator&lt;
@@ -7769,7 +7646,7 @@ template &lt;typename ResultType, typename Args&gt;
 ResultType
     boost_param_no_spec_impl_const ## __LINE__ ## operator(
         (ResultType(*)())
-      , Args const& args
+      , Args const&amp; args
     ) const
 </pre>
 <p>Only the <a class="reference internal" href="#argumentpack"><span
@@ -7795,6 +7672,7 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a constructor that can take in named arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -7805,10 +7683,10 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">When designing a front-end class template whose back-end is
-configurable via parameterized inheritance, it can be useful to omit argument
-specifiers from a named-parameter constructor so that the delegate
-constructors of the back-end classes can enforce their own specifications.</p>
+<p>When designing a front-end class template whose back-end is configurable
+via parameterized inheritance, it can be useful to omit argument specifiers
+from a named-parameter constructor so that the delegate constructors of the
+back-end classes can enforce their own specifications.</p>
 <pre class="first literal-block">
 template &lt;typename B&gt;
 struct frontend : B
@@ -7816,8 +7694,8 @@ struct frontend : B
     BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(frontend, (B))
 };
 </pre>
-<p class="first">Named parameters are required when invoking the constructor;
-however, none of their tags need to be in the same namespace.</p>
+<p>Named parameters are required when invoking the constructor; however, none
+of their tags need to be in the same namespace.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(a0)
@@ -7826,9 +7704,9 @@ however, none of their tags need to be in the same namespace.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>(a2)
 </pre>
-<p class="first">For this example, each of the back-end class templates
-requires its own parameter to be present in the argument pack.  In practice,
-such parameters should be optional, with default values.</p>
+<p>For this example, each of the back-end class templates requires its own
+parameter to be present in the argument pack.  In practice, such parameters
+should be optional, with default values.</p>
 <pre class="first literal-block">
 struct _enabler
 {
@@ -7909,8 +7787,8 @@ href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
     }
 };
 </pre>
-<p class="first">This example shows that while <tt class="docutils literal"
->backend0</tt> must always be the root base class template and that <tt
+<p>This example shows that while <tt class="docutils literal">backend0</tt>
+must always be the root base class template and that <tt
 class="docutils literal">frontend</tt> must always be the most derived class
 template, the other back-ends can be chained together in different orders.</p>
 <pre class="first literal-block">
@@ -7925,7 +7803,7 @@ BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
 BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
 BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
 </pre>
-<p class="last">The <a class="reference external"
+<p>The <a class="reference external"
 href="../../test/parameterized_inheritance.cpp"
 >test/parameterized_inheritance.cpp</a> and <a class="reference external"
 href="../../test/preprocessor_eval_cat_no_spec.cpp"
@@ -7997,6 +7875,7 @@ href="../../../../boost/parameter/preprocessor.hpp"
 </tr>
 </tbody>
 </table>
+<p>Generates a constructor that can take in named arguments.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -8007,8 +7886,8 @@ href="../../../../boost/parameter/preprocessor.hpp"
 <tr>
 <td>&nbsp;</td>
 <td class="field-body">
-<p class="first">The return type of each of the following functon templates
-falls under a different reference category.</p>
+<p>The return type of each of the following functon templates falls under a
+different value category.</p>
 <pre class="first literal-block">
 template &lt;std::size_t N&gt;
 std::bitset&lt;N + 1&gt; rvalue_bitset()
@@ -8036,10 +7915,10 @@ std::bitset&lt;N + 1&gt; const&amp; lvalue_const_bitset()
     return clset;
 }
 </pre>
-<p class="first">The <tt class="docutils literal">U::evaluate_category</tt>
-static member function template has a simple job: to return the correct
-reference category when passed in an object returned by one of the functions
-defined above.  Assume that <a class="reference internal"
+<p>The <tt class="docutils literal">U::evaluate_category</tt> static member
+function template has a simple job: to return the correct value category when
+passed in an object returned by one of the functions defined above.  Assume
+that <a class="reference internal"
 href="#boost-parameter-has-perfect-forwarding"><tt class="docutils literal"
 >BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a> is defined.</p>
 <pre class="first literal-block">
@@ -8078,8 +7957,8 @@ struct U
     }
 };
 </pre>
-<p class="first">Named parameters are required when invoking the constructor;
-however, none of their tags need to be in the same namespace.</p>
+<p>Named parameters are required when invoking the constructor; however, none
+of their tags need to be in the same namespace.</p>
 <pre class="first literal-block">
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_lrc, kw0) in(lrc))
@@ -8090,7 +7969,7 @@ however, none of their tags need to be in the same namespace.</p>
 <a class="reference internal" href="#boost-parameter-name-name"
 >BOOST_PARAMETER_NAME</a>((_rr, kw3) consume(rr))
 </pre>
-<p class="first">Unlike <a class="reference internal"
+<p>Unlike <a class="reference internal"
 href="#boost-parameter-no-spec-constructor-cls-impl"><tt
 class="docutils literal">BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR</tt></a>, this
 macro doesn't require a base class, only a delegate function to which the
@@ -8100,8 +7979,6 @@ href="#argumentpack"><span class="concept">ArgumentPack</span></a>.</p>
 struct D
 {
     BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(D, D::_evaluate)
-    {
-    }
 
  private:
     template &lt;typename Args&gt;
@@ -8132,8 +8009,7 @@ struct D
     }
 };
 </pre>
-<p class="first">To invoke the constructor, bind all its arguments to named
-parameters.</p>
+<p>To invoke the constructor, bind all its arguments to named parameters.</p>
 <pre class="first literal-block">
 D dp0(
     _rr0 = rvalue_bitset&lt;3&gt;()
@@ -8146,7 +8022,7 @@ D dp1(
   , _lrc0 = lvalue_const_bitset&lt;0&gt;()
 );
 </pre>
-<p class="last">The <a class="reference external"
+<p>The <a class="reference external"
 href="../../test/preprocessor_eval_cat_no_spec.cpp"
 >test/preprocessor_eval_cat_no_spec.cpp</a> test program demonstrates proper
 usage of this macro.</p>
@@ -8486,16 +8362,15 @@ r
     return <strong>name</strong>_with_named_params(
         pk(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A1&gt;(a1)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A1&gt;(a1)
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A2&gt;(a2)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A2&gt;(a2)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->l</strong>&gt;(a ## <strong>l</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>l</strong>&gt;(a ## <strong>l</strong>)
         )
     );
 }
@@ -8526,21 +8401,20 @@ href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
     return <strong>name</strong>_with_named_params(
         pk(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A1&gt;(a1)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A1&gt;(a1)
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A2&gt;(a2)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A2&gt;(a2)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->l</strong>&gt;(a ## <strong>l</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>l</strong>&gt;(a ## <strong>l</strong>)
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <a
-class="reference external" href="../../../preprocessor/doc/ref/inc.html"
->BOOST_PP_INC</a>(<strong>l</strong>)&gt;(a ## <a class="reference external"
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <a class="reference external"
+href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
+>l</strong>)&gt;(a ## <a class="reference external"
 href="../../../preprocessor/doc/ref/inc.html">BOOST_PP_INC</a>(<strong
 >l</strong>))
         )
@@ -8561,16 +8435,15 @@ r
     return <strong>name</strong>_with_named_params(
         pk(
             std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A1&gt;(a1)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A1&gt;(a1)
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A2&gt;(a2)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A2&gt;(a2)
           , …
           , std::<a class="reference external"
-href="http://en.cppreference.com/w/cpp/utility/forward"><tt
-class="docutils literal">forward</tt></a>&lt;A ## <strong
->h</strong>&gt;(a ## <strong>h</strong>)
+href="http://en.cppreference.com/w/cpp/utility/forward"
+>forward</a>&lt;A ## <strong>h</strong>&gt;(a ## <strong>h</strong>)
         )
     );
 }
@@ -9025,9 +8898,8 @@ class="docutils literal">BOOST_NO_RESULT_OF</tt></a> is <tt
 class="docutils literal">#defined</tt>, <tt class="docutils literal"
 >boost::</tt><a class="reference external"
 href="../../../utility/utility.htm#result_of"><tt class="docutils literal"
->result_of</tt></a><tt class="docutils literal"><span class="pre"
->&lt;F()&gt;::type</span></tt> is replaced by <tt class="docutils literal"
-><span class="pre">F::result_type</span></tt>.</td></tr>
+>result_of</tt></a><tt class="docutils literal">&lt;F()&gt;::type</tt> is
+replaced by <tt class="docutils literal">F::result_type</tt>.</td></tr>
 </tbody>
 </table>
 </div>

--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -1357,7 +1357,7 @@ default</li>
 <dl class="docutils" id="id13">
 <dt><tt class="docutils literal">operator()</tt></dt>
 <dd>
-\<pre class="first literal-block">
+<pre class="first literal-block">
 template &lt;typename ...Args&gt;
 <a class="reference internal" href="#argumentpack"><span class="concept"
 >ArgumentPack</span></a> operator()(Args&amp;&amp;... args) const;

--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -8853,7 +8853,7 @@ href="../../../mpl/doc/refmanual/limit-vector-size.html"
 ><tt class="docutils literal">BOOST_MPL_LIMIT_VECTOR_SIZE</tt></a> (defined by
 <a class="reference external" href="../../../mpl/doc/index.html"
 >Boost.MPL</a>) if perfect forwarding is supported,
-<tt class="docutils literal">20</tt> otherwise.</td>
+<tt class="docutils literal">8</tt> otherwise.</td>
 </tr>
 <tr class="field">
 <th class="field-name">Minimum Value:</th>

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -291,8 +291,6 @@ The type of every |keyword object| is a specialization of |keyword|.
 
 __ ../../../../boost/parameter/keyword.hpp
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-
 .. parsed-literal::
 
     template <typename Tag>
@@ -519,135 +517,6 @@ __ ../../../../boost/parameter/keyword.hpp
         static keyword<Tag>& get_\();
     };
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-.. parsed-literal::
-
-    template <typename Tag>
-    struct keyword
-    {
-        typedef Tag tag;
-
-        template <typename T>
-        typename boost::`enable_if`_<
-            typename boost::mpl::`eval_if_`_<
-                boost::`is_scalar`_<T>
-              , boost::mpl::`true_`_
-              , boost::mpl::`eval_if_`_<
-                    boost::`is_same`_<
-                        typename Tag::qualifier
-                      , boost::parameter::in_reference
-                    >
-                  , boost::mpl::`true_`_
-                  , boost::mpl::`if_`_<
-                        boost::`is_same`_<
-                            typename Tag::qualifier
-                          , boost::parameter::forward_reference
-                        >
-                      , boost::mpl::`true_`_
-                      , boost::mpl::`false_`_
-                    >
-                >
-            >::type
-          , |ArgumentPack|_
-        >::type constexpr
-            `operator=`_\(T const& value) const;
-
-        template <typename T>
-        typename boost::`enable_if`_<
-            typename boost::mpl::`eval_if_`_<
-                typename boost::mpl::`eval_if_`_<
-                    boost::`is_same`_<
-                        typename Tag::qualifier
-                      , boost::parameter::out_reference
-                    >
-                  , boost::mpl::`true_`_
-                  , boost::mpl::`if_`_<
-                        boost::`is_same`_<
-                            typename Tag::qualifier
-                          , boost::parameter::forward_reference
-                        >
-                      , boost::mpl::`true_`_
-                      , boost::mpl::`false_`_
-                    >
-                >::type
-              , boost::mpl::`if_`_<
-                    boost::`is_const`_<T>
-                  , boost::mpl::`false_`_
-                  , boost::mpl::`true_`_
-                >
-              , boost::mpl::`false_`_
-            >::type
-          , |ArgumentPack|_
-        >::type constexpr
-            `operator=`_\(T& value) const;
-
-        template <typename T>
-        typename boost::`enable_if`_<
-            typename boost::mpl::`eval_if_`_<
-                boost::`is_scalar`_<T>
-              , boost::mpl::`true_`_
-              , boost::mpl::`eval_if_`_<
-                    boost::`is_same`_<
-                        typename Tag::qualifier
-                      , boost::parameter::in_reference
-                    >
-                  , boost::mpl::`true_`_
-                  , boost::mpl::`if_`_<
-                        boost::`is_same`_<
-                            typename Tag::qualifier
-                          , boost::parameter::forward_reference
-                        >
-                      , boost::mpl::`true_`_
-                      , boost::mpl::`false_`_
-                    >
-                >
-            >::type
-          , *tagged default*
-        >::type
-            `operator|`_\(T const& x) const;
-
-        template <typename T>
-        typename boost::`enable_if`_<
-            typename boost::mpl::`eval_if_`_<
-                typename boost::mpl::`eval_if_`_<
-                    boost::`is_same`_<
-                        typename Tag::qualifier
-                      , boost::parameter::out_reference
-                    >
-                  , boost::mpl::`true_`_
-                  , boost::mpl::`if_`_<
-                        boost::`is_same`_<
-                            typename Tag::qualifier
-                          , boost::parameter::forward_reference
-                        >
-                      , boost::mpl::`true_`_
-                      , boost::mpl::`false_`_
-                    >
-                >::type
-              , boost::mpl::`if_`_<
-                    boost::`is_const`_<T>
-                  , boost::mpl::`false_`_
-                  , boost::mpl::`true_`_
-                >
-              , boost::mpl::`false_`_
-            >::type
-          , *tagged default*
-        >::type
-            `operator|`_\(T& x) const;
-
-        template <typename F>
-        *tagged lazy default* `operator||`_\(F const&) const;
-
-        template <typename F>
-        *tagged lazy default* `operator||`_\(F&) const;
-
-        static keyword<Tag> const& instance;
-
-        static keyword<Tag>& get_\();
-    };
-
 .. _enable_if: ../../../core/doc/html/core/enable_if.html
 .. _eval_if_: ../../../mpl/doc/refmanual/eval-if.html
 .. _false_: ../../../mpl/doc/refmanual/bool.html
@@ -665,10 +534,6 @@ __ ../../../../boost/parameter/keyword.hpp
 
     template <typename T> |ArgumentPack|_ operator=(T const& value) const;
     template <typename T> |ArgumentPack|_ operator=(T& value) const;
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-.. parsed-literal::
-
     template <typename T> |ArgumentPack|_ operator=(T const&& value) const;
     template <typename T> |ArgumentPack|_ operator=(T&& value) const;
 
@@ -700,10 +565,6 @@ nested ``qualifier`` type of ``Tag`` must be ``consume_reference`` or
 
     template <typename T> *tagged default* operator|(T const& x) const;
     template <typename T> *tagged default* operator|(T& x) const;
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-.. parsed-literal::
-
     template <typename T> *tagged default* operator|(T const&& x) const;
     template <typename T> *tagged default* operator|(T&& x) const;
 
@@ -801,18 +662,17 @@ The |ntp_cpp|_ test program demonstrates proper usage of this class template.
 ``parameters``
 --------------
 
-Provides an interface for assembling the actual arguments to a
-`forwarding function` into an |ArgumentPack|, in which any
-|positional| arguments will be tagged according to the
-corresponding template argument to ``parameters``.  
+Provides an interface for assembling the actual arguments to a `forwarding
+function` into an |ArgumentPack|, in which any |positional| arguments will be
+tagged according to the corresponding template argument to ``parameters``.  If
+no template arguments are passed into ``parameters``, then the interface
+cannot assemble any |positional| arguments, only |tagged reference| arguments.
 
 .. _forwarding function: `forwarding functions`_
 
 :Defined in: `boost/parameter/parameters.hpp`__
 
 __ ../../../../boost/parameter/parameters.hpp
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
 
 .. parsed-literal::
 
@@ -827,6 +687,17 @@ __ ../../../../boost/parameter/parameters.hpp
 
         template <typename ...Args>
         |ArgumentPack|_ `operator()`_\(Args&&... args) const;
+    };
+
+    template <>
+    struct parameters<>
+    {
+        template <typename ...Args>
+        typename boost::`enable_if`_<
+            |are_tagged_arguments|_<Args...>
+          , |ArgumentPack|_
+        >::type
+            `operator()`_\(Args const&... args) const;
     };
 
 :Requires: Each element in the ``PSpec`` parameter pack must be a model of
@@ -857,77 +728,11 @@ __ ../../../../boost/parameter/parameters.hpp
     |     else
     |         ``K`` ## *i* is the |keyword tag type| of ``P`` ## *i*.
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-.. parsed-literal::
-
-    template <
-        typename P0 = *unspecified*
-      , typename P1 = *unspecified*
-      , …
-      , typename P ## β = *unspecified*
-    >
-    struct parameters
-    {
-        template <
-            typename A0
-          , typename A1 = *unspecified*
-          , …
-          , typename A ## β = *unspecified*
-        >
-        struct `match`_
-        {
-            typedef … type;
-        };
-
-        template <typename A0>
-        |ArgumentPack|_ `operator()`_\(A0& a0) const;
-
-        template <typename A0, typename A1>
-        |ArgumentPack|_ `operator()`_\(A0& a0, A1& a1) const;
-
-        :vellipsis:`⋮`
-
-        template <typename A0, typename A1, …, typename A ## β>
-        |ArgumentPack|_
-        `operator()`_\(A0& a0, A1& a1, …, A ## β & a ## β) const;
-    };
-
-:Requires: ``P0``, ``P1``, …, ``P`` ## β must be models of |ParameterSpec|_.
-
-.. Note::
-
-    In this section, ``R`` ## *i* and ``K`` ## *i* are defined as follows: for
-    any argument type ``A`` ## *i*:
-
-    | let ``D0`` the set [ d0, …, d ## *j*] of all **deduced**
-    | *parameter specs* in [ ``P0``, …, ``P`` ## β]
-    | ``R`` ## *i* is the |intended argument type| of ``A`` ## *i*
-    |
-    | if ``A`` ## *i* is a result type of ``keyword<T>::`` |operator=|_
-    | then 
-    |     ``K`` ## *i* is ``T``
-    | else
-    |     if some ``A`` ## *j* where *j* ≤ *i* is a result type of
-    |     ``keyword<T>::`` |operator=|_
-    |     *or* some ``P`` ## *j* in *j* ≤ *i* is **deduced**
-    |     then
-    |         if some *parameter spec* ``d`` ## *j* in ``D`` ## *i*
-    |         matches ``A`` ## *i*
-    |         then
-    |             ``K`` ## *i* is the |keyword tag type| of ``d`` ## *j*.
-    |             ``D``:sub:`i+1` is ``D`` ## *i* - [ ``d`` ## *j*]
-    |     else
-    |         ``K`` ## *i* is the |keyword tag type| of ``P`` ## *i*.
-
 .. _match:
 
 ``match``
     A |Metafunction|_ used to remove a `forwarding function`_ from overload
     resolution.
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
 
 :Returns: if all elements in ``Params...`` are *satisfied* (see below), then
 ``parameters<Params...>``.  Otherwise, ``match<Args...>::type`` is not
@@ -945,48 +750,14 @@ Each element ``P`` in ``Params...`` is **satisfied** if either:
     - ``X`` is some ``K`` ## *i*, **and**
     - ``mpl::apply<F,R`` ## *i* ``>::type::value`` is ``true``
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-:Returns: if ``P0``, ``P1``, …, ``Pβ`` are *satisfied* (see below), then
-``parameters<P0,P1,…,Pβ>``.  Otherwise, ``match<A0,A1,…,Aβ>::type`` is not
-defined.
-
-``P0``, ``P1``, …, ``Pβ`` are **satisfied** if, for every *j* in 0…β,
-either:
-
-* ``P`` ## *j* is the *unspecified* default
-* **or**, ``P`` ## *j* is a *keyword tag type*
-* **or**, ``P`` ## *j* is |optional|_ ``<X,F>`` and either
-    - ``X`` is not ``K`` ## *i* for any *i*,
-    - **or** ``X`` is some ``K`` ## *i*  and ``mpl::apply<F,R`` ## *i*\
-        ``>::type::value`` is ``true``
-* **or**, ``P`` ## *j* is |required|_ ``<X,F>``, and
-    - ``X`` is some ``K`` ## *i*, **and**
-    - ``mpl::apply<F,R`` ## *i* ``>::type::value`` is ``true``
-
 .. _operator():
 
 ``operator()``
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
 
 .. parsed-literal::
 
     template <typename ...Args>
     |ArgumentPack|_ operator()(Args&&... args) const;
-
-**Else**
-
-.. parsed-literal::
-
-    template <typename A0> |ArgumentPack|_ operator()(A0 const& a0) const;
-
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## β>
-    |ArgumentPack|_
-    `operator()`_\(A0 const& a0, …, A ## β const& a ## β) const;
 
 :Returns: An |ArgumentPack|_ containing, for each ``a`` ## *i*,  
 
@@ -1132,13 +903,68 @@ __ ../../../../boost/parameter/value_type.hpp
 
 :Returns: the (possibly const-qualified) type of the |tagged reference| in
 ``A`` having |keyword tag type| ``K``, if any.  If no such |tagged reference|
-exists, returns ``D``. Equivalent to::
+exists, returns ``D``.  Equivalent to::
 
-    typename remove_reference<
-        typename binding<A, K, D>::type
+    typename boost::`remove_reference`_<
+        typename |binding|_<A, K, D>::type
     >::type
 
 … when ``D`` is not a reference type.
+
+.. _remove_reference: ../../../type_traits/doc/html/boost_typetraits/remove_reference.html
+
+``are_tagged_arguments``
+------------------------
+
+:Defined in: `boost/parameter/are_tagged_arguments.hpp`__
+
+__ ../../../../boost/parameter/are_tagged_arguments.hpp
+
+.. parsed-literal::
+
+    template <typename T0, typename ...Pack>
+    struct are_tagged_arguments  // : mpl::true_ or mpl::false_
+    {
+    };
+
+:Returns:
+``mpl::true_`` if ``T0`` and all elements in parameter pack ``Pack`` are
+|tagged reference| types, ``mpl::false_`` otherwise.
+
+:Example usage:
+When implementing a Boost.Parameter-enabled constructor for a container that
+conforms to the C++ standard, one needs to remember that the standard requires
+the presence of other constructors that are typically defined as templates,
+such as range constructors.  To avoid overload ambiguities between the two
+constructors, use this metafunction in conjunction with ``disable_if`` to
+define the range constructor.
+
+.. parsed-literal::
+
+    template <typename B>
+    class frontend : public B
+    {
+        struct _enabler
+        {
+        };
+
+     public:
+        |BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR|_(frontend, (B))
+
+        template <typename Iterator>
+        frontend(
+            Iterator itr
+          , Iterator itr_end
+          , typename boost::`disable_if`_<
+                are_tagged_arguments<Iterator>
+              , _enabler
+            >::type = _enabler()
+        ) : B(itr, itr_end)
+        {
+        }
+    };
+
+.. _disable_if: ../../../core/doc/html/core/enable_if.html
 
 ``is_argument_pack``
 --------------------
@@ -1154,8 +980,58 @@ __ ../../../../boost/parameter/is_argument_pack.hpp
     {
     };
 
-:Returns: ``mpl::true_`` if ``T`` is a model of |ArgumentPack|_,
-``mpl::false_`` otherwise.
+:Returns:
+``mpl::true_`` if ``T`` is a model of |ArgumentPack|_, ``mpl::false_``
+otherwise.
+
+:Example usage:
+To avoid overload ambiguities between a constructor that takes in an
+|ArgumentPack|_ and a templated conversion constructor, use this metafunction
+in conjunction with ``enable_if``.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(a0)
+
+    template <typename T>
+    class backend0
+    {
+        struct _enabler
+        {
+        };
+
+        T a0;
+
+     public:
+        template <typename ArgPack>
+        explicit backend0(
+            ArgPack const& args
+          , typename boost::`enable_if`_<
+                is_argument_pack<ArgPack>
+              , _enabler
+            >::type = _enabler()
+        ) : a0(args[_a0])
+        {
+        }
+
+        template <typename U>
+        backend0(
+            backend0<U> const& copy
+          , typename boost::`enable_if`_<
+                boost::`is_convertible`_<U,T>
+              , _enabler
+            >::type = _enabler()
+        ) : a0(copy.get_a0())
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->a0;
+        }
+    };
+
+.. _is_convertible: ../../../type_traits/doc/html/boost_typetraits/is_convertible.html
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -1172,11 +1048,206 @@ using the Parameter library by eliminating repetitive boilerplate.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-:Requires: ``result`` is the parenthesized return type of the
-function.  ``name`` is the base name of the function; it determines the name
-of the generated forwarding functions.  ``tag_namespace`` is the namespace in
-which the keywords used by the function resides.  ``arguments`` is a
-`Boost.Preprocessor`_ `sequence`_ of *argument-specifiers*, as defined below.
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal function header.  Enclose the
+return type ``bool`` in parentheses.  For each parameter, also enclose the
+expected value type in parentheses.  Since the value types are mutually
+exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of ``args`` to extract the corresponding argument.  Note that the
+second method doesn't require ``std::forward`` to preserve value categories.
+
+.. parsed-literal::
+
+    BOOST_PARAMETER_FUNCTION((bool), evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset<1>))
+                (lr, (std::bitset<2>))
+            )
+            (optional
+                (rrc, (std::bitset<3>), rvalue_const_bitset<2>())
+                (rr, (std::bitset<4>), rvalue_bitset<3>())
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category<0>(lrc)
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category<1>(lr)
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category<2>(std::`forward`_<rrc0_type>(rrc0))
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category<3>(args[_rr0])
+        );
+
+        return true;
+    }
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
+
+The |preprocessor|_, |preprocessor_deduced|_, and |preprocessor_eval_cat|_
+test programs demonstrate proper usage of this macro.
+
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
+.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
+.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
+.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
 
 :Argument specifiers syntax:
 .. parsed-literal::
@@ -1214,17 +1285,17 @@ which the keywords used by the function resides.  ``arguments`` is a
         ( '**(**' *type-name* '**)**' ) |
         '**\***'
 
-* ``argument-name`` is any valid C++ identifier.
-* ``default-value`` is any valid C++ expression; if necessary, user code can
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
 compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
 the ``argument-name`` in a previous ``specifier-group0`` or
 ``specifier-group1``.  *This expression will be invoked exactly once.*
-* ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will be
-the type of the corresponding ``argument-name``, whose second argument will be
-the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
 Constant`_; however, user code *cannot* compute ``mfc`` in terms of
 ``previous-name ## _type``.
-* ``type-name`` is either the name of a **target type** or an `MPL Binary
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
 Metafunction Class`_ whose first argument will be the type of the
 corresponding ``argument-name``, whose second argument will be the entire
 |ArgumentPack|_, and whose return type is the **target type**.  If
@@ -1238,21 +1309,11 @@ in ``args``) will be cast to that type.
 .. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
 .. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
 
-:Generated names in enclosing scope:
-* ``boost_param_result_ ## __LINE__ ## name``
-* ``boost_param_params_ ## __LINE__ ## name``
-* ``boost_param_parameters_ ## __LINE__ ## name``
-* ``boost_param_impl ## name``
-* ``boost_param_dispatch_0boost_ ## __LINE__ ## name``
-* ``boost_param_dispatch_1boost_ ## __LINE__ ## name``
-
 Approximate expansion:
 **Where**:
 
 * ``n`` denotes the *minimum* arity, as determined from ``arguments``.
 * ``m`` denotes the *maximum* arity, as determined from ``arguments``.
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
 
 .. parsed-literal::
 
@@ -1263,28 +1324,28 @@ Approximate expansion:
     };
 
     struct boost_param_params\_ ## __LINE__ ## **name**
-      : boost::parameter::parameters<
+      : |parameters|_<
             *list of parameter specifications, based on arguments*
         >
     {
     };
 
-    typedef boost_param_params\_ ## __LINE__ ## **name** 
+    typedef boost_param_params\_ ## __LINE__ ## **name**
         boost_param_parameters\_ ## __LINE__ ## **name**;
 
     template <typename Args>
     typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
-        boost_param_impl ## **name**\ (Args const&);
+        boost_param_impl ## __LINE__ ## **name**\ (Args const&);
 
     template <typename A0, …, typename A ## **n**>
     **result** **name**\ (
         A0&& a0, …, A ## **n**\ && a ## **n**
-      , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-            A0, …, A ## **n**
-        >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
     )
     {
-        return boost_param_impl ## **name**\ (
+        return boost_param_impl ## __LINE__ ## **name**\ (
             boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
                 std::`forward`_<A0>(a0)
               , …
@@ -1298,12 +1359,12 @@ Approximate expansion:
     template <typename A0, …, typename A ## **m**>
     **result** **name**\ (
         A0&& a0, …, A ## **m**\ && a ## **m**
-      , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-            A0, …, A ## **m**
-        >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
     )
     {
-        return boost_param_impl ## **name**\ (
+        return boost_param_impl ## __LINE__ ## **name**\ (
             boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
                 std::`forward`_<A0>(a0)
               , …
@@ -1348,10 +1409,14 @@ Approximate expansion:
 
     template <typename Args>
     typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
-        boost_param_impl ## **name**\ (Args const& args)
+        boost_param_impl ## __LINE__ ## **name**\ (Args const& args)
     {
         return boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
-            static_cast<ResultType(\ *)()>(std::nullptr)
+            static_cast<
+                typename boost_param_result\_ ## __LINE__ ## **name**\ <
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
           , args
           , std::`forward`_<
                 typename boost::parameter::value_type<
@@ -1424,8 +1489,284 @@ Approximate expansion:
           , *argument name* ## **m** ## _type&& *argument name* ## **m**
         )
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+
+``BOOST_PARAMETER_MEMBER_FUNCTION(result, name, tag_namespace, arguments)``
+---------------------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``static`` member function
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of ``args`` to extract the corresponding argument.  Note that the
+second method doesn't require ``std::forward`` to preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        BOOST_PARAMETER_MEMBER_FUNCTION((bool), static evaluate, kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>), rvalue_const_bitset<2>())
+                    (rr, (std::bitset<4>), rvalue_bitset<3>())
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(lrc)
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(lr)
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(std::`forward`_<rrc0_type>(rrc0))
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(args[_rr0])
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B::evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    B::evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    B::evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    B::evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    B::evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    B::evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    B::evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
+
+The |preprocessor|_ and |preprocessor_eval_cat|_ test programs demonstrate
+proper usage of this macro.
+
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
+.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.  ``name`` may be qualified by the ``static``
+keyword to declare the member function and its helpers as not associated with
+any object of the enclosing type.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *optional-specifier* {*optional-specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *required-specifier* {*required-specifier*\ }
+            '**)**'
+        )
+
+    optional-specifier ::=
+        '**(**'
+            *argument-name* '**,**' *restriction* '**,**' *default-value*
+        ')'
+
+    required-specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
+compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
+the ``argument-name`` in a previous ``specifier-group0`` or
+``specifier-group1``.  *This expression will be invoked exactly once.*
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.  If
+``restriction`` uses this form, then the type of the generated name
+``argument-name ## _type`` will be computed in terms of the **target type**,
+and the generated reference ``argument-name`` (but not its corresponding entry
+in ``args``) will be cast to that type.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
 
 .. parsed-literal::
 
@@ -1436,50 +1777,28 @@ Approximate expansion:
     };
 
     struct boost_param_params\_ ## __LINE__ ## **name**
-      : boost::parameter::parameters<
+      : |parameters|_<
             *list of parameter specifications, based on arguments*
         >
     {
     };
 
-    typedef boost_param_params\_ ## __LINE__ ## **name** 
+    typedef boost_param_params\_ ## __LINE__ ## **name**
         boost_param_parameters\_ ## __LINE__ ## **name**;
 
-    template <typename Args>
-    typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
-        boost_param_impl ## **name**\ (Args const&);
-
     template <typename A0, …, typename A ## **n**>
-    **result**
-        **name**\ (
-            A0 const& a0, …, A ## **n** const& a ## **n**
-          , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-                A0 const, …, A ## **n** const
-            >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
-        )
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
     {
-        return boost_param_impl ## **name**\ (
+        return this->boost_param_impl ## __LINE__ ## **name**\ (
             boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
-                a0, …, a ## **n**
-            )
-        );
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **n**>
-    **result**
-        **name**\ (
-            A0& a0, …, A ## **n** & a ## **n**
-          , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-                A0, …, A ## **n**
-            >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
-        )
-    {
-        return boost_param_impl ## **name**\ (
-            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
-                a0, …, a ## **n**
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
             )
         );
     }
@@ -1487,84 +1806,46 @@ Approximate expansion:
     :vellipsis:`⋮`
 
     template <typename A0, …, typename A ## **m**>
-    **result**
-        **name**\ (
-            A0 const& a0, …, A ## **m** const& a ## **m**
-          , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-                A0 const, …, A ## **m** const
-            >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
-        )
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
     {
-        return boost_param_impl ## **name**\ (
+        return this->boost_param_impl ## __LINE__ ## **name**\ (
             boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
-                a0, …, a ## **m**
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
             )
         );
     }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **m**>
-    **result**
-        **name**\ (
-            A0& a0, …, A ## **m** & a ## **m**
-          , typename boost_param_parameters\_ ## __LINE__ ## **name**::match<
-                A0, …, A ## **m**
-            >::type = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
-        )
-    {
-        return boost_param_impl ## **name**\ (
-            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
-                a0, …, a ## **m**
-            )
-        );
-    }
-
-    template <
-        typename ResultType
-      , typename Args
-      , typename *argument name* ## **0** ## _type
-      , …
-      , typename *argument name* ## **n** ## _type
-    >
-    ResultType
-        boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
-            (ResultType(\ *)())
-          , Args const& args
-          , *argument name* ## **0** ## _type& *argument name* ## **0**
-          , …
-          , *argument name* ## **n** ## _type& *argument name* ## **m**
-        );
-
-    :vellipsis:`⋮`
-
-    template <
-        typename ResultType
-      , typename Args
-      , typename *argument name* ## **0** ## _type
-      , …
-      , typename *argument name* ## **m** ## _type
-    >
-    ResultType
-        boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
-            (ResultType(\ *)())
-          , Args const& args
-          , *argument name* ## **0** ## _type& *argument name* ## **0**
-          , …
-          , *argument name* ## **m** ## _type& *argument name* ## **m**
-        );
 
     template <typename Args>
     typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
-        boost_param_impl ## **name**\ (Args const& args)
+        boost_param_impl ## __LINE__ ## **name**\ (Args const& args)
     {
-        return boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
-            static_cast<ResultType(\ *)()>(std::nullptr)
+        return this->boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
+            static_cast<
+                typename boost_param_result\_ ## __LINE__ ## **name**\ <
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
           , args
-          , args[ *keyword object of required parameter* ## **0**]
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **0**
+                >::type
+            >(args[ *keyword object of required parameter* ## **0**])
           , …
-          , args[ *keyword object of required parameter* ## **n**]
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **n**
+                >::type
+            >(args[ *keyword object of required parameter* ## **n**])
         );
     }
 
@@ -1579,20 +1860,29 @@ Approximate expansion:
         boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
             (ResultType(\ *)())
           , Args const& args
-          , *argument name* ## **0** ## _type& *argument name* ## **0**
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
           , …
-          , *argument name* ## **n** ## _type& *argument name* ## **m**
+          , *argument name* ## **n** ## _type&& *argument name* ## **n**
         )
     {
-        return boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
+        return this->boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
             static_cast<ResultType(\ *)()>(std::nullptr)
           , (args, *keyword object of optional parameter* ## **n + 1** =
                 *default value of optional parameter* ## **n + 1**
             )
-          , *argument name* ## **0**
+          , std::`forward`_<*argument name* ## **0** ## _type>(
+                *argument name* ## **0**
+            )
           , …
-          , *argument name* ## **n**
-          , *default value of optional parameter* ## **n + 1**
+          , std::`forward`_<*argument name* ## **n** ## _type>(
+                *argument name* ## **n**
+            )
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of optional parameter* ## **n + 1**
+                >::type
+            >(*default value of optional parameter* ## **n + 1**)
         );
     }
 
@@ -1609,45 +1899,12 @@ Approximate expansion:
         boost_param_dispatch_0boost\_ ## __LINE__ ## **name**\ (
             (ResultType(\ *)())
           , Args const& args
-          , *argument name* ## **0** ## _type& *argument name* ## **0**
-            :vellipsis:`⋮`
-          , *argument name* ## **m** ## _type& *argument name* ## **m**
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **m** ## _type&& *argument name* ## **m**
         )
 
-The |preprocessor|_, |preprocessor_deduced|_, and |preprocessor_eval_cat|_
-test programs demonstrate proper usage of this macro.
-
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
-.. |preprocessor| replace:: preprocessor.cpp
-.. _preprocessor: ../../test/preprocessor.cpp
-.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
-.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
-.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
-.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
-
-``BOOST_PARAMETER_MEMBER_FUNCTION(result, name, tag_namespace, arguments)``
----------------------------------------------------------------------------
-
-:Defined in: `boost/parameter/preprocessor.hpp`__
-
-__ ../../../../boost/parameter/preprocessor.hpp
-
-Same as ``BOOST_PARAMETER_FUNCTION``, except:
-
-\*. ``name`` may be qualified by the ``static`` keyword to declare the member
-function and its helpers as not associated with any object of the enclosing
-type.
-
-\*. Expansion of this macro omits all forward declarations of the front-end
-implementation and dispatch functions.
-
-The |preprocessor|_ and |preprocessor_eval_cat|_ test programs demonstrate
-proper usage of this macro.
-
-.. |preprocessor| replace:: preprocessor.cpp
-.. _preprocessor: ../../test/preprocessor.cpp
-.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
-.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
 
 ``BOOST_PARAMETER_CONST_MEMBER_FUNCTION(result, name, tag_ns, arguments)``
 --------------------------------------------------------------------------
@@ -1656,14 +1913,415 @@ proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_MEMBER_FUNCTION``, except that the overloaded
-forwarding member functions and their helper methods are
-``const``-qualified.
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``const`` member function
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of ``args`` to extract the corresponding argument.  Note that the
+second method doesn't require ``std::forward`` to preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        B()
+        {
+        }
+
+        BOOST_PARAMETER_CONST_MEMBER_FUNCTION((bool), evaluate, kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>), rvalue_const_bitset<2>())
+                    (rr, (std::bitset<4>), rvalue_bitset<3>())
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(lrc)
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(lr)
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(std::`forward`_<rrc0_type>(rrc0))
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(args[_rr0])
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B const b = B();
+    b.evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    b.evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    b.evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    b.evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    b.evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    b.evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    b.evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
 
 The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *optional-specifier* {*optional-specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *required-specifier* {*required-specifier*\ }
+            '**)**'
+        )
+
+    optional-specifier ::=
+        '**(**'
+            *argument-name* '**,**' *restriction* '**,**' *default-value*
+        ')'
+
+    required-specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
+compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
+the ``argument-name`` in a previous ``specifier-group0`` or
+``specifier-group1``.  *This expression will be invoked exactly once.*
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.  If
+``restriction`` uses this form, then the type of the generated name
+``argument-name ## _type`` will be computed in terms of the **target type**,
+and the generated reference ``argument-name`` (but not its corresponding entry
+in ``args``) will be cast to that type.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result_const\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params_const\_ ## __LINE__ ## **name**
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params_const\_ ## __LINE__ ## **name**
+        boost_param_parameters_const\_ ## __LINE__ ## **name**;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## **name**\ (
+            boost_param_parameters_const\_ ## __LINE__ ## **name**\ (
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## **name**\ (
+            boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result_const\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl_const ## __LINE__ ## **name**\ (Args const& args) const
+    {
+        return this->
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## **name**\ (
+            static_cast<
+                typename boost_param_result_const\_ ## __LINE__ ## **name**\ <
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
+          , args
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **0**
+                >::type
+            >(args[ *keyword object of required parameter* ## **0**])
+          , …
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **n**
+                >::type
+            >(args[ *keyword object of required parameter* ## **n**])
+        );
+    }
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **n** ## _type
+    >
+    ResultType
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **n** ## _type&& *argument name* ## **n**
+        ) const
+    {
+        return this->
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## **name**\ (
+            static_cast<ResultType(\ *)()>(std::nullptr)
+          , (args, *keyword object of optional parameter* ## **n + 1** =
+                *default value of optional parameter* ## **n + 1**
+            )
+          , std::`forward`_<*argument name* ## **0** ## _type>(
+                *argument name* ## **0**
+            )
+          , …
+          , std::`forward`_<*argument name* ## **n** ## _type>(
+                *argument name* ## **n**
+            )
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of optional parameter* ## **n + 1**
+                >::type
+            >(*default value of optional parameter* ## **n + 1**)
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **m** ## _type
+    >
+    ResultType
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **m** ## _type&& *argument name* ## **m**
+        ) const
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_FUNCTION_CALL_OPERATOR(result, tag_namespace, arguments)``
 ----------------------------------------------------------------------------
@@ -1672,21 +2330,309 @@ The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_MEMBER_FUNCTION``, except that the name of the
-forwarding member function overloads is ``operator()``.
+:Example usage:
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``tag`` by default.
 
-:Generated names in enclosing scope:
-* ``boost_param_result_ ## __LINE__ ## operator``
-* ``boost_param_params_ ## __LINE__ ## operator``
-* ``boost_param_parameters_ ## __LINE__ ## operator``
-* ``boost_param_impl ## operator``
-* ``boost_param_dispatch_0boost_ ## __LINE__ ## operator``
-* ``boost_param_dispatch_1boost_ ## __LINE__ ## operator``
+.. parsed-literal::
 
-The |preprocessor|_ test program demonstrates proper usage of this macro.
+    |BOOST_PARAMETER_NAME|_(y)
+    |BOOST_PARAMETER_NAME|_(z)
 
+Use the macro as a substitute for a normal function call operator
+header.  Enclose the return type in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  This is especially useful when implementing multiple
+Boost.Parameter-enabled function call operator overloads.
+
+.. parsed-literal::
+
+    class char_reader
+    {
+        int index;
+        char const* key;
+
+     public:
+        explicit char_reader(char const* k) : index(0), key(k)
+        {
+        }
+
+        BOOST_PARAMETER_FUNCTION_CALL_OPERATOR((void), tag,
+            (deduced
+                (required
+                    (y, (int))
+                    (z, (char const*))
+                )
+            )
+        )
+        {
+            this->index = y;
+            this->key = z;
+        }
+
+        |BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR|_((char), tag,
+            (deduced
+                (required
+                    (y, (bool))
+                    (z, (std::`map`_<char const*,std::`string`_>))
+                )
+            )
+        )
+        {
+            return y ? (
+                (z.find(this->key)->second)[this->index]
+            ) : this->key[this->index];
+        }
+    };
+
+As with regular argument-dependent lookup, the value types of the arguments
+passed in determine which function call operator overload gets invoked.
+
+.. parsed-literal::
+
+    char const* keys[] = {"foo", "bar", "baz"};
+    std::`map`_<char const*,std::`string`_> k2s;
+    k2s[keys[0]] = std::`string`_("qux");
+    k2s[keys[1]] = std::`string`_("wmb");
+    k2s[keys[2]] = std::`string`_("zxc");
+    char_reader r(keys[0]);
+
+    // positional arguments
+    BOOST_TEST_EQ('q', (r(true, k2s)));
+    BOOST_TEST_EQ('f', (r(false, k2s)));
+
+    // named arguments
+    r(_z = keys[1], _y = 1);
+    BOOST_TEST_EQ('m', (r(_z = k2s, _y = true)));
+    BOOST_TEST_EQ('a', (r(_z = k2s, _y = false)));
+
+    // deduced arguments
+    r(keys[2], 2);
+    BOOST_TEST_EQ('c', (r(k2s, true)));
+    BOOST_TEST_EQ('z', (r(k2s, false)));
+
+The |preprocessor|_ and |preprocessor_deduced|_ test programs demonstrate
+proper usage of this macro.
+
+.. _`map`: http\://en.cppreference.com/w/cpp/container/map
+.. _`string`: http\://en.cppreference.com/w/cpp/string/basic_string
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
+.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function call operator resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *optional-specifier* {*optional-specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *required-specifier* {*required-specifier*\ }
+            '**)**'
+        )
+
+    optional-specifier ::=
+        '**(**'
+            *argument-name* '**,**' *restriction* '**,**' *default-value*
+        ')'
+
+    required-specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
+compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
+the ``argument-name`` in a previous ``specifier-group0`` or
+``specifier-group1``.  *This expression will be invoked exactly once.*
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.  If
+``restriction`` uses this form, then the type of the generated name
+``argument-name ## _type`` will be computed in terms of the **target type**,
+and the generated reference ``argument-name`` (but not its corresponding entry
+in ``args``) will be cast to that type.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params\_ ## __LINE__ ## operator
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params\_ ## __LINE__ ## operator
+        boost_param_parameters\_ ## __LINE__ ## operator;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** operator()(
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## operator::match<
+            A0, …, A ## **n**
+        >::type = boost_param_parameters\_ ## __LINE__ ## operator()
+    )
+    {
+        return this->boost_param_impl ## __LINE__ ## operator(
+            boost_param_parameters\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** operator()(
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## operator::match<
+            A0, …, A ## **m**
+        >::type = boost_param_parameters\_ ## __LINE__ ## operator()
+    )
+    {
+        return this->boost_param_impl ## __LINE__ ## operator(
+            boost_param_parameters\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## operator<Args>::type
+        boost_param_impl ## __LINE__ ## operator(Args const& args)
+    {
+        return this->boost_param_dispatch_0boost\_ ## __LINE__ ## operator(
+            static_cast<
+                typename boost_param_result\_ ## __LINE__ ## operator<
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
+          , args
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **0**
+                >::type
+            >(args[ *keyword object of required parameter* ## **0**])
+          , …
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **n**
+                >::type
+            >(args[ *keyword object of required parameter* ## **n**])
+        );
+    }
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **n** ## _type
+    >
+    ResultType
+        boost_param_dispatch_0boost\_ ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **n** ## _type&& *argument name* ## **n**
+        )
+    {
+        return this->boost_param_dispatch_0boost\_ ## __LINE__ ## operator(
+            static_cast<ResultType(\ *)()>(std::nullptr)
+          , (args, *keyword object of optional parameter* ## **n + 1** =
+                *default value of optional parameter* ## **n + 1**
+            )
+          , std::`forward`_<*argument name* ## **0** ## _type>(
+                *argument name* ## **0**
+            )
+          , …
+          , std::`forward`_<*argument name* ## **n** ## _type>(
+                *argument name* ## **n**
+            )
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of optional parameter* ## **n + 1**
+                >::type
+            >(*default value of optional parameter* ## **n + 1**)
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **m** ## _type
+    >
+    ResultType
+        boost_param_dispatch_0boost\_ ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **m** ## _type&& *argument name* ## **m**
+        )
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR(result, tag_ns, arguments)``
 ---------------------------------------------------------------------------
@@ -1695,16 +2641,419 @@ The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_FUNCTION_CALL_OPERATOR``, except that the overloaded
-function call operators and their helper methods are ``const``-qualified.
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
 
-The |preprocessor|_ and |preprocessor_eval_cat_8|_ test programs demonstrate
-proper usage of this macro.
+.. parsed-literal::
 
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``const`` function call operator
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  Also, just as with a normal
+function, optional parameters have default values, whereas required parameters
+do not.  Within the function body, either simply use the parameter name or
+pass the matching identifier with the leading underscore to the bracket
+operator of ``args`` to extract the corresponding argument.  Note that the
+second method doesn't require ``std::forward`` to preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        B()
+        {
+        }
+
+        BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR((bool), kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>), rvalue_const_bitset<2>())
+                    (rr, (std::bitset<4>), rvalue_bitset<3>())
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(lrc)
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(lr)
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(std::`forward`_<rrc0_type>(rrc0))
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(args[_rr0])
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B const b = B();
+    b(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    b(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    b((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    b(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    b(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    b(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    b(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
+
+The |preprocessor|_, |preprocessor_deduced|_, and |preprocessor_eval_cat_8|_
+test programs demonstrate proper usage of this macro.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
+.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
 .. |preprocessor_eval_cat_8| replace:: preprocessor_eval_cat_8.cpp
 .. _preprocessor_eval_cat_8: ../../test/preprocessor_eval_cat_8.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function call operator resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *optional-specifier* {*optional-specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *required-specifier* {*required-specifier*\ }
+            '**)**'
+        )
+
+    optional-specifier ::=
+        '**(**'
+            *argument-name* '**,**' *restriction* '**,**' *default-value*
+        ')'
+
+    required-specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``default-value`` is any valid C++ expression; if necessary, user code can
+compute it in terms of ``previous-name ## _type``, where ``previous-name`` is
+the ``argument-name`` in a previous ``specifier-group0`` or
+``specifier-group1``.  *This expression will be invoked exactly once.*
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.  If
+``restriction`` uses this form, then the type of the generated name
+``argument-name ## _type`` will be computed in terms of the **target type**,
+and the generated reference ``argument-name`` (but not its corresponding entry
+in ``args``) will be cast to that type.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result_const\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params_const\_ ## __LINE__ ## operator
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params_const\_ ## __LINE__ ## operator
+        boost_param_parameters_const\_ ## __LINE__ ## operator;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** operator()(
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## operator
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## operator()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## operator(
+            boost_param_parameters_const\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** operator()(
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## operator
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## operator()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## operator(
+            boost_param_parameters_const\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result_const\_ ## __LINE__ ## operator<Args>::type
+        boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+    {
+        return this->
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## operator(
+            static_cast<
+                typename boost_param_result_const\_ ## __LINE__ ## operator<
+                    Args
+                >::type(\ *)()
+            >(std::nullptr)
+          , args
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **0**
+                >::type
+            >(args[ *keyword object of required parameter* ## **0**])
+          , …
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of required parameter* ## **n**
+                >::type
+            >(args[ *keyword object of required parameter* ## **n**])
+        );
+    }
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **n** ## _type
+    >
+    ResultType
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **n** ## _type&& *argument name* ## **n**
+        ) const
+    {
+        return this->
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## operator(
+            static_cast<ResultType(\ *)()>(std::nullptr)
+          , (args, *keyword object of optional parameter* ## **n + 1** =
+                *default value of optional parameter* ## **n + 1**
+            )
+          , std::`forward`_<*argument name* ## **0** ## _type>(
+                *argument name* ## **0**
+            )
+          , …
+          , std::`forward`_<*argument name* ## **n** ## _type>(
+                *argument name* ## **n**
+            )
+          , std::`forward`_<
+                typename boost::parameter::value_type<
+                    Args
+                  , *keyword tag type of optional parameter* ## **n + 1**
+                >::type
+            >(*default value of optional parameter* ## **n + 1**)
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <
+        typename ResultType
+      , typename Args
+      , typename *argument name* ## **0** ## _type
+      , …
+      , typename *argument name* ## **m** ## _type
+    >
+    ResultType
+        boost_param_dispatch_const_0boost\_ ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+          , *argument name* ## **0** ## _type&& *argument name* ## **0**
+          , …
+          , *argument name* ## **m** ## _type&& *argument name* ## **m**
+        ) const
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_CONSTRUCTOR(cls, impl, tag_namespace, arguments)``
 --------------------------------------------------------------------
@@ -1713,17 +3062,163 @@ proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-:Requires: ``cls`` is the name of the enclosing class.  ``impl`` is the
-parenthesized implementation base class for ``cls``.  ``tag_namespace`` is the
-namespace in which the keywords used by the function resides.  ``arguments``
-is a list of *argument-specifiers*, as defined in ``BOOST_PARAMETER_FUNCTION``
-except that *optional-specifier* no longer includes *default-value*.  It is up
-to the delegate constructor in ``impl`` to determine the default value of all
+:Example usage:
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``tag`` by default.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(y)
+    |BOOST_PARAMETER_NAME|_(z)
+
+In the base class, implement a delegate constructor template that takes in an
+|ArgumentPack|_.  You must pass the identifiers with leading underscores to
+``args`` in order to extract the corresponding arguments.
+
+.. parsed-literal::
+
+    class char_read_base
+    {
+        int index;
+        char const* key;
+
+     public:
+        template <typename Args>
+        explicit char_read_base(Args const& args)
+          : index(args[_y]), key(args[_z])
+        {
+        }
+
+        |BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR|_((char), tag,
+            (deduced
+                (required
+                    (y, (bool))
+                    (z, (std::`map`_<char const*,std::`string`_>))
+                )
+            )
+        )
+        {
+            return y ? (
+                (z.find(this->key)->second)[this->index]
+            ) : this->key[this->index];
+        }
+    };
+
+Use the macro as a substitute for a normal constructor definition.  Note the
+lack of an explicit body.  Enclose the base type in parentheses.  For each
+parameter, also enclose the expected value type in parentheses.  Since the
+value types are mutually exclusive, you can wrap the parameters in a
+``(deduced …)`` clause.
+
+.. parsed-literal::
+
+    struct char_reader : public char_read_base
+    {
+        BOOST_PARAMETER_CONSTRUCTOR(char_reader, (char_read_base), tag,
+            (deduced
+                (required
+                    (y, (int))
+                    (z, (char const*))
+                )
+            )
+        )
+    };
+
+The following ``char_reader`` constructor calls are legal.
+
+.. parsed-literal::
+
+    char const* keys[] = {"foo", "bar", "baz"};
+    std::`map`_<char const*,std::`string`_> k2s;
+    k2s[keys[0]] = std::`string`_("qux");
+    k2s[keys[1]] = std::`string`_("wmb");
+    k2s[keys[2]] = std::`string`_("zxc");
+
+    // positional arguments
+    char_reader r0(0, keys[0]);
+    BOOST_TEST_EQ('q', (r0(true, k2s)));
+    BOOST_TEST_EQ('f', (r0(false, k2s)));
+
+    // named arguments
+    char_reader r1(_z = keys[1], _y = 1);
+    BOOST_TEST_EQ('m', (r1(_z = k2s, _y = true)));
+    BOOST_TEST_EQ('a', (r1(_z = k2s, _y = false)));
+
+    // deduced arguments
+    char_reader r2(keys[2], 2);
+    BOOST_TEST_EQ('c', (r2(k2s, true)));
+    BOOST_TEST_EQ('z', (r2(k2s, false)));
+
+The |preprocessor|_ and |preprocessor_deduced|_ test programs demonstrate
+proper usage of this macro.
+
+.. _`map`: http\://en.cppreference.com/w/cpp/container/map
+.. _`string`: http\://en.cppreference.com/w/cpp/string/basic_string
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+.. |preprocessor_deduced| replace:: preprocessor_deduced.cpp
+.. _preprocessor_deduced: ../../test/preprocessor_deduced.cpp
+.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
+.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
+
+:Macro parameters:
+\*. ``cls`` is the name of the enclosing class.
+\*. ``impl`` is the parenthesized implementation base class for ``cls``.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+constructor resides.
+\*. ``arguments`` is a list of *argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+delegate constructor in ``impl`` to determine the default value of all
 optional arguments.
 
-:Generated names in enclosing scope:
-* ``boost_param_params_ ## __LINE__ ## ctor``
-* ``constructor_parameters ## __LINE__``
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
 
 Approximate expansion:
 **Where**:
@@ -1731,23 +3226,21 @@ Approximate expansion:
 * ``n`` denotes the *minimum* arity, as determined from ``arguments``.
 * ``m`` denotes the *maximum* arity, as determined from ``arguments``.
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-
 .. parsed-literal::
 
     struct boost_param_params\_ ## __LINE__ ## ctor
-      : boost::parameter::parameters<
+      : |parameters|_<
             *list of parameter specifications, based on arguments*
         >
     {
     };
 
-    typedef boost_param_params\_ ## __LINE__ ## **name**
+    typedef boost_param_params\_ ## __LINE__ ## ctor
         constructor_parameters ## __LINE__;
 
     template <typename A0, …, typename A ## **n**>
-    *cls*\ (A0&& a0, …, A ## **n** && a ## **n**)
-      : *impl*\ (
+    **cls**\ (A0&& a0, …, A ## **n** && a ## **n**)
+      : **impl**\ (
             constructor_parameters ## __LINE__(
                 std::`forward`_<A0>(a0)
               , …
@@ -1760,8 +3253,8 @@ Approximate expansion:
     :vellipsis:`⋮`
 
     template <typename A0, …, typename A ## **m**>
-    *cls*\ (A0&& a0, …, A ## **m** && a ## **m**)
-      : *impl*\ (
+    **cls**\ (A0&& a0, …, A ## **m** && a ## **m**)
+      : **impl**\ (
             constructor_parameters ## __LINE__(
                 std::`forward`_<A0>(a0)
               , …
@@ -1771,61 +3264,7 @@ Approximate expansion:
     {
     }
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-.. parsed-literal::
-
-    struct boost_param_params\_ ## __LINE__ ## ctor
-      : boost::parameter::parameters<
-            *list of parameter specifications, based on arguments*
-        >
-    {
-    };
-
-    typedef boost_param_params\_ ## __LINE__ ## **name**
-        constructor_parameters ## __LINE__;
-
-    template <typename A0, …, typename A ## **n**>
-    *cls*\ (A0 const& a0, …, A ## **n** const& a ## **n**)
-      : *impl*\ (constructor_parameters ## __LINE__(a0, …, a ## **n**))
-    {
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **n**>
-    *cls*\ (A0& a0, …, A ## **n** & a ## **n**)
-      : *impl*\ (constructor_parameters ## __LINE__(a0, …, a ## **n**))
-    {
-    }
-
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **m**>
-    *cls*\ (A0 const& a0, …, A ## **m** const& a ## **m**)
-      : *impl*\ (constructor_parameters ## __LINE__(a0, …, a ## **m**))
-    {
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A0, …, typename A ## **m**>
-    *cls*\ (A0& a0, …, A ## **m** & a ## **m**)
-      : *impl*\ (constructor_parameters ## __LINE__(a0, …, a ## **m**))
-    {
-    }
-
-The |preprocessor|_ and |preprocessor_eval_cat|_ test programs demonstrate
-proper usage of this macro.
-
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
-.. |preprocessor| replace:: preprocessor.cpp
-.. _preprocessor: ../../test/preprocessor.cpp
-.. |preprocessor_eval_cat| replace:: preprocessor_eval_category.cpp
-.. _preprocessor_eval_cat: ../../test/preprocessor_eval_category.cpp
 
 ``BOOST_PARAMETER_BASIC_FUNCTION(result, name, tag_namespace, arguments)``
 --------------------------------------------------------------------------
@@ -1834,27 +3273,326 @@ proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_FUNCTION``, except:
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
 
-\*. For the argument specifiers syntax, *optional-specifier* no longer
-includes *default-value*.  It is up to the function body to determine the
-default value of all optional arguments.
+.. parsed-literal::
 
-\*. Generated names in the enclosing scope no longer include
-``boost_param_dispatch_0boost_ ## __LINE__ ## name`` or
-``boost_param_dispatch_1boost_ ## __LINE__ ## name``.
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
 
-\*. Expansion of this macro omits all overloads of
-``boost_param_dispatch_0boost_ ## __LINE__ ## name`` and
-``boost_param_dispatch_1boost_ ## __LINE__ ## name`` and stops at the header
-of ``boost_param_impl ## name``.  Therefore, only the |ArgumentPack|_ type
-``Args`` and its object instance ``args`` are available for use within the
-function body.
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal function header.  Enclose the
+return type ``bool`` in parentheses.  For each parameter, also enclose the
+expected value type in parentheses.  Since the value types are mutually
+exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of ``args`` to extract the
+corresponding argument, but at least this doesn't require ``std::forward`` to
+preserve value categories.
+
+.. parsed-literal::
+
+    BOOST_PARAMETER_BASIC_FUNCTION((bool), evaluate, kw,
+        (deduced
+            (required
+                (lrc, (std::bitset<1>))
+                (lr, (std::bitset<2>))
+            )
+            (optional
+                (rrc, (std::bitset<3>))
+                (rr, (std::bitset<4>))
+            )
+        )
+    )
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category<0>(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category<1>(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category<2>(
+                args[_rrc0 | rvalue_const_bitset<2>()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category<3>(args[_rr0 | rvalue_bitset<3>()])
+        );
+
+        return true;
+    }
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
 
 The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params\_ ## __LINE__ ## **name**
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params\_ ## __LINE__ ## **name**
+        boost_param_parameters\_ ## __LINE__ ## **name**;
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl ## **name**\ (Args const&);
+
+    template <typename A0, …, typename A ## **n**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
+    {
+        return boost_param_impl ## __LINE__ ## **name**\ (
+            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
+    {
+        return boost_param_impl ## __LINE__ ## **name**\ (
+            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl ## __LINE__ ## **name**\ (Args const& args)
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_BASIC_MEMBER_FUNCTION(result, name, tag_ns, arguments)``
 --------------------------------------------------------------------------
@@ -1863,19 +3601,330 @@ The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_BASIC_FUNCTION``, except that:
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
 
-\*. ``name`` may be qualified by the ``static`` keyword to declare the member
-function and its helpers as not associated with any object of the enclosing
-type.
+.. parsed-literal::
 
-\*. Expansion of this macro omits the forward declaration of the
-implementation function.
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``static`` member function
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of ``args`` to extract the
+corresponding argument, but at least this doesn't require ``std::forward`` to
+preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        BOOST_PARAMETER_BASIC_MEMBER_FUNCTION((bool), static evaluate, kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>))
+                    (rr, (std::bitset<4>))
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc0 | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr0 | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B::evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    B::evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    B::evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    B::evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    B::evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    B::evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    B::evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
 
 The |preprocessor|_ test program demonstrates proper usage of this macro.
 
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.  ``name`` may be qualified by the ``static``
+keyword to declare the member function and its helpers as not associated with
+any object of the enclosing type.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params\_ ## __LINE__ ## **name**
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params\_ ## __LINE__ ## **name**
+        boost_param_parameters\_ ## __LINE__ ## **name**;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
+    {
+        return this->boost_param_impl ## **name**\ (
+            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters\_ ## __LINE__ ## **name**\ ()
+    )
+    {
+        return this->boost_param_impl ## **name**\ (
+            boost_param_parameters\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl ## **name**\ (Args const& args)
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION(result, name, tag_ns, args)``
 ---------------------------------------------------------------------------
@@ -1884,13 +3933,2214 @@ The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
-Same as ``BOOST_PARAMETER_BASIC_MEMBER_FUNCTION``, except that the overloaded
-forwarding member functions and their helper methods are ``const``-qualified.
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``const`` member function
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of ``args`` to extract the
+corresponding argument, but at least this doesn't require ``std::forward`` to
+preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        B()
+        {
+        }
+
+        BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION((bool), evaluate, kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>))
+                    (rr, (std::bitset<4>))
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc0 | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr0 | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B const b = B();
+    b.evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    b.evaluate(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    b.evaluate((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    b.evaluate(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    b.evaluate(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    b.evaluate(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    b.evaluate(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
+
+The |preprocessor|_ test program demonstrates proper usage of this macro.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated forwarding functions.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result_const\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params_const\_ ## __LINE__ ## **name**
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params_const\_ ## __LINE__ ## **name**
+        boost_param_parameters_const\_ ## __LINE__ ## **name**;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## **name**\ (
+            boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** **name**\ (
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## **name**
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## **name**\ (
+            boost_param_parameters_const\_ ## __LINE__ ## **name**\ ()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result_const\_ ## __LINE__ ## **name**\ <Args>::type
+        boost_param_impl_const ## __LINE__ ## **name**\ (Args const& args) const
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+
+``BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR(result, tag_ns, arguments)``
+---------------------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``tag`` by default.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(y)
+    |BOOST_PARAMETER_NAME|_(z)
+
+Use the macro as a substitute for a normal function call operator
+header.  Enclose the return type in parentheses.  For each parameter, also
+enclose the expected value type in parentheses.  Since the value types are
+mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  This is especially useful when implementing multiple
+Boost.Parameter-enabled function call operator overloads.
+
+.. parsed-literal::
+
+    class char_reader
+    {
+        int index;
+        char const* key;
+
+     public:
+        explicit char_reader(char const* k) : index(0), key(k)
+        {
+        }
+
+        BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR((void), tag,
+            (deduced
+                (required
+                    (y, (int))
+                    (z, (char const*))
+                )
+            )
+        )
+        {
+            this->index = args[_y];
+            this->key = args[_z];
+        }
+
+        |BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR|_((char), tag,
+            (deduced
+                (required
+                    (y, (bool))
+                    (z, (std::`map`_<char const*,std::`string`_>))
+                )
+            )
+        )
+        {
+            return args[_y] ? (
+                (args[_z].find(this->key)->second)[this->index]
+            ) : this->key[this->index];
+        }
+    };
+
+As with regular argument-dependent lookup, the value types of the arguments
+passed in determine which function call operator overload gets invoked.
+
+.. parsed-literal::
+
+    char const* keys[] = {"foo", "bar", "baz"};
+    std::`map`_<char const*,std::`string`_> k2s;
+    k2s[keys[0]] = std::`string`_("qux");
+    k2s[keys[1]] = std::`string`_("wmb");
+    k2s[keys[2]] = std::`string`_("zxc");
+    char_reader r(keys[0]);
+
+    // positional arguments
+    BOOST_TEST_EQ('q', (r(true, k2s)));
+    BOOST_TEST_EQ('f', (r(false, k2s)));
+
+    // named arguments
+    r(_z = keys[1], _y = 1);
+    BOOST_TEST_EQ('m', (r(_z = k2s, _y = true)));
+    BOOST_TEST_EQ('a', (r(_z = k2s, _y = false)));
+
+    // deduced arguments
+    r(keys[2], 2);
+    BOOST_TEST_EQ('c', (r(k2s, true)));
+    BOOST_TEST_EQ('z', (r(k2s, false)));
+
+The |preprocessor|_ test program demonstrates proper usage of this macro.
+
+.. _`map`: http\://en.cppreference.com/w/cpp/container/map
+.. _`string`: http\://en.cppreference.com/w/cpp/string/basic_string
+.. |preprocessor| replace:: preprocessor.cpp
+.. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function call operator resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params\_ ## __LINE__ ## operator
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params\_ ## __LINE__ ## operator
+        boost_param_parameters\_ ## __LINE__ ## operator;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** operator()(
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters\_ ## __LINE__ ## operator::match<
+            A0, …, A ## **n**
+        >::type = boost_param_parameters\_ ## __LINE__ ## operator()
+    )
+    {
+        return this->boost_param_impl ## __LINE__ ## operator(
+            boost_param_parameters\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** operator()(
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters\_ ## __LINE__ ## operator::match<
+            A0, …, A ## **m**
+        >::type = boost_param_parameters\_ ## __LINE__ ## operator()
+    )
+    {
+        return this->boost_param_impl ## __LINE__ ## operator(
+            boost_param_parameters\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result\_ ## __LINE__ ## operator<Args>::type
+        boost_param_impl ## __LINE__ ## operator(Args const& args)
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function call operator body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+
+``BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR(result, tag_ns, args)``
+----------------------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Define the named parameters that will comprise the argument specification that
+this macro will use.  Ensure that all their tag types are in the same
+namespace, which is ``kw`` in this case.  The identifiers with leading
+underscores can be passed to the bracket operator of ``args`` to extract the
+same argument to which the corresponding named parameter (without underscores)
+is bound, as will be shown later.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw) consume(rr))
+
+Use the macro as a substitute for a normal ``const`` function call operator
+header.  Enclose the return type ``bool`` in parentheses.  For each parameter,
+also enclose the expected value type in parentheses.  Since the value types
+are mutually exclusive, you can wrap the parameters in a ``(deduced …)``
+clause.  Otherwise, just as with a normal function, the order in which you
+specify the parameters determines their position.  However, unlike a normal
+function, default values must be specified within the function body.  Also
+within the function body, you must pass the matching identifier with the
+leading underscore to the bracket operator of ``args`` to extract the
+corresponding argument, but at least this doesn't require ``std::forward`` to
+preserve value categories.
+
+.. parsed-literal::
+
+    struct B
+    {
+        B()
+        {
+        }
+
+        BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR((bool), kw,
+            (deduced
+                (required
+                    (lrc, (std::bitset<1>))
+                    (lr, (std::bitset<2>))
+                )
+                (optional
+                    (rrc, (std::bitset<3>))
+                    (rr, (std::bitset<4>))
+                )
+            )
+        )
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc0 | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr0 | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+The following function calls are legal.
+
+.. parsed-literal::
+
+    B const b = B();
+    b(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+      , rvalue_bitset<3>()
+    );
+    b(  // positional arguments
+        lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+    );
+    b((  // composed arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    ));
+    b(  // named arguments
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    b(  // named arguments
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+Because the parameters were wrapped in a ``(deduced …)`` clause, the following
+function calls are also legal.
+
+.. parsed-literal::
+
+    b(  // deduced arguments
+        rvalue_bitset<3>()
+      , lvalue_const_bitset<0>()
+      , lvalue_bitset<1>()
+      , rvalue_const_bitset<2>()
+    );
+    b(  // deduced arguments
+        lvalue_bitset<1>()
+      , lvalue_const_bitset<0>()
+    );
 
 The |preprocessor|_ test program demonstrates proper usage of this macro.
 
 .. |preprocessor| replace:: preprocessor.cpp
 .. _preprocessor: ../../test/preprocessor.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+\*. ``tag_namespace`` is the namespace in which the keywords used by the
+function call operator resides.
+\*. ``arguments`` is a `Boost.Preprocessor`_ `sequence`_ of
+*argument-specifiers*, as defined below.
+
+:Argument specifiers syntax:
+.. parsed-literal::
+
+    argument-specifiers ::= *specifier-group0* {*specifier-group0*\ }
+
+    specifier-group0 ::= *specifier-group1* |
+        (
+            '**(**' '**deduced**'
+                *specifier-group1* {*specifier-group1*\ }
+            '**)**'
+        )
+
+    specifier-group1 ::=
+        (
+            '**(**' '**optional**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        ) | (
+            '**(**' '**required**'
+                *specifier* {*specifier*\ }
+            '**)**'
+        )
+
+    specifier ::=
+        '**(**' *argument-name* '**,**' *restriction* ')'
+
+    restriction ::=
+        ( '**\***' '**(**' *mfc* '**)**' ) |
+        ( '**(**' *type-name* '**)**' ) |
+        '**\***'
+
+\*. ``argument-name`` is any valid C++ identifier.
+\*. ``mfc`` is an `MPL Binary Metafunction Class`_ whose first argument will
+be the type of the corresponding ``argument-name``, whose second argument will
+be the entire |ArgumentPack|_, and whose return type is a `Boolean Integral
+Constant`_; however, user code *cannot* compute ``mfc`` in terms of
+``previous-name ## _type``.
+\*. ``type-name`` is either the name of a **target type** or an `MPL Binary
+Metafunction Class`_ whose first argument will be the type of the
+corresponding ``argument-name``, whose second argument will be the entire
+|ArgumentPack|_, and whose return type is the **target type**.
+
+Note that *specifier* does not include *default-value*.  It is up to the
+function body to determine the default value of all optional arguments.
+
+.. _`Boost.Preprocessor`: ../../../preprocessor/doc/index.html
+.. _`sequence`: ../../../preprocessor/doc/data/sequences.html
+.. _`MPL Binary Metafunction Class`: ../../../mpl/doc/refmanual/metafunction-class.html
+.. _`Boolean Integral Constant`: ../../../mpl/doc/refmanual/integral-constant.html
+
+Approximate expansion:
+**Where**:
+
+* ``n`` denotes the *minimum* arity, as determined from ``arguments``.
+* ``m`` denotes the *maximum* arity, as determined from ``arguments``.
+
+.. parsed-literal::
+
+    template <typename T>
+    struct boost_param_result_const\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    struct boost_param_params_const\_ ## __LINE__ ## operator
+      : |parameters|_<
+            *list of parameter specifications, based on arguments*
+        >
+    {
+    };
+
+    typedef boost_param_params_const\_ ## __LINE__ ## operator
+        boost_param_parameters_const\_ ## __LINE__ ## operator;
+
+    template <typename A0, …, typename A ## **n**>
+    **result** operator()(
+        A0&& a0, …, A ## **n**\ && a ## **n**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## operator
+        ::match<A0, …, A ## **n**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## operator()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## operator(
+            boost_param_parameters_const\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **n**>(a ## **n**)
+            )
+        );
+    }
+
+    :vellipsis:`⋮`
+
+    template <typename A0, …, typename A ## **m**>
+    **result** operator()(
+        A0&& a0, …, A ## **m**\ && a ## **m**
+      , typename boost_param_parameters_const\_ ## __LINE__ ## operator
+        ::match<A0, …, A ## **m**>::type
+        = boost_param_parameters_const\_ ## __LINE__ ## operator()
+    ) const
+    {
+        return this->boost_param_impl_const ## __LINE__ ## operator(
+            boost_param_parameters_const\_ ## __LINE__ ## operator()(
+                std::`forward`_<A0>(a0)
+              , …
+              , std::`forward`_<A ## **m**>(a ## **m**)
+            )
+        );
+    }
+
+    template <typename Args>
+    typename boost_param_result_const\_ ## __LINE__ ## operator<Args>::type
+        boost_param_impl_const ## __LINE__ ## operator(Args const& args) const
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function call operator body.
+
+.. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
+
+``BOOST_PARAMETER_NO_SPEC_FUNCTION(result, name)``
+--------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Named parameters are required when invoking the function; however, none of
+their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw0) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw1) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw2) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw3) consume(rr))
+
+Use the macro as a substitute for a variadic function header.  Enclose the
+return type ``bool`` in parentheses.
+
+.. parsed-literal::
+
+    BOOST_PARAMETER_NO_SPEC_FUNCTION((bool), evaluate)
+    {
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference_to_const
+          , U::evaluate_category<0>(args[_lrc])
+        );
+        BOOST_TEST_EQ(
+            passed_by_lvalue_reference
+          , U::evaluate_category<1>(args[_lr])
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference_to_const
+          , U::evaluate_category<2>(
+                args[_rrc | rvalue_const_bitset<2>()]
+            )
+        );
+        BOOST_TEST_EQ(
+            passed_by_rvalue_reference
+          , U::evaluate_category<3>(args[_rr | rvalue_bitset<3>()])
+        );
+
+        return true;
+    }
+
+To invoke the function, bind all its arguments to named parameters.
+
+.. parsed-literal::
+
+    evaluate(
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    evaluate(
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+The |preproc_eval_cat_no_spec|_ test program demonstrates proper usage of
+this macro.
+
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated implementation function.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+        );
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result\_ ## __LINE__ ## **name**\ <
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        **name**\ (TaggedArg0 const& arg0, TaggedArgs const&... args)
+    {
+        return boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            static_cast<
+                typename
+                boost_param_no_spec_result\_ ## __LINE__ ## **name**\ <
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+        )
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION(result, name)``
+---------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+When designing a front-end class template whose back-end is configurable via
+parameterized inheritance, it can be useful to omit argument specifiers from
+a named-parameter member function so that the delegate member functions of the
+back-end classes can enforce their own specifications.
+
+.. parsed-literal::
+
+    template <typename B>
+    struct frontend : B
+    {
+        frontend() : B()
+        {
+        }
+
+        BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((void), initialize)
+        {
+            this->initialize_impl(args);
+        }
+    };
+
+Named parameters are required when invoking the member function; however, none
+of their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(a0)
+    |BOOST_PARAMETER_NAME|_(a1)
+    |BOOST_PARAMETER_NAME|_(a2)
+
+For this example, each of the back-end class templates requires its own
+parameter to be present in the argument pack.  In practice, such parameters
+should be optional, with default values.
+
+.. parsed-literal::
+
+    template <typename T>
+    class backend0
+    {
+        T a0;
+
+     public:
+        backend0() : a0()
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->a0;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            this->a0 = args[_a0];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend1 : public B
+    {
+        T a1;
+
+     public:
+        backend1() : B(), a1()
+        {
+        }
+
+        T const& get_a1() const
+        {
+            return this->a1;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->a1 = args[_a1];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend2 : public B
+    {
+        T a2;
+
+     public:
+        backend2() : B(), a2()
+        {
+        }
+
+        T const& get_a2() const
+        {
+            return this->a2;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->a2 = args[_a2];
+        }
+    };
+
+This example shows that while ``backend0`` must always be the root base class
+template and that ``frontend`` must always be the most derived class template,
+the other back-ends can be chained together in different orders.
+
+.. parsed-literal::
+
+    char const* p = "foo";
+    frontend<
+        backend2<backend1<backend0<char const*>, char>, int>
+    > composed_obj0;
+    frontend<
+        backend1<backend2<backend0<char const*>, int>, char>
+    > composed_obj1;
+    composed_obj0.initialize(_a2 = 4, _a1 = ' ', _a0 = p);
+    composed_obj1.initialize(_a0 = p, _a1 = ' ', _a2 = 4);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+
+The |parameterized_inheritance|_ and |preproc_eval_cat_no_spec|_ test programs
+demonstrate proper usage of this macro.
+
+.. |parameterized_inheritance| replace:: parameterized_inheritance.cpp
+.. _parameterized_inheritance: ../../test/parameterized_inheritance.cpp
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated implementation function.  ``name`` may be qualified by the
+``static`` keyword to declare the member function and its helpers as not
+associated with any object of the enclosing type.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result\_ ## __LINE__ ## **name**\ <
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        **name**\ (TaggedArg0 const& arg0, TaggedArgs const&... args)
+    {
+        return this->boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            static_cast<
+                typename
+                boost_param_no_spec_result\_ ## __LINE__ ## **name**\ <
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+        )
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION(result, name)``
+---------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Named parameters are required when invoking the member function; however, none
+of their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw0) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw1) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw2) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw3) consume(rr))
+
+Use the macro as a substitute for a variadic function header.  Enclose the
+return type ``bool`` in parentheses.  The macro will qualify the function with
+the ``const`` keyword.
+
+.. parsed-literal::
+
+    struct D
+    {
+        D()
+        {
+        }
+
+        BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION((bool), evaluate_m)
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+To invoke the member function, bind all its arguments to named parameters.
+
+.. parsed-literal::
+
+    D const d = D();
+    d.evaluate_m(
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    d.evaluate_m(
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+The |preproc_eval_cat_no_spec|_ test program demonstrates proper usage of this
+macro.
+
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function.
+\*. ``name`` is the base name of the function; it determines the name of the
+generated implementation function.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result_const\_ ## __LINE__ ## **name**
+    {
+        typedef **result** type;
+    };
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result_const\_ ## __LINE__ ## **name**\ <
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        **name**\ (TaggedArg0 const& arg0, TaggedArgs const&... args) const
+    {
+        return this->boost_param_no_spec_impl_const ## __LINE__ ## **name**\ (
+            static_cast<
+                typename
+                boost_param_no_spec_result_const\_ ## __LINE__ ## **name**\ <
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl_const ## __LINE__ ## **name**\ (
+            (ResultType(\ *)())
+          , Args const& args
+        ) const
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR(result)``
+----------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+When designing a front-end class template whose back-end is configurable via
+parameterized inheritance, it can be useful to omit argument specifiers from
+a named-parameter function call operator so that the delegate member functions
+of the back-end classes can enforce their own specifications.
+
+.. parsed-literal::
+
+    template <typename B>
+    struct frontend : B
+    {
+        frontend() : B()
+        {
+        }
+
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR((void))
+        {
+            this->initialize_impl(args);
+        }
+    };
+
+Named parameters are required when invoking the function call operator;
+however, none of their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(a0)
+    |BOOST_PARAMETER_NAME|_(a1)
+    |BOOST_PARAMETER_NAME|_(a2)
+
+For this example, each of the back-end class templates requires its own
+parameter to be present in the argument pack.  In practice, such parameters
+should be optional, with default values.
+
+.. parsed-literal::
+
+    template <typename T>
+    class backend0
+    {
+        T a0;
+
+     public:
+        backend0() : a0()
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->a0;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            this->a0 = args[_a0];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend1 : public B
+    {
+        T a1;
+
+     public:
+        backend1() : B(), a1()
+        {
+        }
+
+        T const& get_a1() const
+        {
+            return this->a1;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->a1 = args[_a1];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend2 : public B
+    {
+        T a2;
+
+     public:
+        backend2() : B(), a2()
+        {
+        }
+
+        T const& get_a2() const
+        {
+            return this->a2;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->a2 = args[_a2];
+        }
+    };
+
+This example shows that while ``backend0`` must always be the root base class
+template and that ``frontend`` must always be the most derived class template,
+the other back-ends can be chained together in different orders.
+
+.. parsed-literal::
+
+    char const* p = "foo";
+    frontend<
+        backend2<backend1<backend0<char const*>, char>, int>
+    > composed_obj0;
+    frontend<
+        backend1<backend2<backend0<char const*>, int>, char>
+    > composed_obj1;
+    composed_obj0(_a2 = 4, _a1 = ' ', _a0 = p);
+    composed_obj1(_a0 = p, _a1 = ' ', _a2 = 4);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+
+The |parameterized_inheritance|_ and |preproc_eval_cat_no_spec|_ test programs
+demonstrate proper usage of this macro.
+
+.. |parameterized_inheritance| replace:: parameterized_inheritance.cpp
+.. _parameterized_inheritance: ../../test/parameterized_inheritance.cpp
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result\_ ## __LINE__ ## operator<
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        operator()(TaggedArg0 const& arg0, TaggedArgs const&... args)
+    {
+        return this->boost_param_no_spec_impl ## __LINE__ ## operator(
+            static_cast<
+                typename
+                boost_param_no_spec_result\_ ## __LINE__ ## operator<
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+        )
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR(result)``
+----------------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following function templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Named parameters are required when invoking the function call operator;
+however, none of their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw0) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw1) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw2) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw3) consume(rr))
+
+Use the macro as a substitute for a variadic function call operator
+header.  Enclose the return type ``bool`` in parentheses.  The macro will
+qualify the function with the ``const`` keyword.
+
+.. parsed-literal::
+
+    struct D
+    {
+        D()
+        {
+        }
+
+        BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR((bool))
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+To invoke the function call operator, bind all its arguments to named
+parameters.
+
+.. parsed-literal::
+
+    D const d = D();
+    d(
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    d(
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+The |preproc_eval_cat_no_spec|_ test program demonstrates proper usage of this
+macro.
+
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``result`` is the parenthesized return type of the function call operator.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct boost_param_no_spec_result_const\_ ## __LINE__ ## operator
+    {
+        typedef **result** type;
+    };
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename boost::`lazy_enable_if`_<
+        |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+      , boost_param_no_spec_result_const\_ ## __LINE__ ## operator<
+            TaggedArg0
+          , TaggedArgs...
+        >
+    >::type
+        operator()(
+            TaggedArg0 const& arg0
+          , TaggedArgs const&... args
+        ) const
+    {
+        return this->boost_param_no_spec_impl_const ## __LINE__ ## operator(
+            static_cast<
+                typename
+                boost_param_no_spec_result_const\_ ## __LINE__ ## operator<
+                    TaggedArg0
+                  , TaggedArgs...
+                >::type(\*)()
+            >(std::nullptr)
+          , |parameters|_<>()(arg0, args...)
+        );
+    }
+
+    template <typename ResultType, typename Args>
+    ResultType
+        boost_param_no_spec_impl_const ## __LINE__ ## operator(
+            (ResultType(\ *)())
+          , Args const& args
+        ) const
+
+Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
+available for use within the function body.
+
+.. _lazy_enable_if: ../../../core/doc/html/core/enable_if.html
+
+``BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(cls, impl)``
+--------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+When designing a front-end class template whose back-end is configurable via
+parameterized inheritance, it can be useful to omit argument specifiers from
+a named-parameter constructor so that the delegate constructors of the
+back-end classes can enforce their own specifications.
+
+.. parsed-literal::
+
+    template <typename B>
+    struct frontend : B
+    {
+        BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(frontend, (B))
+    };
+
+Named parameters are required when invoking the constructor; however, none of
+their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_(a0)
+    |BOOST_PARAMETER_NAME|_(a1)
+    |BOOST_PARAMETER_NAME|_(a2)
+
+For this example, each of the back-end class templates requires its own
+parameter to be present in the argument pack.  In practice, such parameters
+should be optional, with default values.
+
+.. parsed-literal::
+
+    struct _enabler
+    {
+    };
+
+    template <typename T>
+    class backend0
+    {
+        T a0;
+
+     public:
+        template <typename ArgPack>
+        explicit backend0(
+            ArgPack const& args
+          , typename boost::`enable_if`_<
+                |is_argument_pack|_<ArgPack>
+              , _enabler
+            >::type = _enabler()
+        ) : a0(args[_a0])
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->a0;
+        }
+    };
+
+    template <typename B, typename T>
+    class backend1 : public B
+    {
+        T a1;
+
+     public:
+        template <typename ArgPack>
+        explicit backend1(
+            ArgPack const& args
+          , typename boost::`enable_if`_<
+                |is_argument_pack|_<ArgPack>
+              , _enabler
+            >::type = _enabler()
+        ) : B(args), a1(args[_a1])
+        {
+        }
+
+        T const& get_a1() const
+        {
+            return this->a1;
+        }
+    };
+
+    template <typename B, typename T>
+    class backend2 : public B
+    {
+        T a2;
+
+     public:
+        template <typename ArgPack>
+        explicit backend2(
+            ArgPack const& args
+          , typename boost::`enable_if`_<
+                |is_argument_pack|_<ArgPack>
+              , _enabler
+            >::type = _enabler()
+        ) : B(args), a2(args[_a2])
+        {
+        }
+
+        T const& get_a2() const
+        {
+            return this->a2;
+        }
+    };
+
+This example shows that while ``backend0`` must always be the root base class
+template and that ``frontend`` must always be the most derived class template,
+the other back-ends can be chained together in different orders.
+
+.. parsed-literal::
+
+    char const* p = "foo";
+    frontend<
+        backend2<backend1<backend0<char const*>, char>, int>
+    > composed_obj0(_a2 = 4, _a1 = ' ', _a0 = p);
+    frontend<
+        backend1<backend2<backend0<char const*>, int>, char>
+    > composed_obj1(_a0 = p, _a1 = ' ', _a2 = 4);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+
+The |parameterized_inheritance|_ and |preproc_eval_cat_no_spec|_ test programs
+demonstrate proper usage of this macro.
+
+.. |parameterized_inheritance| replace:: parameterized_inheritance.cpp
+.. _parameterized_inheritance: ../../test/parameterized_inheritance.cpp
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``cls`` is the name of the enclosing class.
+\*. ``impl`` is the parenthesized implementation base class for ``cls``.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <
+        typename TaggedArg0
+      , typename ...TaggedArgs
+      , typename = typename boost::`enable_if`_<
+            |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+        >::type
+    >
+    inline explicit **cls**\ (
+        TaggedArg0 const& arg0
+      , TaggedArgs const&... args
+    ) : **impl**\ (|parameters|_<>()(arg0, args...))
+    {
+    }
+
+``BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(cls, impl)``
+----------------------------------------------------------
+
+:Defined in: `boost/parameter/preprocessor.hpp`__
+
+__ ../../../../boost/parameter/preprocessor.hpp
+
+:Example usage:
+The return type of each of the following functon templates falls under a
+different value category.
+
+.. parsed-literal::
+
+    template <std::size_t N>
+    std::bitset<N + 1> rvalue_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const rvalue_const_bitset()
+    {
+        return std::bitset<N + 1>();
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1>& lvalue_bitset()
+    {
+        static std::bitset<N + 1> lset = std::bitset<N + 1>();
+        return lset;
+    }
+
+    template <std::size_t N>
+    std::bitset<N + 1> const& lvalue_const_bitset()
+    {
+        static std::bitset<N + 1> const clset = std::bitset<N + 1>();
+        return clset;
+    }
+
+The ``U::evaluate_category`` static member function template has a simple job:
+to return the correct value category when passed in an object returned by one
+of the functions defined above.  Assume that
+|BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is defined.
+
+.. parsed-literal::
+
+    enum invoked
+    {
+        passed_by_lvalue_reference_to_const
+      , passed_by_lvalue_reference
+      , passed_by_rvalue_reference_to_const
+      , passed_by_rvalue_reference
+    };
+
+    struct U
+    {
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&)
+        {
+            return passed_by_lvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&)
+        {
+            return passed_by_lvalue_reference;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1> const&&)
+        {
+            return passed_by_rvalue_reference_to_const;
+        }
+
+        template <std::size_t N>
+        static invoked evaluate_category(std::bitset<N + 1>&&)
+        {
+            return passed_by_rvalue_reference;
+        }
+    };
+
+Named parameters are required when invoking the constructor; however, none of
+their tags need to be in the same namespace.
+
+.. parsed-literal::
+
+    |BOOST_PARAMETER_NAME|_((_lrc, kw0) in(lrc))
+    |BOOST_PARAMETER_NAME|_((_lr, kw1) in_out(lr))
+    |BOOST_PARAMETER_NAME|_((_rrc, kw2) in(rrc))
+    |BOOST_PARAMETER_NAME|_((_rr, kw3) consume(rr))
+
+Unlike |BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR|, this macro doesn't require a
+base class, only a delegate function to which the generated constructor can
+pass its |ArgumentPack|_.
+
+.. parsed-literal::
+
+    struct D
+    {
+        BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(D, D::_evaluate)
+
+     private:
+        template <typename Args>
+        static bool _evaluate(Args const& args)
+        {
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference_to_const
+              , U::evaluate_category<0>(args[_lrc])
+            );
+            BOOST_TEST_EQ(
+                passed_by_lvalue_reference
+              , U::evaluate_category<1>(args[_lr])
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference_to_const
+              , U::evaluate_category<2>(
+                    args[_rrc | rvalue_const_bitset<2>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                passed_by_rvalue_reference
+              , U::evaluate_category<3>(
+                    args[_rr | rvalue_bitset<3>()]
+                )
+            );
+
+            return true;
+        }
+    };
+
+To invoke the constructor, bind all its arguments to named parameters.
+
+.. parsed-literal::
+
+    D dp0(
+        _rr0 = rvalue_bitset<3>()
+      , _lrc0 = lvalue_const_bitset<0>()
+      , _lr0 = lvalue_bitset<1>()
+      , _rrc0 = rvalue_const_bitset<2>()
+    );
+    D dp1(
+        _lr0 = lvalue_bitset<1>()
+      , _lrc0 = lvalue_const_bitset<0>()
+    );
+
+The |preproc_eval_cat_no_spec|_ test program demonstrates proper usage of this
+macro.
+
+.. |preproc_eval_cat_no_spec| replace:: preprocessor_eval_cat_no_spec.cpp
+.. _preproc_eval_cat_no_spec: ../../test/preprocessor_eval_cat_no_spec.cpp
+
+:Macro parameters:
+\*. ``cls`` is the name of the enclosing class.
+\*. ``func`` is a function that takes in the |ArgumentPack|_ that the
+generated constructor passes on.
+
+:Argument specifiers syntax:
+None.
+
+Approximate expansion:
+.. parsed-literal::
+
+    template <
+        typename TaggedArg0
+      , typename ...TaggedArgs
+      , typename = typename boost::`enable_if`_<
+            |are_tagged_arguments|_<TaggedArg0,TaggedArgs...>
+        >::type
+    >
+    inline explicit **cls**\ (
+        TaggedArg0 const& arg0
+      , TaggedArgs const&... args
+    )
+    {
+        **func**\ (|parameters|_<>()(arg0, args...));
+    }
 
 ``BOOST_PARAMETER_NAME(name)``
 ------------------------------
@@ -2095,8 +6345,6 @@ __ ../../../../boost/parameter/macros.hpp
 :Requires: ``l`` and ``h`` are nonnegative integer tokens
 such that ``l`` < ``h``
 
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is ``#defined``, **then**
-
 Expands to:
 
 .. parsed-literal::
@@ -2164,109 +6412,6 @@ Expands to:
               , std::`forward`_<A ## **h**>(a ## **h**)
             )
         );
-    }
-
-**If** |BOOST_PARAMETER_HAS_PERFECT_FORWARDING| is **not** ``#defined``,
-**then**
-
-Expands to:
-
-.. parsed-literal::
-
-    template <typename A1, typename A2, …, typename A ## **l**>
-    r
-        name(
-            A1 const& a1, A2 const& a2, …, A ## **l** const& a ## **l**
-          , typename **p**::match<A1, A2, …, A ## **l**>::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(pk(a1, a2, …, a ## **l**));
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A1, typename A2, …, typename A ## **l**>
-    r
-        name(
-            A1& a1, A2& a2, …, A ## **l** & a ## **l**
-          , typename **p**::match<A1, A2, …, A ## **l**>::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(pk(a1, a2, …, a ## **l**));
-    }
-
-    template <
-        typename A1
-      , typename A2
-      , …
-      , typename A ## **l**
-      , typename A ## `BOOST_PP_INC`_\ (**l**)
-    >
-    r
-        name(
-            A1 const& a1, A2 const& a2, …, A ## **l** const& a ## **l**
-          , A ## `BOOST_PP_INC`_\ (**l**) const& a ## `BOOST_PP_INC`_\ (**l**)
-          , typename **p**::match<
-                A1 const, A2 const, …, A ## **l** const
-              , A ## `BOOST_PP_INC`_\ (**l**) const
-            >::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(
-            pk(a1, a2, …, a ## **l**, a ## `BOOST_PP_INC`_\ (**l**))
-        );
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <
-        typename A1
-      , typename A2
-      , …
-      , typename A ## **l**
-      , typename A ## `BOOST_PP_INC`_\ (**l**)
-    >
-    r
-        name(
-            A1& a1, A2& a2, …, A ## **l** & a ## **l**
-          , A ## `BOOST_PP_INC`_\ (**l**) & a ## `BOOST_PP_INC`_\ (**l**)
-          , typename **p**::match<
-                A1, A2, …, A ## **l**, A ## `BOOST_PP_INC`_\ (**l**)
-            >::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(
-            pk(a1, a2, …, a ## **l**, a ## `BOOST_PP_INC`_\ (**l**))
-        );
-    }
-
-    :vellipsis:`⋮`
-
-    template <typename A1, typename A2, …, typename A ## **h**>
-    r
-        name(
-            A1 const& a1, A2 const& a2, …, A ## **h** const& x ## **h**
-          , typename **p**::match<
-                A1 const, A2 const, …, A ## **h** const
-            >::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(pk(a1, a2, …, a ## **h**));
-    }
-
-    *… exponential number of overloads …*
-    :vellipsis:`⋮`
-
-    template <typename A1, typename A2, …, typename A ## **h**>
-    r
-        name(
-            A1& a1, A2& a2, …, A ## **h** & x ## **h**
-          , typename **p**::match<A1, A2, …, A ## **h**>::type pk = **p**\ ()
-        )
-    {
-        return **name**\ _with_named_params(pk(a1, a2, …, a ## **h**));
     }
 
 The |macros_cpp|_ and |macros_eval_cat_cpp|_ test programs demonstrate proper
@@ -2453,7 +6598,8 @@ equal to ``BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY``.
 
 __ ../../../../boost/parameter/config.hpp
 
-:Default Value: |BOOST_MPL_LIMIT_VECTOR_SIZE|_ (defined by `Boost.MPL`_) if perfect forwarding is supported, ``8`` otherwise.
+:Default Value: |BOOST_MPL_LIMIT_VECTOR_SIZE|_ (defined by `Boost.MPL`_) if
+perfect forwarding is supported, ``20`` otherwise.
 :Minimum Value: ``2``
 
 .. |BOOST_MPL_LIMIT_VECTOR_SIZE| replace:: ``BOOST_MPL_LIMIT_VECTOR_SIZE``

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -1048,6 +1048,9 @@ using the Parameter library by eliminating repetitive boilerplate.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.
+
 :Example usage:
 The return type of each of the following function templates falls under a
 different value category.
@@ -1498,6 +1501,9 @@ Approximate expansion:
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a member function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.
+
 :Example usage:
 The return type of each of the following function templates falls under a
 different value category.
@@ -1912,6 +1918,9 @@ Approximate expansion:
 :Defined in: `boost/parameter/preprocessor.hpp`__
 
 __ ../../../../boost/parameter/preprocessor.hpp
+
+Generates a member function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.
 
 :Example usage:
 The return type of each of the following function templates falls under a
@@ -2330,6 +2339,9 @@ Approximate expansion:
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a function call operator that can take in positional arguments,
+composed arguments, named arguments, and deduced arguments.
+
 :Example usage:
 Define the named parameters that will comprise the argument specification that
 this macro will use.  Ensure that all their tag types are in the same
@@ -2640,6 +2652,9 @@ Approximate expansion:
 :Defined in: `boost/parameter/preprocessor.hpp`__
 
 __ ../../../../boost/parameter/preprocessor.hpp
+
+Generates a function call operator that can take in positional arguments,
+composed arguments, named arguments, and deduced arguments.
 
 :Example usage:
 The return type of each of the following function templates falls under a
@@ -3062,6 +3077,9 @@ Approximate expansion:
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a constructor that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.
+
 :Example usage:
 Define the named parameters that will comprise the argument specification that
 this macro will use.  Ensure that all their tag types are in the same
@@ -3272,6 +3290,9 @@ Approximate expansion:
 :Defined in: `boost/parameter/preprocessor.hpp`__
 
 __ ../../../../boost/parameter/preprocessor.hpp
+
+Generates a function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.
 
 :Example usage:
 The return type of each of the following function templates falls under a
@@ -3600,6 +3621,9 @@ available for use within the function body.
 :Defined in: `boost/parameter/preprocessor.hpp`__
 
 __ ../../../../boost/parameter/preprocessor.hpp
+
+Generates a member function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.
 
 :Example usage:
 The return type of each of the following function templates falls under a
@@ -3932,6 +3956,9 @@ available for use within the function body.
 :Defined in: `boost/parameter/preprocessor.hpp`__
 
 __ ../../../../boost/parameter/preprocessor.hpp
+
+Generates a member function that can take in positional arguments, composed
+arguments, named arguments, and deduced arguments.
 
 :Example usage:
 The return type of each of the following function templates falls under a
@@ -4268,6 +4295,9 @@ available for use within the function body.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a function call operator that can take in positional arguments,
+composed arguments, named arguments, and deduced arguments.
+
 :Example usage:
 Define the named parameters that will comprise the argument specification that
 this macro will use.  Ensure that all their tag types are in the same
@@ -4490,6 +4520,9 @@ available for use within the function call operator body.
 :Defined in: `boost/parameter/preprocessor.hpp`__
 
 __ ../../../../boost/parameter/preprocessor.hpp
+
+Generates a function call operator that can take in positional arguments,
+composed arguments, named arguments, and deduced arguments.
 
 :Example usage:
 The return type of each of the following function templates falls under a
@@ -4823,6 +4856,8 @@ available for use within the function call operator body.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a function that can take in named arguments.
+
 :Example usage:
 The return type of each of the following function templates falls under a
 different value category.
@@ -5022,6 +5057,8 @@ available for use within the function body.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a member function that can take in named arguments.
+
 :Example usage:
 When designing a front-end class template whose back-end is configurable via
 parameterized inheritance, it can be useful to omit argument specifiers from
@@ -5215,6 +5252,8 @@ available for use within the function body.
 :Defined in: `boost/parameter/preprocessor.hpp`__
 
 __ ../../../../boost/parameter/preprocessor.hpp
+
+Generates a member function that can take in named arguments.
 
 :Example usage:
 The return type of each of the following function templates falls under a
@@ -5419,6 +5458,8 @@ available for use within the function body.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a function call operator that can take in named arguments.
+
 :Example usage:
 When designing a front-end class template whose back-end is configurable via
 parameterized inheritance, it can be useful to omit argument specifiers from
@@ -5608,6 +5649,8 @@ available for use within the function body.
 :Defined in: `boost/parameter/preprocessor.hpp`__
 
 __ ../../../../boost/parameter/preprocessor.hpp
+
+Generates a function call operator that can take in named arguments.
 
 :Example usage:
 The return type of each of the following function templates falls under a
@@ -5814,6 +5857,8 @@ available for use within the function body.
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a constructor that can take in named arguments.
+
 :Example usage:
 When designing a front-end class template whose back-end is configurable via
 parameterized inheritance, it can be useful to omit argument specifiers from
@@ -5972,8 +6017,10 @@ Approximate expansion:
 
 __ ../../../../boost/parameter/preprocessor.hpp
 
+Generates a constructor that can take in named arguments.
+
 :Example usage:
-The return type of each of the following functon templates falls under a
+The return type of each of the following function templates falls under a
 different value category.
 
 .. parsed-literal::

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -6599,7 +6599,7 @@ equal to ``BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY``.
 __ ../../../../boost/parameter/config.hpp
 
 :Default Value: |BOOST_MPL_LIMIT_VECTOR_SIZE|_ (defined by `Boost.MPL`_) if
-perfect forwarding is supported, ``20`` otherwise.
+perfect forwarding is supported, ``8`` otherwise.
 :Minimum Value: ``2``
 
 .. |BOOST_MPL_LIMIT_VECTOR_SIZE| replace:: ``BOOST_MPL_LIMIT_VECTOR_SIZE``

--- a/include/boost/parameter/are_tagged_arguments.hpp
+++ b/include/boost/parameter/are_tagged_arguments.hpp
@@ -1,0 +1,125 @@
+// Copyright Cromwell D. Enage 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_HPP
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_HPP
+
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct are_tagged_arguments;
+}} // namespace boost::parameter
+
+#include <boost/parameter/aux_/is_tagged_argument.hpp>
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0>
+    struct are_tagged_arguments<TaggedArg0>
+      : ::boost::parameter::aux::is_tagged_argument<TaggedArg0>
+    {
+    };
+}} // namespace boost::parameter
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct are_tagged_arguments
+      : ::boost::mpl::if_<
+            ::boost::parameter::aux::is_tagged_argument<TaggedArg0>
+          , ::boost::parameter::are_tagged_arguments<TaggedArgs...>
+          , ::boost::mpl::false_
+        >::type
+    {
+    };
+}} // namespace boost::parameter
+
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z(z, n, false_t) , false_t>
+/**/
+
+#include <boost/parameter/aux_/is_tagged_argument.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/preprocessor/cat.hpp>
+
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_BEGIN_Z(z, n, prefix)           \
+    ::boost::mpl::eval_if<                                                   \
+        ::boost::parameter::aux::is_tagged_argument<BOOST_PP_CAT(prefix, n)>,
+/**/
+
+#include <boost/parameter/aux_/void.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/preprocessor/arithmetic/sub.hpp>
+#include <boost/preprocessor/facilities/intercept.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/repetition/enum_trailing_params.hpp>
+
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_OVERLOADS_Z(z, n, prefix)       \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename prefix)>                 \
+    struct are_tagged_arguments<                                             \
+        BOOST_PP_ENUM_PARAMS_Z(z, n, prefix)                                 \
+        BOOST_PP_ENUM_TRAILING_PARAMS_Z(                                     \
+            z                                                                \
+          , BOOST_PP_SUB(BOOST_PARAMETER_MAX_ARITY, n)                       \
+          , ::boost::parameter::void_ BOOST_PP_INTERCEPT                     \
+        )                                                                    \
+    > : BOOST_PP_CAT(BOOST_PP_REPEAT_, z)(                                   \
+            n                                                                \
+          , BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_BEGIN_Z                     \
+          , prefix                                                           \
+        )                                                                    \
+        ::boost::mpl::true_                                                  \
+        BOOST_PP_CAT(BOOST_PP_REPEAT_, z)(                                   \
+            n                                                                \
+          , BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z                       \
+          , ::boost::mpl::false_                                             \
+        )::type                                                              \
+    {                                                                        \
+    };
+/**/
+
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+
+namespace boost { namespace parameter {
+
+    template <
+        BOOST_PP_ENUM_BINARY_PARAMS(
+            BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)
+          , typename TaggedArg
+          , = ::boost::parameter::void_ BOOST_PP_INTERCEPT
+        )
+    >
+    struct are_tagged_arguments;
+}} // namespace boost::parameter
+
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
+namespace boost { namespace parameter {
+
+    BOOST_PP_REPEAT_FROM_TO(
+        1
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)
+      , BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_OVERLOADS_Z
+      , TaggedArg
+    )
+}} // namespace boost::parameter
+
+#undef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_OVERLOADS_Z
+#undef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_BEGIN_Z
+#undef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z
+
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+#endif  // include guard
+

--- a/include/boost/parameter/aux_/arg_list.hpp
+++ b/include/boost/parameter/aux_/arg_list.hpp
@@ -144,6 +144,7 @@ namespace boost { namespace parameter { namespace aux {
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -153,9 +154,13 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename TaggedArg
       , typename Next = ::boost::parameter::aux::empty_arg_list
+      , typename EmitErrors = ::boost::mpl::true_
     >
-    struct arg_list : Next
+    class arg_list : public Next
     {
+        TaggedArg arg;      // Stores the argument
+
+     public:
         typedef TaggedArg tagged_arg;
         typedef ::boost::parameter::aux::arg_list<TaggedArg,Next> self;
         typedef typename TaggedArg::key_type key_type;
@@ -175,8 +180,6 @@ namespace boost { namespace parameter { namespace aux {
           , reference
           , typename TaggedArg::value_type
         >::type value_type;
-
-        TaggedArg arg;      // Stores the argument
 
         // Create a new list by prepending arg to a copy of tail.  Used when
         // incrementally building this structure with the comma operator.
@@ -276,16 +279,22 @@ namespace boost { namespace parameter { namespace aux {
         static ::boost::parameter::aux::yes_tag has_key(key_type*);
         using Next::has_key;
 
-        BOOST_MPL_ASSERT_MSG(
+     private:
+        typedef ::boost::mpl::bool_<
             sizeof(
                 Next::has_key(
                     static_cast<key_type*>(BOOST_TTI_DETAIL_NULLPTR)
                 )
             ) == sizeof(::boost::parameter::aux::no_tag)
+        > _has_unique_key;
+
+        BOOST_MPL_ASSERT_MSG(
+            !(EmitErrors::value) || (_has_unique_key::value)
           , duplicate_keyword
           , (key_type)
         );
 
+     public:
         //
         // Begin implementation of indexing operators
         // for looking up specific arguments by name.
@@ -356,11 +365,18 @@ namespace boost { namespace parameter { namespace aux {
         // satisfied by TaggedArg.  Used only for compile-time computation
         // and never really called, so a declaration is enough.
         template <typename HasDefault, typename Predicate, typename ArgPack>
-        static typename ::boost::mpl::apply_wrap2<
-            ::boost::parameter::aux
-            ::augment_predicate<Predicate,reference,key_type>
-          , value_type
-          , ArgPack
+        static typename ::boost::lazy_enable_if<
+            typename ::boost::mpl::if_<
+                EmitErrors
+              , ::boost::mpl::true_
+              , _has_unique_key
+            >::type
+          , ::boost::mpl::apply_wrap2<
+                ::boost::parameter::aux
+                ::augment_predicate<Predicate,reference,key_type>
+              , value_type
+              , ArgPack
+            >
         >::type
             satisfies(
                 ::boost::parameter::aux::parameter_requirements<
@@ -524,6 +540,10 @@ namespace boost { namespace parameter { namespace aux {
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 #include <boost/preprocessor/repetition/enum_shifted_params.hpp>
 
+#if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+#include <boost/core/enable_if.hpp>
+#endif
+
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
 #include <boost/tti/detail/dnullptr.hpp>
 #endif
@@ -535,9 +555,13 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename TaggedArg
       , typename Next = ::boost::parameter::aux::empty_arg_list
+      , typename EmitErrors = ::boost::mpl::true_
     >
-    struct arg_list : Next
+    class arg_list : public Next
     {
+        TaggedArg arg;      // Stores the argument
+
+     public:
         typedef TaggedArg tagged_arg;
         typedef ::boost::parameter::aux::arg_list<TaggedArg,Next> self;
         typedef typename TaggedArg::key_type key_type;
@@ -557,8 +581,6 @@ namespace boost { namespace parameter { namespace aux {
           , reference
           , typename TaggedArg::value_type
         >::type value_type;
-
-        TaggedArg arg;      // Stores the argument
 
         // Create a new list by prepending arg to a copy of tail.  Used when
         // incrementally building this structure with the comma operator.
@@ -613,6 +635,7 @@ namespace boost { namespace parameter { namespace aux {
         static ::boost::parameter::aux::yes_tag has_key(key_type*);
         using Next::has_key;
 
+#if defined(BOOST_NO_SFINAE) || BOOST_WORKAROUND(BOOST_MSVC, < 1800)
         BOOST_MPL_ASSERT_MSG(
             sizeof(
                 Next::has_key(
@@ -622,8 +645,25 @@ namespace boost { namespace parameter { namespace aux {
           , duplicate_keyword
           , (key_type)
         );
-#endif
+#else
+     private:
+        typedef ::boost::mpl::bool_<
+            sizeof(
+                Next::has_key(
+                    static_cast<key_type*>(BOOST_TTI_DETAIL_NULLPTR)
+                )
+            ) == sizeof(::boost::parameter::aux::no_tag)
+        > _has_unique_key;
 
+        BOOST_MPL_ASSERT_MSG(
+            !(EmitErrors::value) || (_has_unique_key::value)
+          , duplicate_keyword
+          , (key_type)
+        );
+#endif
+#endif  // Borland workarounds not needed.
+
+     public:
         //
         // Begin implementation of indexing operators
         // for looking up specific arguments by name.
@@ -786,11 +826,23 @@ namespace boost { namespace parameter { namespace aux {
         // satisfied by TaggedArg.  Used only for compile-time computation
         // and never really called, so a declaration is enough.
         template <typename HasDefault, typename Predicate, typename ArgPack>
-        static typename ::boost::mpl::apply_wrap2<
-            ::boost::parameter::aux
-            ::augment_predicate<Predicate,reference,key_type>
-          , value_type
-          , ArgPack
+        static typename
+#if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+        ::boost::lazy_enable_if<
+            typename ::boost::mpl::if_<
+                EmitErrors
+              , ::boost::mpl::true_
+              , _has_unique_key
+            >::type,
+#endif
+            ::boost::mpl::apply_wrap2<
+                ::boost::parameter::aux
+                ::augment_predicate<Predicate,reference,key_type>
+              , value_type
+              , ArgPack
+#if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+           >
+#endif
         >::type
             satisfies(
                 ::boost::parameter::aux::parameter_requirements<

--- a/include/boost/parameter/aux_/pack/deduce_tag.hpp
+++ b/include/boost/parameter/aux_/pack/deduce_tag.hpp
@@ -14,6 +14,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
+      , typename EmitErrors
     >
     struct deduce_tag;
 }}} // namespace boost::parameter::aux
@@ -38,6 +39,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
+      , typename EmitErrors
     >
     struct deduce_tag0
     {
@@ -59,9 +61,13 @@ namespace boost { namespace parameter { namespace aux {
                     UsedArgs
                   , typename ::boost::parameter::aux::tag_type<spec>::type
                 >::type
-              , ::boost::mpl::if_<
+              , ::boost::mpl::eval_if<
                     condition
-                  , ::boost::mpl::false_
+                  , ::boost::mpl::if_<
+                        EmitErrors
+                      , ::boost::mpl::false_
+                      , ::boost::mpl::true_
+                    >
                   , ::boost::mpl::true_
                 >
               , ::boost::mpl::true_
@@ -77,6 +83,7 @@ namespace boost { namespace parameter { namespace aux {
               , typename DeducedArgs::tail
               , UsedArgs
               , TagFn
+              , EmitErrors
             >
         >::type type;
     };
@@ -108,6 +115,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
+      , typename EmitErrors
     >
     struct deduce_tag
       : ::boost::mpl::eval_if<
@@ -119,6 +127,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedArgs
               , UsedArgs
               , TagFn
+              , EmitErrors
             >
         >
     {

--- a/include/boost/parameter/aux_/pack/make_arg_list.hpp
+++ b/include/boost/parameter/aux_/pack/make_arg_list.hpp
@@ -16,6 +16,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename UsedArgs
       , typename ArgumentPack
       , typename Error
+      , typename EmitErrors
     >
     struct make_arg_list_aux;
 }}} // namespace boost::parameter::aux
@@ -54,6 +55,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename argument
 #endif
       , typename Error
+      , typename EmitErrors
     >
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     struct make_arg_list00
@@ -114,6 +116,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedArgs
               , used_args
               , TagFn
+              , EmitErrors
             >
         >::type deduced_data;
 
@@ -147,7 +150,11 @@ namespace boost { namespace parameter { namespace aux {
         typedef typename ::boost::mpl::if_<
             ::boost::is_same<tagged,::boost::parameter::void_>
           , ArgumentPack
+#if defined(BOOST_NO_SFINAE) || BOOST_WORKAROUND(BOOST_MSVC, < 1800)
           , ::boost::parameter::aux::arg_list<tagged,ArgumentPack>
+#else
+          , ::boost::parameter::aux::arg_list<tagged,ArgumentPack,EmitErrors>
+#endif
         >::type argument_pack;
 
         typedef typename ::boost::parameter::aux::make_arg_list_aux<
@@ -158,6 +165,7 @@ namespace boost { namespace parameter { namespace aux {
           , typename deduced_data::second
           , argument_pack
           , error
+          , EmitErrors
         >::type type;
     };
 
@@ -170,6 +178,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename UsedArgs
       , typename ArgumentPack
       , typename Error
+      , typename EmitErrors
     >
     struct make_arg_list0
     {
@@ -184,6 +193,7 @@ namespace boost { namespace parameter { namespace aux {
               , ArgumentPack
               , typename List::arg const
               , Error
+              , EmitErrors
             >
           , ::boost::parameter::aux::make_arg_list00<
                 List
@@ -194,6 +204,7 @@ namespace boost { namespace parameter { namespace aux {
               , ArgumentPack
               , typename List::arg
               , Error
+              , EmitErrors
             >
         >::type type;
     };
@@ -226,6 +237,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedSet
       , typename ArgumentPack
       , typename Error
+      , typename EmitErrors
     >
     struct make_arg_list_aux
       : ::boost::mpl::eval_if<
@@ -239,6 +251,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedSet
               , ArgumentPack
               , Error
+              , EmitErrors
             >
         >
     {
@@ -266,6 +279,7 @@ namespace boost { namespace parameter { namespace aux {
           , ::boost::parameter::aux::set0
           , ::boost::parameter::aux::empty_arg_list
           , ::boost::parameter::void_
+          , EmitErrors
         >
     {
     };

--- a/include/boost/parameter/aux_/preprocessor/impl/forwarding_overloads.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/forwarding_overloads.hpp
@@ -7,9 +7,104 @@
 #ifndef BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_FORWARDING_OVERLOADS_HPP
 #define BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_FORWARDING_OVERLOADS_HPP
 
+#include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
+
+// Defines the no-spec implementation function header.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_HEAD(name, is_const)           \
+    template <typename ResultType, typename Args>                            \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(name) ResultType                  \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(                          \
+            name, is_const                                                   \
+        )(ResultType(*)(), Args const& args)
+/**/
+
 #include <boost/parameter/config.hpp>
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
+
+// Expands to the result metafunction for the specified no-spec function.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, name, is_const)        \
+    template <typename TaggedArg0, typename ...TaggedArgs>                   \
+    struct BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(name, is_const)      \
+    {                                                                        \
+        typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
+    };
+/**/
+
+#include <boost/parameter/parameters.hpp>
+#include <boost/parameter/are_tagged_arguments.hpp>
+#include <boost/core/enable_if.hpp>
+
+// Exapnds to a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The enclosing class must inherit from the
+// specified base class, which in turn must implement a constructor that takes
+// in the argument pack that this one passes on.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(class_, base)                    \
+    template <                                                               \
+        typename TaggedArg0                                                  \
+      , typename ...TaggedArgs                                               \
+      , typename = typename ::boost::enable_if<                              \
+            ::boost::parameter                                               \
+            ::are_tagged_arguments<TaggedArg0,TaggedArgs...>                 \
+        >::type                                                              \
+    > inline explicit                                                        \
+    class_(TaggedArg0 const& arg0, TaggedArgs const&... args)                \
+      : BOOST_PARAMETER_PARENTHESIZED_TYPE(base)(                            \
+            ::boost::parameter::parameters<>()(arg0, args...)                \
+        )                                                                    \
+    {                                                                        \
+    }
+/**/
+
+// Exapnds to a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The specified function must be able to
+// take in the argument pack that this constructor passes on.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(class_, func)            \
+    template <                                                               \
+        typename TaggedArg0                                                  \
+      , typename ...TaggedArgs                                               \
+      , typename = typename ::boost::enable_if<                              \
+            ::boost::parameter                                               \
+            ::are_tagged_arguments<TaggedArg0,TaggedArgs...>                 \
+        >::type                                                              \
+    > inline explicit                                                        \
+    class_(TaggedArg0 const& arg0, TaggedArgs const&... args)                \
+    {                                                                        \
+        func(::boost::parameter::parameters<>()(arg0, args...));             \
+    }
+/**/
+
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/preprocessor/control/expr_if.hpp>
+
+// Exapnds to a variadic function that is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD(name, impl, is_m, c)       \
+    template <typename TaggedArg0, typename ...TaggedArgs>                   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(impl)                             \
+    inline typename ::boost::lazy_enable_if<                                 \
+        ::boost::parameter                                                   \
+        ::are_tagged_arguments<TaggedArg0,TaggedArgs...>                     \
+      , BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(                        \
+            impl, c                                                          \
+        )<TaggedArg0,TaggedArgs...>                                          \
+    >::type BOOST_PARAMETER_MEMBER_FUNCTION_NAME(name)                       \
+    (TaggedArg0 const& arg0, TaggedArgs const&... args)                      \
+    BOOST_PP_EXPR_IF(c, const)                                               \
+    {                                                                        \
+        return BOOST_PP_EXPR_IF(is_m, this->)                                \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(impl, c)(                 \
+            static_cast<                                                     \
+                typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(       \
+                    impl, c                                                  \
+                )<TaggedArg0,TaggedArgs...>::type(*)()                       \
+            >(BOOST_TTI_DETAIL_NULLPTR)                                      \
+          , ::boost::parameter::parameters<>()(arg0, args...)                \
+        );                                                                   \
+    }
+/**/
 
 #include <boost/preprocessor/cat.hpp>
 
@@ -26,7 +121,6 @@
     ::std::forward<BOOST_PP_CAT(type_prefix, n)>(BOOST_PP_CAT(a, n))
 /**/
 
-#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
 
 // Expands to the default constructor, whose job is to pass an empty back to
@@ -41,29 +135,33 @@
 /**/
 
 #include <boost/parameter/aux_/pp_impl/argument_pack.hpp>
-#include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
-#include <boost/preprocessor/control/expr_if.hpp>
 
 // Expands to a 0-arity forwarding function, whose job is to pass an empty
 // pack to the front-end implementation function.
 #define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_0_Z(z, n, data)            \
-    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(3, 1, data))  \
-    inline                                                                   \
-    BOOST_PARAMETER_FUNCTION_RESULT_NAME(BOOST_PP_TUPLE_ELEM(3, 1, data))<   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline BOOST_PARAMETER_FUNCTION_RESULT_NAME(                             \
+        BOOST_PP_TUPLE_ELEM(4, 1, data)                                      \
+      , BOOST_PP_TUPLE_ELEM(4, 3, data)                                      \
+    )<                                                                       \
         ::boost::parameter::aux::argument_pack<                              \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )                                                                \
         >::type                                                              \
     >::type                                                                  \
     BOOST_PARAMETER_MEMBER_FUNCTION_NAME(BOOST_PP_TUPLE_ELEM(3, 0, data))()  \
-    BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(3, 2, data), const)                 \
+    BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)                 \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
-            BOOST_PP_TUPLE_ELEM(3, 1, data)                                  \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                  \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )()()                                                            \
         );                                                                   \
     }
@@ -78,12 +176,15 @@
 // into a pack for the front-end implementation function to take in.
 #define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_1_Z(z, n, data)            \
     template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename ParameterArgumentType)>  \
-    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(3, 1, data))  \
-    inline typename                                                          \
-    BOOST_PARAMETER_FUNCTION_RESULT_NAME(BOOST_PP_TUPLE_ELEM(3, 1, data))<   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(                    \
+        BOOST_PP_TUPLE_ELEM(4, 1, data)                                      \
+      , BOOST_PP_TUPLE_ELEM(4, 3, data)                                      \
+    )<                                                                       \
         typename ::boost::parameter::aux::argument_pack<                     \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )                                                                \
           , BOOST_PP_CAT(BOOST_PP_ENUM_, z)(                                 \
                 n                                                            \
@@ -92,23 +193,27 @@
             )                                                                \
         >::type                                                              \
     >::type                                                                  \
-    BOOST_PARAMETER_MEMBER_FUNCTION_NAME(BOOST_PP_TUPLE_ELEM(3, 0, data))(   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_NAME(BOOST_PP_TUPLE_ELEM(4, 0, data))(   \
         BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, ParameterArgumentType, && a)     \
         BOOST_PARAMETER_FUNCTION_FORWARD_MATCH_Z(                            \
             z                                                                \
           , BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )                                                                \
           , n                                                                \
           , ParameterArgumentType                                            \
         )                                                                    \
-    ) BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(3, 2, data), const)               \
+    ) BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)               \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
-            BOOST_PP_TUPLE_ELEM(3, 1, data)                                  \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                  \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )()(                                                             \
                 BOOST_PP_CAT(BOOST_PP_ENUM_, z)(                             \
                     n                                                        \
@@ -169,12 +274,21 @@
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
 
 // Helper macro for BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(name, impl, range, c) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(nm, impl, r, is_m, c) \
     BOOST_PP_REPEAT_FROM_TO(                                                 \
-        BOOST_PP_TUPLE_ELEM(2, 0, range)                                     \
-      , BOOST_PP_TUPLE_ELEM(2, 1, range)                                     \
+        BOOST_PP_TUPLE_ELEM(2, 0, r)                                         \
+      , BOOST_PP_TUPLE_ELEM(2, 1, r)                                         \
       , BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_Z                          \
-      , (name, impl, c)                                                      \
+      , (                                                                    \
+            nm                                                               \
+          , impl                                                             \
+          , BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_MEMBER_FUNCTION_IS_STATIC(nm)                \
+              , 0                                                            \
+              , is_m                                                         \
+            )                                                                \
+          , c                                                                \
+        )                                                                    \
     )
 /**/
 
@@ -192,9 +306,9 @@
 
 // Expands to the layer of forwarding functions for the function with the
 // specified name, whose arguments determine the range of arities.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, args, const_) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, a, is_m, c)   \
     BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(                          \
-        name, impl, BOOST_PARAMETER_ARITY_RANGE(args), const_                \
+        name, impl, BOOST_PARAMETER_ARITY_RANGE(a), is_m, c                  \
     )
 /**/
 
@@ -208,9 +322,228 @@
 
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 
+#include <boost/parameter/aux_/void.hpp>
 #include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
-#include <boost/preprocessor/seq/seq.hpp>
+#include <boost/preprocessor/facilities/intercept.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+
+// Expands to the result metafunction for the specified no-spec function.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, name, is_const)        \
+    template <                                                               \
+        BOOST_PP_ENUM_BINARY_PARAMS(                                         \
+            BOOST_PARAMETER_MAX_ARITY                                        \
+          , typename TaggedArg                                               \
+          , = ::boost::parameter::void_ BOOST_PP_INTERCEPT                   \
+        )                                                                    \
+    >                                                                        \
+    struct BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(name, is_const)      \
+    {                                                                        \
+        typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
+    };
+/**/
+
+#include <boost/parameter/parameters.hpp>
+#include <boost/preprocessor/comparison/equal.hpp>
+#include <boost/preprocessor/control/expr_if.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
+
+#if defined(BOOST_NO_SFINAE)
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the base class delegate constructor.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR_OVERLOAD_Z(z, n, data)           \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+    ) : BOOST_PARAMETER_PARENTHESIZED_TYPE(BOOST_PP_TUPLE_ELEM(2, 1, data))( \
+            ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        )                                                                    \
+    {                                                                        \
+    }
+/**/
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the delegate function.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR_OVERLOAD_Z(z, n, data)   \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+    )                                                                        \
+    {                                                                        \
+        BOOST_PP_TUPLE_ELEM(2, 1, data)(                                     \
+            ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+#include <boost/tti/detail/dnullptr.hpp>
+
+// Exapnds to a tagged-argument function overload.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD_Z(z, n, data)              \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(            \
+        BOOST_PP_TUPLE_ELEM(4, 1, data)                                      \
+      , BOOST_PP_TUPLE_ELEM(4, 3, data)                                      \
+    )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>::type                         \
+        BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                \
+            BOOST_PP_TUPLE_ELEM(4, 0, data)                                  \
+        )(BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg))        \
+        BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)             \
+    {                                                                        \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(                          \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
+        )(                                                                   \
+            static_cast<                                                     \
+                typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(       \
+                    BOOST_PP_TUPLE_ELEM(4, 1, data)                          \
+                  , BOOST_PP_TUPLE_ELEM(4, 3, data)                          \
+                )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>::type(*)()        \
+            >(BOOST_TTI_DETAIL_NULLPTR)                                      \
+          , ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+#else   // !defined(BOOST_NO_SFINAE)
+
+#include <boost/parameter/are_tagged_arguments.hpp>
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the base class delegate constructor.  This constructor is enabled
+// if and only if all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR_OVERLOAD_Z(z, n, data)           \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+      , typename ::boost::enable_if<                                         \
+            ::boost::parameter::are_tagged_arguments<                        \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)                      \
+            >                                                                \
+        >::type* = BOOST_TTI_DETAIL_NULLPTR                                  \
+    ) : BOOST_PARAMETER_PARENTHESIZED_TYPE(BOOST_PP_TUPLE_ELEM(2, 1, data))( \
+            ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        )                                                                    \
+    {                                                                        \
+    }
+/**/
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the delegate function.  This constructor is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR_OVERLOAD_Z(z, n, data)   \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+      , typename ::boost::enable_if<                                         \
+            ::boost::parameter::are_tagged_arguments<                        \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)                      \
+            >                                                                \
+        >::type* = BOOST_TTI_DETAIL_NULLPTR                                  \
+    )                                                                        \
+    {                                                                        \
+        BOOST_PP_TUPLE_ELEM(2, 1, data)(                                     \
+            ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+// Exapnds to a function overload that is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD_Z(z, n, data)              \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline typename ::boost::lazy_enable_if<                                 \
+        ::boost::parameter                                                   \
+        ::are_tagged_arguments<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>      \
+      , BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(                        \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
+        )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>                           \
+    >::type BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                            \
+        BOOST_PP_TUPLE_ELEM(4, 0, data)                                      \
+    )(BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg))            \
+    BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)                 \
+    {                                                                        \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(                          \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
+        )(                                                                   \
+            static_cast<                                                     \
+                typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(       \
+                    BOOST_PP_TUPLE_ELEM(4, 1, data)                          \
+                  , BOOST_PP_TUPLE_ELEM(4, 3, data)                          \
+                )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>::type(*)()        \
+            >(BOOST_TTI_DETAIL_NULLPTR)                                      \
+          , ::boost::parameter::parameters<>()(                              \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, arg)                            \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+#endif  // BOOST_NO_SFINAE
+
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
+// Emulates a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The enclosing class must inherit from the
+// specified base class, which in turn must implement a constructor that takes
+// in the argument pack that this one passes on.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(class_, base)                    \
+    BOOST_PP_REPEAT_FROM_TO(                                                 \
+        1                                                                    \
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)                              \
+      , BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR_OVERLOAD_Z                       \
+      , (class_, base)                                                       \
+    )
+/**/
+
+// Emulates a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The specified function must be able to
+// take in the argument pack that this constructor passes on.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(class_, func)            \
+    BOOST_PP_REPEAT_FROM_TO(                                                 \
+        1                                                                    \
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)                              \
+      , BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR_OVERLOAD_Z               \
+      , (class_, func)                                                       \
+    )
+/**/
+
+// Emulates a variadic function that is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD(name, impl, is_m, c)       \
+    BOOST_PP_REPEAT_FROM_TO(                                                 \
+        1                                                                    \
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)                              \
+      , BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD_Z                          \
+      , (name, impl, is_m, c)                                                \
+    )
+/**/
+
+#include <boost/preprocessor/seq/seq.hpp>
 #include <boost/preprocessor/cat.hpp>
 
 // Expands to the default constructor, whose job is to pass an empty argument
@@ -228,49 +561,64 @@
 /**/
 
 #include <boost/parameter/aux_/pp_impl/argument_pack.hpp>
-#include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
-#include <boost/preprocessor/control/expr_if.hpp>
 
 // Expands to a 0-arity forwarding function, whose job is to pass an empty
 // argument pack to the front-end implementation function.
 #define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_0_ARITY(z, n, seq)         \
     BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(                                  \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
     )                                                                        \
     inline BOOST_PARAMETER_FUNCTION_RESULT_NAME(                             \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+        )                                                                    \
+      , BOOST_PP_TUPLE_ELEM(                                                 \
+            4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
     )<                                                                       \
         ::boost::parameter::aux::argument_pack<                              \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
                 BOOST_PP_TUPLE_ELEM(                                         \
-                    3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                    4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                )                                                            \
+              , BOOST_PP_TUPLE_ELEM(                                         \
+                    4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
                 )                                                            \
             )                                                                \
         >::type                                                              \
     >::type                                                                  \
     BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                    \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 0, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 0, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
     )() BOOST_PP_EXPR_IF(                                                    \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 2, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
       , const                                                                \
     )                                                                        \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
+        return BOOST_PP_EXPR_IF(                                             \
             BOOST_PP_TUPLE_ELEM(                                             \
-                3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
+                4, 2, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
+            )                                                                \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                \
+            BOOST_PP_TUPLE_ELEM(                                             \
+                4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
+            )                                                                \
+          , BOOST_PP_TUPLE_ELEM(                                             \
+                4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
             )                                                                \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
                 BOOST_PP_TUPLE_ELEM(                                         \
-                    3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                    4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                )                                                            \
+              , BOOST_PP_TUPLE_ELEM(                                         \
+                    4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
                 )                                                            \
             )()()                                                            \
         );                                                                   \
@@ -279,8 +627,6 @@
 
 #include <boost/parameter/aux_/preprocessor/binary_seq_to_args.hpp>
 #include <boost/parameter/aux_/preprocessor/impl/function_forward_match.hpp>
-#include <boost/preprocessor/comparison/equal.hpp>
-#include <boost/preprocessor/repetition/enum_params.hpp>
 #include <boost/preprocessor/seq/size.hpp>
 
 // Expands to a constructor whose job is to consolidate its arguments into a
@@ -332,14 +678,16 @@
         )                                                                    \
     >                                                                        \
     BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(                                  \
-        BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))                    \
+        BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))                    \
     )                                                                        \
     inline typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(                    \
-        BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))                    \
+        BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))                    \
+      , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))                    \
     )<                                                                       \
         typename ::boost::parameter::aux::argument_pack<                     \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))            \
+                BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))            \
+              , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))            \
             )                                                                \
           , BOOST_PARAMETER_AUX_PP_BINARY_SEQ_TO_ARGS(                       \
                 BOOST_PP_SEQ_TAIL(seq), (ParameterArgumentType)              \
@@ -347,27 +695,33 @@
         >::type                                                              \
     >::type                                                                  \
     BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                    \
-        BOOST_PP_TUPLE_ELEM(3, 0, BOOST_PP_SEQ_HEAD(seq))                    \
+        BOOST_PP_TUPLE_ELEM(4, 0, BOOST_PP_SEQ_HEAD(seq))                    \
     )(                                                                       \
         BOOST_PARAMETER_AUX_PP_BINARY_SEQ_TO_ARGS(                           \
             BOOST_PP_SEQ_TAIL(seq), (ParameterArgumentType)(a)               \
         )                                                                    \
         BOOST_PARAMETER_FUNCTION_FORWARD_MATCH(                              \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))            \
+                BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))            \
+              , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))            \
             )                                                                \
           , BOOST_PP_SEQ_SIZE(BOOST_PP_SEQ_TAIL(seq))                        \
           , ParameterArgumentType                                            \
         )                                                                    \
     ) BOOST_PP_EXPR_IF(                                                      \
-        BOOST_PP_TUPLE_ELEM(3, 2, BOOST_PP_SEQ_HEAD(seq)), const             \
+        BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq)), const             \
     )                                                                        \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
-            BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))                \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PP_TUPLE_ELEM(4, 2, BOOST_PP_SEQ_HEAD(seq))                \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                \
+            BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))                \
+          , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))                \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))            \
+                BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))            \
+              , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))            \
             )()(                                                             \
                 BOOST_PP_ENUM_PARAMS(                                        \
                     BOOST_PP_SEQ_SIZE(BOOST_PP_SEQ_TAIL(seq)), a             \
@@ -402,8 +756,6 @@
     )(z, n, (BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_R)(data))
 /**/
 
-#include <boost/preprocessor/repetition/repeat_from_to.hpp>
-
 // Helper macro for BOOST_PARAMETER_CONSTRUCTOR_OVERLOADS.
 #define BOOST_PARAMETER_CONSTRUCTOR_OVERLOADS_AUX(class_, base, range)       \
     BOOST_PP_REPEAT_FROM_TO(                                                 \
@@ -415,12 +767,21 @@
 /**/
 
 // Helper macro for BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(name, impl, range, c) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(nm, impl, r, is_m, c) \
     BOOST_PP_REPEAT_FROM_TO(                                                 \
-        BOOST_PP_TUPLE_ELEM(2, 0, range)                                     \
-      , BOOST_PP_TUPLE_ELEM(2, 1, range)                                     \
+        BOOST_PP_TUPLE_ELEM(2, 0, r)                                         \
+      , BOOST_PP_TUPLE_ELEM(2, 1, r)                                         \
       , BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_Z                          \
-      , (name, impl, c)                                                      \
+      , (                                                                    \
+            nm                                                               \
+          , impl                                                             \
+          , BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_MEMBER_FUNCTION_IS_STATIC(impl)              \
+              , 0                                                            \
+              , is_m                                                         \
+            )                                                                \
+          , c                                                                \
+        )                                                                    \
     )
 /**/
 
@@ -438,12 +799,13 @@
 
 // Expands to the layer of forwarding functions for the function with the
 // specified name, whose arguments determine the range of arities.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, args, const_) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, a, is_m, c)   \
     BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(                          \
         name                                                                 \
       , impl                                                                 \
-      , BOOST_PARAMETER_ARITY_RANGE(args)                                    \
-      , const_                                                               \
+      , BOOST_PARAMETER_ARITY_RANGE(a)                                       \
+      , is_m                                                                 \
+      , c                                                                    \
     )
 /**/
 

--- a/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_layer.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_layer.hpp
@@ -281,7 +281,10 @@
     BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_TPL(n, x)                         \
     inline BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_PRN(n, x, 0, 0)            \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                      \
             static_cast<ResultType(*)()>(BOOST_TTI_DETAIL_NULLPTR)           \
           , args                                                             \
           , 0L                                                               \
@@ -304,7 +307,10 @@
     BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_TPL(n, x)                         \
     inline BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_PRN(n, x, 1, 0)            \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                      \
             static_cast<ResultType(*)()>(BOOST_TTI_DETAIL_NULLPTR)           \
           , args                                                             \
           , 0L                                                               \
@@ -331,7 +337,10 @@
     BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_TPL(n, x)                         \
     inline BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_PRN(n, x, 0, 1)            \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 1)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 1)(                      \
             static_cast<ResultType(*)()>(BOOST_TTI_DETAIL_NULLPTR)           \
           , (args                                                            \
               , BOOST_PARAMETER_FUNCTION_DISPATCH_DEFAULT(                   \
@@ -357,7 +366,7 @@
 
 // x is a tuple:
 //
-//   (base_name, split_args, is_const, tag_namespace)
+//   (base_name, split_args, is_member, is_const, tag_namespace)
 //
 // Generates all dispatch functions for the function named base_name.  Each
 // dispatch function that takes in n optional parameters passes the default
@@ -391,15 +400,21 @@
         BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
     ) inline typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(                  \
         BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
+      , BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                        \
     )<Args>::type BOOST_PARAMETER_FUNCTION_IMPL_NAME(                        \
         BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
+      , BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                        \
     )(Args const& args)                                                      \
     BOOST_PP_EXPR_IF(BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x), const)   \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                      \
             static_cast<                                                     \
                 typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(               \
                     BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)           \
+                  , BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)            \
                 )<Args>::type(*)()                                           \
             >(BOOST_TTI_DETAIL_NULLPTR)                                      \
           , args                                                             \

--- a/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp
@@ -10,19 +10,23 @@
 
 // Accessor macros for the input tuple to the dispatch macros.
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
-    BOOST_PP_TUPLE_ELEM(4, 0, x)
+    BOOST_PP_TUPLE_ELEM(5, 0, x)
 /**/
 
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_SPLIT_ARGS(x)                      \
-    BOOST_PP_TUPLE_ELEM(4, 1, x)
+    BOOST_PP_TUPLE_ELEM(5, 1, x)
+/**/
+
+#define BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                       \
+    BOOST_PP_TUPLE_ELEM(5, 2, x)
 /**/
 
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                        \
-    BOOST_PP_TUPLE_ELEM(4, 2, x)
+    BOOST_PP_TUPLE_ELEM(5, 3, x)
 /**/
 
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_TAG_NAMESPACE(x)                   \
-    BOOST_PP_TUPLE_ELEM(4, 3, x)
+    BOOST_PP_TUPLE_ELEM(5, 4, x)
 /**/
 
 #endif  // include guard

--- a/include/boost/parameter/aux_/preprocessor/impl/function_name.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_name.hpp
@@ -72,18 +72,64 @@
 /**/
 
 // Produces a name for a parameter specification for the function named base.
-#define BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(base)                    \
+#define BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(base, is_const)          \
     BOOST_PP_CAT(                                                            \
-        BOOST_PP_CAT(boost_param_parameters_, __LINE__)                      \
-      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(name)                           \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_parameters_const_                                \
+              , boost_param_parameters_                                      \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
+    )
+/**/
+
+// Produces a name for a result type metafunction for the no-spec function
+// named base.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(base, is_const)         \
+    BOOST_PP_CAT(                                                            \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_no_spec_result_const_                            \
+              , boost_param_no_spec_result_                                  \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )
 /**/
 
 // Produces a name for a result type metafunction for the function named base.
-#define BOOST_PARAMETER_FUNCTION_RESULT_NAME(base)                           \
+#define BOOST_PARAMETER_FUNCTION_RESULT_NAME(base, is_const)                 \
     BOOST_PP_CAT(                                                            \
-        BOOST_PP_CAT(boost_param_result_, __LINE__)                          \
-      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(name)                           \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_result_const_                                    \
+              , boost_param_result_                                          \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
+    )
+/**/
+
+// Produces a name for the implementation function to which the no-spec
+// function named base forwards its result type and argument pack.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(base, is_const)           \
+    BOOST_PP_CAT(                                                            \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_no_spec_impl_const                               \
+              , boost_param_no_spec_impl                                     \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )
 /**/
 
@@ -92,8 +138,14 @@
 // daniel: what? how is that relevant? the reason for using CAT()
 // is to make sure base is expanded. i'm not sure we need to here,
 // but it's more stable to do it.
-#define BOOST_PARAMETER_FUNCTION_IMPL_NAME(base)                             \
-    BOOST_PP_CAT(boost_param_impl, BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base))
+#define BOOST_PARAMETER_FUNCTION_IMPL_NAME(base, is_const)                   \
+    BOOST_PP_CAT(                                                            \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(is_const, boost_param_impl_const, boost_param_impl)  \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
+    )
 /**/
 
 #include <boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp>
@@ -102,8 +154,12 @@
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, n)                         \
     BOOST_PP_CAT(                                                            \
         BOOST_PP_CAT(                                                        \
-            BOOST_PP_CAT(boost_param_dispatch_, n)                           \
-          , BOOST_PP_CAT(boost_, __LINE__)                                   \
+            BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                \
+              , boost_param_dispatch_const_                                  \
+              , boost_param_dispatch_                                        \
+            )                                                                \
+          , BOOST_PP_CAT(BOOST_PP_CAT(n, boost_), __LINE__)                  \
         )                                                                    \
       , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                \
             BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                   \

--- a/include/boost/parameter/aux_/preprocessor/impl/specification.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/specification.hpp
@@ -67,15 +67,23 @@
 
 #include <boost/parameter/parameters.hpp>
 #include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
+#include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 
 // Expands to a boost::parameter::parameters<> specialization for the
 // function named base.  Used by BOOST_PARAMETER_CONSTRUCTOR_AUX and
 // BOOST_PARAMETER_FUNCTION_HEAD for their respective ParameterSpec models.
-#define BOOST_PARAMETER_SPECIFICATION(tag_ns, base, split_args)              \
+#define BOOST_PARAMETER_SPECIFICATION(tag_ns, base, split_args, is_const)    \
     template <typename BoostParameterDummy>                                  \
     struct BOOST_PP_CAT(                                                     \
-        BOOST_PP_CAT(boost_param_params_, __LINE__)                          \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_params_const_                                    \
+              , boost_param_params_                                          \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
       , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     ) : ::boost::parameter::parameters<                                      \
             BOOST_PP_SEQ_FOR_EACH_I(                                         \
@@ -85,7 +93,14 @@
     {                                                                        \
     };                                                                       \
     typedef BOOST_PP_CAT(                                                    \
-        BOOST_PP_CAT(boost_param_params_, __LINE__)                          \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_params_const_                                    \
+              , boost_param_params_                                          \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
       , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )<int>
 /**/

--- a/include/boost/parameter/aux_/preprocessor/no_perfect_forwarding_begin.hpp
+++ b/include/boost/parameter/aux_/preprocessor/no_perfect_forwarding_begin.hpp
@@ -12,8 +12,47 @@
 #define BOOST_PARAMETER_satisfies_end(z, n, false_t) ,false_t>
 /**/
 
-#include <boost/preprocessor/seq/elem.hpp>
 #include <boost/preprocessor/cat.hpp>
+
+#define BOOST_PARAMETER_make_simple_arg_list_type_prefix(z, n, prefix)       \
+    ::boost::parameter::aux::arg_list<BOOST_PP_CAT(prefix, n)
+/**/
+
+#include <boost/preprocessor/repetition/enum.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+
+#define BOOST_PARAMETER_make_simple_arg_list_type(z, n, prefix)              \
+    BOOST_PP_CAT(BOOST_PP_ENUM_, z)(                                         \
+        n, BOOST_PARAMETER_make_simple_arg_list_type_prefix, prefix          \
+    ) BOOST_PP_CAT(BOOST_PP_REPEAT_, z)(n, BOOST_PARAMETER_right_angle, _)
+/**/
+
+#include <boost/parameter/aux_/void.hpp>
+#include <boost/preprocessor/arithmetic/sub.hpp>
+#include <boost/preprocessor/facilities/intercept.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+#include <boost/preprocessor/repetition/enum_trailing_params.hpp>
+
+#define BOOST_PARAMETER_make_simple_arg_list_function_call_op(z, n, prefix)  \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename prefix)>                 \
+    inline BOOST_PARAMETER_make_simple_arg_list_type(z, n, prefix)           \
+        operator()(                                                          \
+            BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, prefix, const& a)            \
+        ) const                                                              \
+    {                                                                        \
+        return BOOST_PARAMETER_make_simple_arg_list_type(z, n, prefix)(      \
+            BOOST_PP_ENUM_PARAMS_Z(z, n, a)                                  \
+            BOOST_PP_ENUM_TRAILING_PARAMS_Z(                                 \
+                z                                                            \
+              , BOOST_PP_SUB(BOOST_PARAMETER_MAX_ARITY, n)                   \
+              , ::boost::parameter::aux::void_reference() BOOST_PP_INTERCEPT \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+
+#include <boost/preprocessor/seq/elem.hpp>
 
 // Generates:
 //
@@ -30,9 +69,7 @@
         BOOST_PP_CAT(BOOST_PP_SEQ_ELEM(2, names), n),
 /**/
 
-#include <boost/parameter/aux_/void.hpp>
 #include <boost/mpl/identity.hpp>
-#include <boost/preprocessor/repetition/repeat.hpp>
 
 #define BOOST_PARAMETER_build_arg_list(n, make, param_spec, arg_type)        \
     BOOST_PP_REPEAT(                                                         \
@@ -94,19 +131,12 @@
     >
 /**/
 
-#include <boost/preprocessor/arithmetic/sub.hpp>
-
 #define BOOST_PARAMETER_function_call_arg_pack_init(z, n, limit)             \
     BOOST_PP_CAT(a, BOOST_PP_SUB(limit, n))
 /**/
 
 #include <boost/parameter/aux_/preprocessor/binary_seq_to_args.hpp>
 #include <boost/preprocessor/arithmetic/dec.hpp>
-#include <boost/preprocessor/facilities/intercept.hpp>
-#include <boost/preprocessor/repetition/enum.hpp>
-#include <boost/preprocessor/repetition/enum_params.hpp>
-#include <boost/preprocessor/repetition/enum_binary_params.hpp>
-#include <boost/preprocessor/repetition/enum_trailing_params.hpp>
 #include <boost/preprocessor/seq/seq.hpp>
 
 #define BOOST_PARAMETER_function_call_op_overload_R(r, seq)                  \

--- a/include/boost/parameter/aux_/preprocessor/no_perfect_forwarding_end.hpp
+++ b/include/boost/parameter/aux_/preprocessor/no_perfect_forwarding_end.hpp
@@ -19,6 +19,9 @@
 #undef BOOST_PARAMETER_make_deduced_list
 #undef BOOST_PARAMETER_build_arg_list
 #undef BOOST_PARAMETER_make_arg_list
+#undef BOOST_PARAMETER_make_simple_arg_list_function_call_op
+#undef BOOST_PARAMETER_make_simple_arg_list_type
+#undef BOOST_PARAMETER_make_simple_arg_list_type_prefix
 #undef BOOST_PARAMETER_satisfies_end
 #undef BOOST_PARAMETER_right_angle
 

--- a/include/boost/parameter/config.hpp
+++ b/include/boost/parameter/config.hpp
@@ -15,13 +15,9 @@
 // SFINAE support, needed explicitly by tagged_argument & keyword & cast;
 // correct function template ordering, needed by the code generation macros;
 // rvalue references, needed throughout; variadic templates, needed by
-// parameters; function template default arguments, needed by the code
-// generation macros; and the ability to handle multiple parameter packs,
-// needed by parameters.  Older versions of GCC either don't have the latter
-// ability or cannot disambiguate between keyword's overloaded
-// operators.  Older versions of Clang either fail to compile due to
-// differences in length between parameter packs 'Args' and 'args' or fail at
-// runtime due to segmentation faults.
+// parameters; and the ability to handle multiple parameter packs, needed by
+// parameters.  Older versions of GCC either don't have the latter ability or
+// cannot disambiguate between keyword's overloaded operators.
 // -- Cromwell D. Enage
 #if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
     !defined(BOOST_PARAMETER_DISABLE_PERFECT_FORWARDING) && \
@@ -29,14 +25,8 @@
     !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING) && \
     !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
     !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && \
-    !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && !( \
-        defined(BOOST_CLANG) && (1 == BOOST_CLANG) && ( \
-            (__clang_major__ < 3) || ( \
-                (3 == __clang_major__) && (__clang_minor__ < 2) \
-            ) \
-        ) \
-    ) && !BOOST_WORKAROUND(BOOST_GCC, < 40900)
+    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
+    !BOOST_WORKAROUND(BOOST_GCC, < 40900)
 #define BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 #endif
 

--- a/include/boost/parameter/config.hpp
+++ b/include/boost/parameter/config.hpp
@@ -15,9 +15,13 @@
 // SFINAE support, needed explicitly by tagged_argument & keyword & cast;
 // correct function template ordering, needed by the code generation macros;
 // rvalue references, needed throughout; variadic templates, needed by
-// parameters; and the ability to handle multiple parameter packs, needed by
-// parameters.  Older versions of GCC either don't have the latter ability or
-// cannot disambiguate between keyword's overloaded operators.
+// parameters; function template default arguments, needed by the code
+// generation macros; and the ability to handle multiple parameter packs,
+// needed by parameters.  Older versions of GCC either don't have the latter
+// ability or cannot disambiguate between keyword's overloaded
+// operators.  Older versions of Clang either fail to compile due to
+// differences in length between parameter packs 'Args' and 'args' or fail at
+// runtime due to segmentation faults.
 // -- Cromwell D. Enage
 #if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
     !defined(BOOST_PARAMETER_DISABLE_PERFECT_FORWARDING) && \
@@ -25,8 +29,14 @@
     !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING) && \
     !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
     !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
-    !BOOST_WORKAROUND(BOOST_GCC, < 40900)
+    !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) && \
+    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && !( \
+        defined(BOOST_CLANG) && (1 == BOOST_CLANG) && ( \
+            (__clang_major__ < 3) || ( \
+                (3 == __clang_major__) && (__clang_minor__ < 2) \
+            ) \
+        ) \
+    ) && !BOOST_WORKAROUND(BOOST_GCC, < 40900)
 #define BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 #endif
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -591,6 +591,17 @@ alias parameter_macros_eval_category
 
 alias parameter_evaluate_category_10
     :
+    [ run evaluate_category_10.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=10
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
+        :
+            evaluate_category_10_gcc_4_8_linux
+        :
+            <preserve-target-tests>off
+    ]
     :
         <target-os>linux
         <toolset>gcc
@@ -599,16 +610,17 @@ alias parameter_evaluate_category_10
 
 alias parameter_evaluate_category_10
     :
-    :
-        # This test fails for xcode 7.3.0 on osx
-        # so we turn off this test for this compiler for now
-        <target-os>darwin
-        <cxxstd>03
-        # TODO: Differentiate by xcode version or by clang version
-    ;
-
-alias parameter_evaluate_category_10
-    :
+    [ run evaluate_category_10.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=10
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
+        :
+            evaluate_category_10_mingw
+        :
+            <preserve-target-tests>off
+    ]
     :
         <target-os>windows
         <toolset>gcc
@@ -664,40 +676,17 @@ alias parameter_evaluate_category_10
 
 alias parameter_preprocessor_eval_cat_8
     :
-    :
-        <target-os>linux
-        <toolset>gcc
-        <toolset-gcc:version>4.8
-    ;
-
-alias parameter_preprocessor_eval_cat_8
-    :
-    :
-        <target-os>linux
-        <toolset>gcc
-        <toolset-gcc:version>4.9
-    ;
-
-alias parameter_preprocessor_eval_cat_8
-    :
-    :
-        <target-os>linux
-        <toolset>gcc
-        <cxxstd>03
-    ;
-
-alias parameter_preprocessor_eval_cat_8
-    :
-    :
-        # This test fails for xcode 7.3.0 and xcode 8.3.0 on osx
-        # so we turn off this test for this compiler for now
-        <target-os>darwin
-        <cxxstd>03
-        # TODO: Differentiate by xcode version or by clang version
-    ;
-
-alias parameter_preprocessor_eval_cat_8
-    :
+    [ run preprocessor_eval_cat_8.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
+        :
+            preproc_eval_cat_8_mingw
+        :
+            <preserve-target-tests>off
+    ]
     :
         <target-os>windows
         <toolset>gcc

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -81,6 +81,15 @@ alias parameter_standard_tests
         :
             <preserve-target-tests>off
     ]
+    [ run preprocessor_eval_cat_no_spec.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+        :
+        :
+            <preserve-target-tests>off
+    ]
     [ run normalized_argument_types.cpp
         :
         :
@@ -127,6 +136,15 @@ alias parameter_standard_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run parameterized_inheritance.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=3
         :
         :
             <preserve-target-tests>off
@@ -179,11 +197,15 @@ alias parameter_standard_tests
     [ compile function_type_tpl_param.cpp ]
     [ compile-fail duplicates.cpp
         :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
         :
             duplicates_fail
     ]
     [ compile-fail deduced_unmatched_arg.cpp
         :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
         :
             deduced_unmatched_arg_fail
     ]
@@ -217,6 +239,8 @@ alias parameter_standard_tests
     ]
     [ compile-fail deduced.cpp
         :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE
         :
             deduced_fail
@@ -726,11 +750,56 @@ alias parameter_msvc_fail_tests ;
 
 alias parameter_msvc_fail_tests
     :
+    [ compile-fail preprocessor_deduced.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_deduced_msvc08_fail
+    ]
+    :
+        <toolset>msvc
+        <toolset-msvc:version>8.0
+    ;
+
+alias parameter_msvc_fail_tests
+    :
+    [ compile-fail preprocessor_deduced.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_deduced_msvc09_fail
+    ]
+    :
+        <toolset>msvc
+        <toolset-msvc:version>9.0
+    ;
+
+alias parameter_msvc_fail_tests
+    :
+    [ compile-fail preprocessor_deduced.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_deduced_msvc10_fail
+    ]
+    :
+        <toolset>msvc
+        <toolset-msvc:version>10.0
+    ;
+
+alias parameter_msvc_fail_tests
+    :
     [ compile-fail compose.cpp
         :
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
-            compose_msvc11_fail_11
+            compose_msvc11_fail
+    ]
+    [ compile-fail preprocessor_deduced.cpp
+        :
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_deduced_msvc11_fail
     ]
     :
         <toolset>msvc
@@ -755,6 +824,13 @@ alias parameter_msvc_fail_tests
         :
             preproc_eval_cat_msvc12_fail
     ]
+    [ compile-fail preprocessor_eval_cat_no_spec.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_eval_cat_no_spec_msvc12_fail
+    ]
     :
         <toolset>msvc
         <toolset-msvc:version>12.0
@@ -778,6 +854,13 @@ alias parameter_msvc_fail_tests
         :
             preproc_eval_cat_msvc14_0_fail
     ]
+    [ compile-fail preprocessor_eval_cat_no_spec.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_eval_cat_no_spec_msvc14_0_fail
+    ]
     :
         <toolset>msvc
         <toolset-msvc:version>14.0
@@ -800,6 +883,13 @@ alias parameter_msvc_fail_tests
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
             preproc_eval_cat_msvc14_1_fail
+    ]
+    [ compile-fail preprocessor_eval_cat_no_spec.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_eval_cat_no_spec_msvc14_1_fail
     ]
     :
         <toolset>msvc

--- a/test/evaluate_category_10.cpp
+++ b/test/evaluate_category_10.cpp
@@ -5,12 +5,11 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_MAX_ARITY < 10)
+#if (BOOST_PARAMETER_MAX_ARITY < 10)
 #error Define BOOST_PARAMETER_MAX_ARITY as 10 or greater.
 #endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -28,9 +27,32 @@ namespace test {
     BOOST_PARAMETER_NAME((_lrc2, keywords) in(lrc2))
     BOOST_PARAMETER_NAME((_lr2, keywords) out(lr2))
     BOOST_PARAMETER_NAME((_rr2, keywords) rr2)
+} // namespace test
+
+#include <boost/parameter/parameters.hpp>
+
+#if ( \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+        !defined(__MINGW32__) \
+    ) || ( \
+        !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+        (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY) \
+    )
+#include <boost/parameter/required.hpp>
+#include <boost/parameter/optional.hpp>
+#endif
+
+namespace test {
 
     struct g_parameters
       : boost::parameter::parameters<
+#if ( \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+        !defined(__MINGW32__) \
+    ) || ( \
+        !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+        (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY) \
+    )
             boost::parameter::required<test::keywords::lrc0>
           , boost::parameter::required<test::keywords::lr0>
           , boost::parameter::required<test::keywords::rrc0>
@@ -41,6 +63,7 @@ namespace test {
           , boost::parameter::optional<test::keywords::lrc2>
           , boost::parameter::optional<test::keywords::lr2>
           , boost::parameter::optional<test::keywords::rr2>
+#endif
         >
     {
     };
@@ -58,67 +81,67 @@ namespace test {
         {
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_lrc0])
+              , test::U::evaluate_category<0>(args[test::_lrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<0>(args[test::_lr0])
+              , test::U::evaluate_category<0>(args[test::_lr0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_lrc1])
+              , test::U::evaluate_category<1>(args[test::_lrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<1>(args[test::_lr1])
+              , test::U::evaluate_category<1>(args[test::_lr1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_lrc2 | test::lvalue_const_bitset<2>()]
                 )
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_lr2 || test::lvalue_bitset_function<2>()]
                 )
             );
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rrc0])
+              , test::U::evaluate_category<0>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference
-              , U::evaluate_category<0>(args[test::_rr0])
+              , test::U::evaluate_category<0>(args[test::_rr0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_rrc1])
+              , test::U::evaluate_category<1>(args[test::_rrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_rr2 || test::rvalue_bitset_function<2>()]
                 )
             );
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rrc0])
+              , test::U::evaluate_category<0>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rr0])
+              , test::U::evaluate_category<0>(args[test::_rr0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_rrc1])
+              , test::U::evaluate_category<1>(args[test::_rrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_rr2 || test::rvalue_bitset_function<2>()]
                 )
             );
@@ -129,13 +152,38 @@ namespace test {
 
 #if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #include <boost/parameter/aux_/as_lvalue.hpp>
-#include <boost/core/ref.hpp>
 #endif
 
 int main()
 {
-#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) || \
-    (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY)
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if defined(__MINGW32__)
+    test::C::evaluate(
+        test::g_parameters()(
+            test::_rrc1 = test::rvalue_const_bitset<1>()
+          , test::_lrc0 = test::lvalue_const_bitset<0>()
+          , test::_lr0 = test::lvalue_bitset<0>()
+          , test::_rrc0 = test::rvalue_const_bitset<0>()
+          , test::_rr0 = test::rvalue_bitset<0>()
+          , test::_lrc1 = test::lvalue_const_bitset<1>()
+          , test::_lr1 = test::lvalue_bitset<1>()
+        )
+    );
+    test::C::evaluate(
+        test::g_parameters()(
+            test::_lr0 = test::lvalue_bitset<0>()
+          , test::_rrc0 = test::rvalue_const_bitset<0>()
+          , test::_rr0 = test::rvalue_bitset<0>()
+          , test::_lrc1 = test::lvalue_const_bitset<1>()
+          , test::_lr1 = test::lvalue_bitset<1>()
+          , test::_rrc1 = test::rvalue_const_bitset<1>()
+          , test::_lrc2 = test::lvalue_const_bitset<2>()
+          , test::_lr2 = test::lvalue_bitset<2>()
+          , test::_rr2 = test::rvalue_bitset<2>()
+          , test::_lrc0 = test::lvalue_const_bitset<0>()
+        )
+    );
+#else   // !defined(__MINGW32__)
     test::C::evaluate(
         test::g_parameters()(
             test::lvalue_const_bitset<0>()
@@ -161,33 +209,68 @@ int main()
           , test::rvalue_bitset<2>()
         )
     );
-#else   // no perfect forwarding support and no exponential overloads
+#endif  // __MINGW32__
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY)
     test::C::evaluate(
         test::g_parameters()(
             test::lvalue_const_bitset<0>()
-          , boost::ref(test::lvalue_bitset<0>())
+          , test::lvalue_bitset<0>()
           , test::rvalue_const_bitset<0>()
           , boost::parameter::aux::as_lvalue(test::rvalue_bitset<0>())
           , test::lvalue_const_bitset<1>()
-          , boost::ref(test::lvalue_bitset<1>())
+          , test::lvalue_bitset<1>()
           , test::rvalue_const_bitset<1>()
         )
     );
     test::C::evaluate(
         test::g_parameters()(
             test::lvalue_const_bitset<0>()
-          , boost::ref(test::lvalue_bitset<0>())
+          , test::lvalue_bitset<0>()
           , test::rvalue_const_bitset<0>()
           , boost::parameter::aux::as_lvalue(test::rvalue_bitset<0>())
           , test::lvalue_const_bitset<1>()
-          , boost::ref(test::lvalue_bitset<1>())
+          , test::lvalue_bitset<1>()
           , test::rvalue_const_bitset<1>()
           , test::lvalue_const_bitset<2>()
-          , boost::ref(test::lvalue_bitset<2>())
+          , test::lvalue_bitset<2>()
           , boost::parameter::aux::as_lvalue(test::rvalue_bitset<2>())
         )
     );
-#endif  // perfect forwarding support, or exponential overloads
+#else   // !(10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY)
+    test::C::evaluate(
+        test::g_parameters()(
+            test::_lrc0 = test::lvalue_const_bitset<0>()
+          , test::_lr0 = test::lvalue_bitset<0>()
+          , test::_rrc0 = test::rvalue_const_bitset<0>()
+          , test::_rr0 = boost::parameter::aux::as_lvalue(
+                test::rvalue_bitset<0>()
+            )
+          , test::_lrc1 = test::lvalue_const_bitset<1>()
+          , test::_lr1 = test::lvalue_bitset<1>()
+          , test::_rrc1 = test::rvalue_const_bitset<1>()
+        )
+    );
+    test::C::evaluate(
+        test::g_parameters()(
+            test::_lrc0 = test::lvalue_const_bitset<0>()
+          , test::_lr0 = test::lvalue_bitset<0>()
+          , test::_rrc0 = test::rvalue_const_bitset<0>()
+          , test::_rr0 = boost::parameter::aux::as_lvalue(
+                test::rvalue_bitset<0>()
+            )
+          , test::_lrc1 = test::lvalue_const_bitset<1>()
+          , test::_lr1 = test::lvalue_bitset<1>()
+          , test::_rrc1 = test::rvalue_const_bitset<1>()
+          , test::_lrc2 = test::lvalue_const_bitset<2>()
+          , test::_lr2 = test::lvalue_bitset<2>()
+          , test::_rr2 = boost::parameter::aux::as_lvalue(
+                test::rvalue_bitset<2>()
+            )
+        )
+    );
+#endif  // (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY)
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
     return boost::report_errors();
 }
 

--- a/test/parameterized_inheritance.cpp
+++ b/test/parameterized_inheritance.cpp
@@ -1,0 +1,263 @@
+// Copyright Cromwell D. Enage 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/parameter/config.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 3)
+#error Define BOOST_PARAMETER_MAX_ARITY as 3 or greater.
+#endif
+
+#include <boost/parameter/name.hpp>
+
+namespace test {
+
+    BOOST_PARAMETER_NAME(a0)
+    BOOST_PARAMETER_NAME(a1)
+    BOOST_PARAMETER_NAME(a2)
+}
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/parameter/is_argument_pack.hpp>
+#include <boost/type_traits/is_convertible.hpp>
+#include <boost/core/enable_if.hpp>
+#endif
+
+namespace test {
+
+#if !defined(BOOST_NO_SFINAE)
+    struct _enabler
+    {
+    };
+#endif
+
+    template <typename T>
+    class backend0
+    {
+        T _a0;
+
+     public:
+        template <typename ArgPack>
+        explicit backend0(
+            ArgPack const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::enable_if<
+                boost::parameter::is_argument_pack<ArgPack>
+              , test::_enabler
+            >::type = test::_enabler()
+#endif
+        ) : _a0(args[test::_a0])
+        {
+        }
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename U>
+        backend0(
+            backend0<U> const& copy
+          , typename boost::enable_if<
+                boost::is_convertible<U,T>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : _a0(copy.get_a0())
+        {
+        }
+#endif
+
+        template <typename Iterator>
+        backend0(Iterator itr, Iterator itr_end) : _a0(itr, itr_end)
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->_a0;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            this->_a0 = args[test::_a0];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend1 : public B
+    {
+        T _a1;
+
+     public:
+        template <typename ArgPack>
+        explicit backend1(
+            ArgPack const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::enable_if<
+                boost::parameter::is_argument_pack<ArgPack>
+              , test::_enabler
+            >::type = test::_enabler()
+#endif
+        ) : B(args), _a1(args[test::_a1])
+        {
+        }
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename Derived>
+        backend1(
+            Derived const& copy
+          , typename boost::disable_if<
+                boost::parameter::is_argument_pack<Derived>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : B(copy), _a1(copy.get_a1())
+        {
+        }
+#endif
+
+        T const& get_a1() const
+        {
+            return this->_a1;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->_a1 = args[test::_a1];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend2 : public B
+    {
+        T _a2;
+
+     public:
+        template <typename ArgPack>
+        explicit backend2(
+            ArgPack const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::enable_if<
+                boost::parameter::is_argument_pack<ArgPack>
+              , test::_enabler
+            >::type = test::_enabler()
+#endif
+        ) : B(args), _a2(args[test::_a2])
+        {
+        }
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename Derived>
+        backend2(
+            Derived const& copy
+          , typename boost::disable_if<
+                boost::parameter::is_argument_pack<Derived>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : B(copy), _a2(copy.get_a2())
+        {
+        }
+#endif
+
+        T const& get_a2() const
+        {
+            return this->_a2;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->_a2 = args[test::_a2];
+        }
+    };
+}
+
+#include <boost/parameter/preprocessor.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/parameter/are_tagged_arguments.hpp>
+#endif
+
+namespace test {
+
+    template <typename B>
+    struct frontend : public B
+    {
+        BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(frontend, (B))
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename Iterator>
+        frontend(
+            Iterator itr
+          , Iterator itr_end
+          , typename boost::disable_if<
+                boost::parameter::are_tagged_arguments<Iterator>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : B(itr, itr_end)
+        {
+        }
+
+        template <typename O>
+        frontend(frontend<O> const& copy) : B(copy)
+        {
+        }
+#endif
+
+        BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((void), initialize)
+        {
+            this->initialize_impl(args);
+        }
+
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR((void))
+        {
+            this->initialize_impl(args);
+        }
+    };
+} // namespace test
+
+#include <boost/core/lightweight_test.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <string>
+#endif
+
+int main()
+{
+    char const* p = "foo";
+    char const* q = "bar";
+    test::frontend<
+        test::backend2<test::backend1<test::backend0<char const*>, char>, int>
+    > composed_obj0(test::_a2 = 4, test::_a1 = ' ', test::_a0 = p);
+#if defined(BOOST_NO_SFINAE)
+    test::frontend<
+        test::backend1<test::backend2<test::backend0<char const*>, int>, char>
+    > composed_obj1(test::_a0 = p, test::_a1 = ' ', test::_a2 = 4);
+#else
+    test::frontend<
+        test::backend1<test::backend2<test::backend0<char const*>, int>, char>
+    > composed_obj1(composed_obj0);
+#endif
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+    composed_obj0.initialize(test::_a0 = q, test::_a1 = '!', test::_a2 = 8);
+    composed_obj1.initialize(test::_a2 = 8, test::_a1 = '!', test::_a0 = q);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+    composed_obj0(test::_a2 = 8, test::_a1 = '!', test::_a0 = q);
+    composed_obj1(test::_a0 = q, test::_a1 = '!', test::_a2 = 8);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+#if !defined(BOOST_NO_SFINAE)
+    test::frontend<test::backend0<std::string> > string_wrap(p, p + 3);
+    BOOST_TEST_EQ(string_wrap.get_a0(), std::string(p));
+#endif
+    return boost::report_errors();
+}
+

--- a/test/preprocessor_eval_cat_8.cpp
+++ b/test/preprocessor_eval_cat_8.cpp
@@ -5,12 +5,11 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_MAX_ARITY < 8)
+#if (BOOST_PARAMETER_MAX_ARITY < 8)
 #error Define BOOST_PARAMETER_MAX_ARITY as 8 or greater.
 #endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -28,6 +27,7 @@ namespace test {
     BOOST_PARAMETER_NAME((_rr1, kw) rr1)
 } // namespace test
 
+#include <boost/parameter/preprocessor.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/if.hpp>
@@ -35,7 +35,7 @@ namespace test {
 #include <boost/type_traits/is_convertible.hpp>
 #include "evaluate_category.hpp"
 
-#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if !defined(__MINGW32__) && defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #include <utility>
 #endif
 
@@ -43,6 +43,10 @@ namespace test {
 
     struct C
     {
+#if ( \
+        !defined(__MINGW32__) && \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) \
+    ) || defined(BOOST_MSVC)
         typedef boost::mpl::if_<
             boost::is_convertible<boost::mpl::_,std::bitset<1> >
           , boost::mpl::true_
@@ -100,57 +104,130 @@ namespace test {
                 )
             )
         )
+#else
+        BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR((bool))
+#endif  // msvc, or perfect forwarding support and not mingw
         {
+#if ( \
+        !defined(__MINGW32__) && \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) \
+    ) || defined(BOOST_MSVC)
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(lrc0)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<0>(lrc0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference
-              , U::evaluate_category<1>(lr0)
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<1>(lr0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<4>(lrc1)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<4>(lrc1)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference
-              , U::evaluate_category<5>(lr1)
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<5>(lr1)
             );
+#else   // mingw, or no perfect forwarding support and not msvc
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<0>(args[test::_lrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<1>(args[test::_lr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<4>(args[test::_lrc1])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<5>(
+                    args[test::_lr1 | test::lvalue_bitset<5>()]
+                )
+            );
+#endif  // msvc, or perfect forwarding support and not mingw
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if defined(__MINGW32__)
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference_to_const
-              , U::evaluate_category<2>(std::forward<rrc0_type>(rrc0))
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference
-              , U::evaluate_category<3>(std::forward<rr0_type>(rr0))
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<3>(args[test::_rr0])
             );
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference_to_const
-              , U::evaluate_category<6>(std::forward<rrc1_type>(rrc1))
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
             );
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference
-              , U::evaluate_category<7>(std::forward<rr1_type>(rr1))
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
             );
+#else   // !defined(__MINGW32__)
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<2>(std::forward<rrc0_type>(rrc0))
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<3>(std::forward<rr0_type>(rr0))
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<6>(std::forward<rrc1_type>(rrc1))
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<7>(std::forward<rr1_type>(rr1))
+            );
+#endif  // __MINGW32__
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if defined(BOOST_MSVC)
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(rrc0)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<2>(rrc0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<3>(rr0)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<3>(rr0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<6>(rrc1)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<6>(rrc1)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<7>(rr1)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<7>(rr1)
             );
+#else   // !defined(BOOST_MSVC)
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<3>(args[test::_rr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
+            );
+#endif  // BOOST_MSVC
 #endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 
             return true;
@@ -163,6 +240,10 @@ int main()
     test::C cp0;
     test::C cp1;
 
+#if ( \
+        !defined(__MINGW32__) && \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) \
+    ) || defined(BOOST_MSVC)
     cp0(
         test::lvalue_const_bitset<4>()
       , test::lvalue_const_bitset<0>()
@@ -188,6 +269,33 @@ int main()
       , test::rvalue_bitset<7>()
       , test::lvalue_const_bitset<0>()
     );
+#else   // mingw, or no perfect forwarding support and not msvc
+    cp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    cp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    cp1(
+        test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+      , test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lr1 = test::lvalue_bitset<5>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_rr1 = test::rvalue_bitset<7>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+    );
+#endif  // msvc, or perfect forwarding support and not mingw
     return boost::report_errors();
 }
 

--- a/test/preprocessor_eval_cat_no_spec.cpp
+++ b/test/preprocessor_eval_cat_no_spec.cpp
@@ -1,0 +1,520 @@
+// Copyright Cromwell D. Enage 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/parameter/config.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 8)
+#error Define BOOST_PARAMETER_MAX_ARITY as 8 or greater.
+#endif
+
+#include <boost/parameter/name.hpp>
+
+namespace test {
+
+    BOOST_PARAMETER_NAME((_lrc0, kw0) in(lrc0))
+    BOOST_PARAMETER_NAME((_lr0, kw1) in_out(lr0))
+    BOOST_PARAMETER_NAME((_rrc0, kw2) in(rrc0))
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+    BOOST_PARAMETER_NAME((_rr0, kw3) consume(rr0))
+#else
+    BOOST_PARAMETER_NAME((_rr0, kw3) rr0)
+#endif
+    BOOST_PARAMETER_NAME((_lrc1, kw4) in(lrc1))
+    BOOST_PARAMETER_NAME((_lr1, kw5) out(lr1))
+    BOOST_PARAMETER_NAME((_rrc1, kw6) in(rrc1))
+    BOOST_PARAMETER_NAME((_rr1, kw7) rr1)
+} // namespace test
+
+#include <boost/parameter/preprocessor.hpp>
+#include <boost/parameter/value_type.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/type_traits/is_scalar.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include "evaluate_category.hpp"
+
+namespace test {
+
+    BOOST_PARAMETER_NO_SPEC_FUNCTION((bool), evaluate)
+    {
+        BOOST_TEST((
+            test::passed_by_lvalue_reference_to_const == test::A<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw0::lrc0
+                    >::type
+                >::type
+            >::evaluate_category(args[test::_lrc0])
+        ));
+        BOOST_TEST((
+            test::passed_by_lvalue_reference == test::A<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw1::lr0
+                    >::type
+                >::type
+            >::evaluate_category(args[test::_lr0])
+        ));
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+        if (
+            boost::is_scalar<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw2::rrc0
+                    >::type
+                >::type
+            >::value
+        )
+        {
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw2::rrc0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rrc0])
+            ));
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw3::rr0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rr0])
+            ));
+        }
+        else // rrc0's value type isn't scalar
+        {
+            BOOST_TEST((
+                test::passed_by_rvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw2::rrc0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rrc0])
+            ));
+            BOOST_TEST((
+                test::passed_by_rvalue_reference == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw3::rr0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rr0])
+            ));
+        }
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+        BOOST_TEST((
+            test::passed_by_lvalue_reference_to_const == test::A<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw2::rrc0
+                    >::type
+                >::type
+            >::evaluate_category(args[test::_rrc0])
+        ));
+        BOOST_TEST((
+            test::passed_by_lvalue_reference_to_const == test::A<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw3::rr0
+                    >::type
+                >::type
+            >::evaluate_category(args[test::_rr0])
+        ));
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+
+        return true;
+    }
+} // namespace test
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+#endif
+
+namespace test {
+
+    char const* baz = "baz";
+
+    struct B
+    {
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
+        B()
+        {
+        }
+#endif
+
+        template <typename Args>
+        explicit B(
+            Args const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::disable_if<
+                typename boost::mpl::if_<
+                    boost::is_base_of<B,Args>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >::type
+            >::type* = BOOST_TTI_DETAIL_NULLPTR
+#endif  // BOOST_NO_SFINAE
+        )
+        {
+            test::evaluate(
+                test::_lrc0 = args[test::_lrc0]
+              , test::_lr0 = args[test::_lr0]
+              , test::_rrc0 = args[test::_rrc0]
+              , test::_rr0 = args[test::_rr0]
+            );
+        }
+
+        BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((bool), static evaluate)
+        {
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw0::lrc0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_lrc0])
+            ));
+            BOOST_TEST((
+                test::passed_by_lvalue_reference == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw1::lr0
+                          , char const*
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_lr0 | test::baz])
+            ));
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw2::rrc0
+                          , float
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rrc0 | 0.0f])
+            ));
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST((
+                test::passed_by_rvalue_reference == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw3::rr0
+                          , std::string
+                        >::type
+                    >::type
+                >::evaluate_category(
+                    args[
+                        test::_rr0 | std::string(args[test::_lr0 | test::baz])
+                    ]
+                )
+            ));
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw3::rr0
+                          , std::string
+                        >::type
+                    >::type
+                >::evaluate_category(
+                    args[
+                        test::_rr0 | std::string(args[test::_lr0 | test::baz])
+                    ]
+                )
+            ));
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+
+            return true;
+        }
+    };
+
+    struct C : B
+    {
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
+        C() : B()
+        {
+        }
+#endif
+
+        BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(C, (B))
+    };
+
+    struct D
+    {
+        BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(D, D::_evaluate)
+
+        BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION((bool), evaluate_m)
+        {
+            return D::_evaluate(args);
+        }
+
+        BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR((bool))
+        {
+            return D::_evaluate(args);
+        }
+
+     private:
+        template <typename Args>
+        static bool _evaluate(Args const& args)
+        {
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<0>(args[test::_lrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<1>(args[test::_lr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<4>(args[test::_lrc1])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<5>(
+                    args[test::_lr1 | test::lvalue_bitset<5>()]
+                )
+            );
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<3>(args[test::_rr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
+            );
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<3>(args[test::_rr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
+            );
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+
+            return true;
+        }
+    };
+} // namespace test
+
+int main()
+{
+    test::evaluate(
+        test::_lr0 = test::lvalue_float()
+      , test::_rrc0 = test::rvalue_const_float()
+      , test::_rr0 = test::rvalue_float()
+      , test::_lrc0 = test::lvalue_const_float()
+    );
+    test::evaluate(
+        test::_lr0 = test::lvalue_char_ptr()
+      , test::_rrc0 = test::rvalue_const_char_ptr()
+      , test::_rr0 = test::rvalue_char_ptr()
+      , test::_lrc0 = test::lvalue_const_char_ptr()
+    );
+    test::evaluate(
+        test::_lr0 = test::lvalue_str()
+      , test::_rrc0 = test::rvalue_const_str()
+      , test::_rr0 = test::rvalue_str()
+      , test::_lrc0 = test::lvalue_const_str()
+    );
+
+    test::C cf1(
+        test::_lr0 = test::lvalue_float()
+      , test::_rrc0 = test::rvalue_const_float()
+      , test::_rr0 = test::rvalue_float()
+      , test::_lrc0 = test::lvalue_const_float()
+    );
+    test::C cc1(
+        test::_lr0 = test::lvalue_char_ptr()
+      , test::_rrc0 = test::rvalue_const_char_ptr()
+      , test::_rr0 = test::rvalue_char_ptr()
+      , test::_lrc0 = test::lvalue_const_char_ptr()
+    );
+    test::C cs1(
+        test::_lr0 = test::lvalue_str()
+      , test::_rrc0 = test::rvalue_const_str()
+      , test::_rr0 = test::rvalue_str()
+      , test::_lrc0 = test::lvalue_const_str()
+    );
+
+    char baz_arr[4] = "qux";
+    typedef char char_arr[4];
+
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
+    // MSVC-12+ treats static_cast<char_arr&&>(baz_arr) as an lvalue.
+#else
+    test::evaluate(
+        test::_lr0 = baz_arr
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+      , test::_rrc0 = static_cast<char_arr const&&>("def")
+      , test::_rr0 = static_cast<char_arr&&>(baz_arr)
+#else
+      , test::_rrc0 = "grl"
+      , test::_rr0 = "grp"
+#endif
+      , test::_lrc0 = "wld"
+    );
+#endif  // MSVC-12+
+    test::B::evaluate(test::_lrc0 = test::lvalue_const_str()[0]);
+    test::C::evaluate(
+        test::_rrc0 = test::rvalue_const_float()
+      , test::_lrc0 = test::lvalue_const_str()[0]
+    );
+
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
+    // MSVC-12+ treats static_cast<char_arr&&>(baz_arr) as an lvalue.
+    test::C cp0;
+    test::C cp1;
+#else
+    test::C cp0(
+        test::_lrc0 = "frd"
+      , test::_lr0 = baz_arr
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+      , test::_rrc0 = static_cast<char_arr const&&>("dfs")
+      , test::_rr0 = static_cast<char_arr&&>(baz_arr)
+#else
+      , test::_rrc0 = "plg"
+      , test::_rr0 = "thd"
+#endif
+    );
+    test::C cp1(
+        test::_lr0 = baz_arr
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+      , test::_rrc0 = static_cast<char_arr const&&>("dgx")
+      , test::_rr0 = static_cast<char_arr&&>(baz_arr)
+#else
+      , test::_rrc0 = "hnk"
+      , test::_rr0 = "xzz"
+#endif
+      , test::_lrc0 = "zts"
+    );
+#endif  // MSVC-12+
+
+    cp0.evaluate(
+        test::_lrc0 = test::lvalue_const_str()[0]
+      , test::_lr0 = test::lvalue_char_ptr()
+      , test::_rr0 = test::rvalue_str()
+      , test::_rrc0 = test::rvalue_const_float()
+    );
+    cp1.evaluate(
+        test::_lrc0 = test::lvalue_const_str()[0]
+      , test::_rr0 = test::rvalue_str()
+      , test::_rrc0 = test::rvalue_const_float()
+      , test::_lr0 = test::lvalue_char_ptr()
+    );
+
+    test::D dp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    test::D dp1(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+
+    dp0.evaluate_m(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    dp1.evaluate_m(
+        test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+      , test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lr1 = test::lvalue_bitset<5>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_rr1 = test::rvalue_bitset<7>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+    );
+    dp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    dp1(
+        test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+      , test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lr1 = test::lvalue_bitset<5>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_rr1 = test::rvalue_bitset<7>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+    );
+    return boost::report_errors();
+}
+


### PR DESCRIPTION
* Add variadic metafunction boost::parameter::are_tagged_arguments to help improve overload resolution capabilities. Used by new BOOST_PARAMETER_NO_SPEC_* code generation macros.
* Add code generation macros BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_NO_SPEC_FUNCTION, BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION, BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION, BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR, and BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR.
* Enable function call operator overloads & overloads of the same name to coexist even with deduced arguments.
* Add usage examples to & remove unnecessary implementation details from reference documentation.