### PR TITLE
Update literate tests and tutorial documentation

### DIFF
--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -187,24 +187,24 @@ id="id39">5&nbsp;&nbsp;&nbsp;Portability Considerations</a>
 <li><a class="reference internal" href="#perfect-forwarding-support"
 id="id40">5.1&nbsp;&nbsp;&nbsp;Perfect Forwarding Support</a></li>
 <li><a class="reference internal" href="#no-sfinae-support"
-id="id41">5.2&nbsp;&nbsp;&nbsp;No SFINAE Support</a></li>
+id="id42">5.2&nbsp;&nbsp;&nbsp;No SFINAE Support</a></li>
 <li><a class="reference internal" href="#no-support-for-result-of"
-id="id42">5.3&nbsp;&nbsp;&nbsp;No Support for
+id="id43">5.3&nbsp;&nbsp;&nbsp;No Support for
 <tt class="docutils literal">result_of</tt></a></li>
 <li><a class="reference internal"
 href="#compiler-can-t-see-references-in-unnamed-namespace"
-id="id43">5.4&nbsp;&nbsp;&nbsp;Compiler Can't See References In Unnamed
+id="id44">5.4&nbsp;&nbsp;&nbsp;Compiler Can't See References In Unnamed
 Namespace</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#python-binding"
-id="id44">6&nbsp;&nbsp;&nbsp;Python Binding</a></li>
+id="id45">6&nbsp;&nbsp;&nbsp;Python Binding</a></li>
 <li><a class="reference internal" href="#reference"
-id="id45">7&nbsp;&nbsp;&nbsp;Reference</a></li>
+id="id46">7&nbsp;&nbsp;&nbsp;Reference</a></li>
 <li><a class="reference internal" href="#glossary"
-id="id46">8&nbsp;&nbsp;&nbsp;Glossary</a></li>
+id="id47">8&nbsp;&nbsp;&nbsp;Glossary</a></li>
 <li><a class="reference internal" href="#acknowledgements"
-id="id47">9&nbsp;&nbsp;&nbsp;Acknowledgements</a></li>
+id="id48">9&nbsp;&nbsp;&nbsp;Acknowledgements</a></li>
 </ul>
 </div>
 <hr class="docutils" />
@@ -2621,15 +2621,15 @@ aware of the following issues and workarounds for particular compilers.</p>
 Forwarding Support</a></h2>
 <p>If your compiler supports <a class="reference external" href=
 "http://www.justsoftwaresolutions.co.uk/cplusplus/rvalue_references_and_perfect_forwarding.html"
->perfect forwarding</a>, then the Parameter library will
-<tt class="docutils literal">#define</tt> the macro
-<a class="reference external"
+>perfect forwarding</a>, then the Parameter library will <tt
+class="docutils literal">#define</tt> the macro <a class="reference external"
 href="reference.html#boost-parameter-has-perfect-forwarding"
 ><tt class="docutils literal">BOOST_PARAMETER_HAS_PERFECT_FORWARDING</tt></a>
 unless you disable it manually.  If your compiler does not provide this
 support, then <tt class="docutils literal"
 >parameter::parameters::operator()</tt> will treat rvalue references as lvalue
-const references to work around the <a class="reference external"
+<tt class="docutils literal">const</tt> references to work around the
+<a class="reference external"
 href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2002/n1385.htm"
 >forwarding problem</a>, so in certain cases you must wrap
 <a class="reference external" href="../../../core/doc/html/core/ref.html"
@@ -2645,7 +2645,7 @@ href="../../test/preprocessor_eval_category.cpp"
 support.</p>
 </div>
 <div class="section" id="no-sfinae-support">
-<h2><a class="toc-backref" href="#id41">5.2&nbsp;&nbsp;&nbsp;No SFINAE
+<h2><a class="toc-backref" href="#id42">5.2&nbsp;&nbsp;&nbsp;No SFINAE
 Support</a></h2>
 <p>Some older compilers don't support SFINAE.  If your compiler meets
 that criterion, then Boost headers will
@@ -2655,7 +2655,7 @@ functions won't be removed from the overload set based on their
 signatures.</p>
 </div>
 <div class="section" id="no-support-for-result-of">
-<h2><a class="toc-backref" href="#id42">5.3&nbsp;&nbsp;&nbsp;No Support
+<h2><a class="toc-backref" href="#id43">5.3&nbsp;&nbsp;&nbsp;No Support
 for</a> <a class="reference external"
 href="../../../utility/utility.htm#result_of"
 ><tt class="docutils literal">result_of</tt></a></h2>
@@ -2703,7 +2703,7 @@ are unspecified, the workaround is to use
 .. |BOOST_PARAMETER_MATCH| replace:: ``BOOST_PARAMETER_MATCH`` -->
 </div>
 <div class="section" id="compiler-can-t-see-references-in-unnamed-namespace">
-<h2><a class="toc-backref" href="#id43">5.3&nbsp;&nbsp;&nbsp;Compiler Can't
+<h2><a class="toc-backref" href="#id44">5.4&nbsp;&nbsp;&nbsp;Compiler Can't
 See References In Unnamed Namespace</a></h2>
 <p>If you use Microsoft Visual C++ 6.x, you may find that the compiler has
 trouble finding your keyword objects.  This problem has been observed, but
@@ -2724,7 +2724,7 @@ namespace graphs {
 </div>
 </div>
 <div class="section" id="python-binding">
-<h1><a class="toc-backref" href="#id44">6&nbsp;&nbsp;&nbsp;Python
+<h1><a class="toc-backref" href="#id45">6&nbsp;&nbsp;&nbsp;Python
 Binding</a></h1>
 <p>Follow <a class="reference external"
 href="../../../parameter_python/doc/html/index.html">this link</a> for
@@ -2733,12 +2733,12 @@ with <a class="reference external" href="../../../python/doc/index.html"
 >Boost.Python</a>.</p>
 </div>
 <div class="section" id="reference">
-<h1><a class="toc-backref" href="#id45">7&nbsp;&nbsp;&nbsp;Reference</a></h1>
+<h1><a class="toc-backref" href="#id46">7&nbsp;&nbsp;&nbsp;Reference</a></h1>
 <p>Follow <a class="reference external" href="reference.html">this link</a> to
 the Boost.Parameter reference documentation.</p>
 </div>
 <div class="section" id="glossary">
-<h1><a class="toc-backref" href="#id46">8&nbsp;&nbsp;&nbsp;Glossary</a></h1>
+<h1><a class="toc-backref" href="#id47">8&nbsp;&nbsp;&nbsp;Glossary</a></h1>
 <table class="docutils field-list" frame="void" id="arguments" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -2779,7 +2779,7 @@ int y = f(3);
 </table>
 </div>
 <div class="section" id="acknowledgements">
-<h1><a class="toc-backref" href="#id47"
+<h1><a class="toc-backref" href="#id48"
 >9&nbsp;&nbsp;&nbsp;Acknowledgements</a></h1>
 <p>The authors would like to thank all the Boosters who participated in the
 review of this library and its documentation, most especially our review

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -849,7 +849,7 @@ prints the arguments:</p>
 #include &lt;boost/graph/depth_first_search.hpp&gt;  // for dfs_visitor
 
 BOOST_PARAMETER_FUNCTION(
-    (void), depth_first_search, tag
+    (bool), depth_first_search, tag
     <em>…signature goes here…</em>
 )
 {
@@ -863,16 +863,20 @@ BOOST_PARAMETER_FUNCTION(
     std::cout &lt;&lt; std::endl;
     std::cout &lt;&lt; &quot;color_map=&quot; &lt;&lt; color_map;
     std::cout &lt;&lt; std::endl;
+    return true;
 }
+
+#include &lt;boost/core/lightweight_test.hpp&gt;
 
 int main()
 {
+    char const* g = &quot;1&quot;;
     depth_first_search(1, 2, 3, 4, 5);
-
     depth_first_search(
-        &quot;1&quot;, '2', _color_map = '5',
+        g, '2', _color_map = '5',
         _index_map = &quot;4&quot;, _root_vertex = &quot;3&quot;
     );
+    return boost::report_errors();
 }
 </pre>
 <p class="compound-last">Despite the fact that default expressions such as <tt
@@ -980,14 +984,18 @@ struct vertex_descriptor_predicate
 {
     template &lt;typename T, typename Args&gt;
     struct apply
-      : boost::is_convertible&lt;
-            T
-          , typename boost::graph_traits&lt;
-                typename boost::parameter::value_type&lt;
-                    Args
-                  , graphs::graph
-                &gt;::type
-            &gt;::vertex_descriptor
+      : boost::mpl::if_&lt;
+            boost::is_convertible&lt;
+                T
+              , typename boost::graph_traits&lt;
+                    typename boost::parameter::value_type&lt;
+                        Args
+                      , graphs::graph
+                    &gt;::type
+                &gt;::vertex_descriptor
+            &gt;
+          , boost::mpl::true_
+          , boost::mpl::false_
         &gt;
     {
     };
@@ -1034,15 +1042,20 @@ struct graph_predicate
 {
     template &lt;typename T, typename Args&gt;
     struct apply
-      : boost::mpl::and_&lt;
+      : boost::mpl::eval_if&lt;
             boost::is_convertible&lt;
                 typename boost::graph_traits&lt;T&gt;::traversal_category
               , boost::incidence_graph_tag
             &gt;
-          , boost::is_convertible&lt;
-                typename boost::graph_traits&lt;T&gt;::traversal_category
-              , boost::vertex_list_graph_tag
+          , boost::mpl::if_&lt;
+                boost::is_convertible&lt;
+                    typename boost::graph_traits&lt;T&gt;::traversal_category
+                  , boost::vertex_list_graph_tag
+                &gt;
+              , boost::mpl::true_
+              , boost::mpl::false_
             &gt;
+          , boost::mpl::false_
         &gt;
     {
     };
@@ -1052,18 +1065,22 @@ struct index_map_predicate
 {
     template &lt;typename T, typename Args&gt;
     struct apply
-      : boost::mpl::and_&lt;
+      : boost::mpl::eval_if&lt;
             boost::is_integral&lt;
                 typename boost::property_traits&lt;T&gt;::value_type
             &gt;
-          , boost::is_same&lt;
-                typename boost::property_traits&lt;T&gt;::key_type
-              , typename boost::graph_traits&lt;
-                    typename boost::parameter::value_type&lt;
-                        Args
-                      , graphs::graph
-                    &gt;::type
-                &gt;::vertex_descriptor
+          , boost::mpl::if_&lt;
+                boost::is_same&lt;
+                    typename boost::property_traits&lt;T&gt;::key_type
+                  , typename boost::graph_traits&lt;
+                        typename boost::parameter::value_type&lt;
+                            Args
+                          , graphs::graph
+                        &gt;::type
+                    &gt;::vertex_descriptor
+                &gt;
+              , boost::mpl::true_
+              , boost::mpl::false_
             &gt;
         &gt;
     {
@@ -1074,14 +1091,18 @@ struct color_map_predicate
 {
     template &lt;typename T, typename Args&gt;
     struct apply
-      : boost::is_same&lt;
-            typename boost::property_traits&lt;T&gt;::key_type
-          , typename boost::graph_traits&lt;
-                typename boost::parameter::value_type&lt;
-                    Args
-                  , graphs::graph
-                &gt;::type
-            &gt;::vertex_descriptor
+      : boost::mpl::if_&lt;
+            boost::is_same&lt;
+                typename boost::property_traits&lt;T&gt;::key_type
+              , typename boost::graph_traits&lt;
+                    typename boost::parameter::value_type&lt;
+                        Args
+                      , graphs::graph
+                    &gt;::type
+                &gt;::vertex_descriptor
+            &gt;
+          , boost::mpl::true_
+          , boost::mpl::false_
         &gt;
     {
     };
@@ -1160,6 +1181,10 @@ BOOST_PARAMETER_NAME((_color_map, graphs) in_out(color_map))
 {
 }
 
+#include <boost/core/lightweight_test.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <utility>
+
 int main()
 {
     typedef boost::adjacency_list<
@@ -1175,9 +1200,10 @@ int main()
 
     depth_first_search(g);
     depth_first_search(g, _root_vertex = static_cast<int>(x));
+    return boost::report_errors();
 }
 ''') -->
-<!-- @test('compile') -->
+<!-- @test('run') -->
 <p>It usually isn't necessary to so completely encode the type requirements on
 arguments to generic functions.  However, doing so is worth the effort: your
 code will be more self-documenting and will often provide a better user
@@ -1271,33 +1297,42 @@ specify parameter names for those arguments.  To generate this interface using
 enclose the deduced parameters in a
 <tt class="docutils literal">(deduced …)</tt> clause, as follows:</p>
 <pre class="literal-block">
-namespace mpl = boost::mpl;
+char const*&amp; blank_char_ptr()
+{
+    static char const* larr = &quot;&quot;;
+    return larr;
+}
 
 BOOST_PARAMETER_FUNCTION(
-    (void), def, tag,
+    (bool), def, tag,
 
     (required (name, (char const*)) (func,*) )  // nondeduced
 
     <strong>(deduced</strong>
         (optional
-            (docstring, (char const*), &quot;&quot;)
+            (docstring, (char const*), blank_char_ptr())
 
             (keywords
                 // see <a class="footnote-reference"
 href="#is-keyword-expression" id="id13"><sup>5</sup></a>
-              , *(is_keyword_expression&lt;mpl::_&gt;)
+              , *(is_keyword_expression&lt;boost::mpl::_&gt;)
               , no_keywords()
             )
 
             (policies
-              , *(mpl::not_&lt;
-                    mpl::or_&lt;
-                        boost::is_convertible&lt;mpl::_, char const*&gt;
-                        // see <a class="footnote-reference"
+              , *(
+                    boost::mpl::eval_if&lt;
+                        boost::is_convertible&lt;boost::mpl::_,char const*&gt;
+                      , boost::mpl::false_
+                      , boost::mpl::if_&lt;
+                            // see <a class="footnote-reference"
 href="#is-keyword-expression" id="id14"><sup>5</sup></a>
-                      , is_keyword_expression&lt;mpl::_&gt;
-                    &gt;
-                &gt;)
+                            is_keyword_expression&lt;boost::mpl::_&gt;
+                          , boost::mpl::false_
+                          , boost::mpl::true_
+                        >
+                    >
+                )
               , default_call_policies()
             )
         )
@@ -1307,7 +1342,7 @@ href="#is-keyword-expression" id="id14"><sup>5</sup></a>
     <em>…</em>
 }
 </pre>
-<!-- @example.replace_emphasis('') -->
+<!-- @example.replace_emphasis('return false;') -->
 <!-- @example.prepend('''
 #include <boost/parameter.hpp>
 
@@ -1346,6 +1381,11 @@ default_call_policies some_policies;
 void f()
 {
 }
+
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 ''') -->
 <div class="admonition-syntax-note admonition">
 <p class="first admonition-title">Syntax Note</p>
@@ -1358,13 +1398,16 @@ parameters at the outer level.</p>
 </div>
 <p>With the declaration above, the following two calls are equivalent:</p>
 <pre class="literal-block">
+char const* f_name = &quot;f&quot;;
 def(
-    &quot;f&quot;, &amp;f
+    f_name
+  , &amp;f
   , <strong>some_policies</strong>
   , <strong>&quot;Documentation for f&quot;</strong>
 );
 def(
-    &quot;f&quot;, &amp;f
+    f_name
+  , &amp;f
   , <strong>&quot;Documentation for f&quot;</strong>
   , <strong>some_policies</strong>
 );
@@ -1379,7 +1422,8 @@ argument that was also, for some reason, convertible to
 parameter name explicitly, as follows:</p>
 <pre class="literal-block">
 def(
-    &quot;f&quot;, &amp;f
+    f_name
+  , &amp;f
   , <strong>_policies = some_policies</strong>
   , &quot;Documentation for f&quot;
 );
@@ -1416,13 +1460,23 @@ struct callable2
         std::cout &lt;&lt; std::endl;
     }
 };
+
+#include &lt;boost/core/lightweight_test.hpp&gt;
+
+int main()
+{
+    callable2 c2;
+    callable2 const&amp; c2_const = c2;
+    c2_const.call(1, 2);
+    return boost::report_errors();
+}
 </pre>
 <!-- @example.prepend('''
 #include <boost/parameter.hpp>
 #include <iostream>
 using namespace boost::parameter;
 ''') -->
-<!-- @test('compile') -->
+<!-- @test('run') -->
 <p>These macros don't directly allow a function's interface to be
 separated from its implementation, but you can always forward
 arguments on to a separate implementation function:</p>
@@ -1433,8 +1487,9 @@ struct callable2
         (void), call, tag, (required (arg1,(int))(arg2,(int)))
     )
     {
-        call_impl(arg1,arg2);
+        call_impl(arg1, arg2);
     }
+
  private:
     void call_impl(int, int);  // implemented elsewhere.
 };
@@ -1463,13 +1518,22 @@ struct somebody
         std::cout &lt;&lt; arg1 &lt;&lt; std::endl;
     }
 };
+
+#include &lt;boost/core/lightweight_test.hpp&gt;
+
+int main()
+{
+    somebody::f();
+    somebody::f(4);
+    return boost::report_errors();
+}
 </pre>
 <!-- @example.prepend('''
 #include <boost/parameter.hpp>
 #include <iostream>
 using namespace boost::parameter;
 ''') -->
-<!-- @test('compile') -->
+<!-- @test('run') -->
 </div>
 </div>
 <div class="section" id="function-call-ops">
@@ -1497,13 +1561,23 @@ struct callable2
         std::cout &lt;&lt; second_arg &lt;&lt; std::endl;
     }
 };
+
+#include &lt;boost/core/lightweight_test.hpp&gt;
+
+int main()
+{
+    callable2 c2;
+    callable2 const&amp; c2_const = c2;
+    c2_const(1, 2);
+    return boost::report_errors();
+}
 </pre>
 <!-- @example.prepend('''
 #include <boost/parameter.hpp>
 #include <iostream>
 using namespace boost::parameter;
 ''') -->
-<!-- @test('compile') -->
+<!-- @test('run') -->
 </div>
 <div class="section" id="parameter-enabled-constructors">
 <h2><a class="toc-backref" href="#id30">2.4&nbsp;&nbsp;&nbsp;Parameter-Enabled
@@ -1514,8 +1588,8 @@ href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1986.pdf"
 >http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1986.pdf</a>) limits
 somewhat the quality of interface this library can provide for defining
 parameter-enabled constructors.  The usual workaround for a lack of
-constructor delegation applies: one must factor the common logic into a base
-class.</p>
+constructor delegation applies: one must factor the common logic into one or
+more base classes.</p>
 <p>Let's build a parameter-enabled constructor that simply prints its
 arguments.  The first step is to write a base class whose constructor accepts
 a single argument known as an <a class="reference external"
@@ -1570,7 +1644,11 @@ myclass x(&quot;bob&quot;, 3);                      // positional
 myclass y(_index = 12, _name = &quot;sally&quot;);  // named
 myclass z(&quot;june&quot;);                        // positional/defaulted
 </pre>
-<!-- @example.wrap('int main() {', '}') -->
+<!-- @example.wrap('''
+#include <boost/core/lightweight_test.hpp>
+
+int main() {
+''', ' return boost::report_errors(); }') -->
 <!-- @test('run', howmany='all') -->
 <p>For more on <span class="concept">ArgumentPack</span> manipulation, see the
 <a class="reference internal" href="#advanced-topics">Advanced Topics</a>
@@ -2010,8 +2088,7 @@ BOOST_PARAMETER_NAME(
     <strong>(</strong>
         <em>object-name</em>
       <strong>,</strong> <em>tag-namespace</em>
-    <strong>)</strong>
-<em>parameter-name</em>
+    <strong>)</strong> <em>parameter-name</em>
 )
 </pre>
 <!-- @ignore() -->

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -765,7 +765,7 @@ that prints the arguments:
     #include <boost/graph/depth_first_search.hpp>  // for dfs_visitor
 
     BOOST_PARAMETER_FUNCTION(
-        (void), depth_first_search, tag
+        (bool), depth_first_search, tag
         *…signature goes here…*
     )
     {
@@ -779,16 +779,20 @@ that prints the arguments:
         std::cout << std::endl;
         std::cout << "color_map=" << color_map;
         std::cout << std::endl;
+        return true;
     }
+
+    #include <boost/core/lightweight_test.hpp>
 
     int main()
     {
+        char const\* g = "1";
         depth_first_search(1, 2, 3, 4, 5);
-
         depth_first_search(
-            "1", '2', _color_map = '5',
+            g, '2', _color_map = '5',
             _index_map = "4", _root_vertex = "3"
         );
+        return boost::report_errors();
     }
 
 Despite the fact that default expressions such as ``vertices(graph).first``
@@ -815,7 +819,7 @@ and each one will print exactly the same thing.
         (color_map, \*)
     )
 ''')
-.. @test('compile')
+.. @test('run')
 
 Signature Matching and Overloading
 ----------------------------------
@@ -893,14 +897,18 @@ __ `parameter table`_
     {
         template <typename T, typename Args>
         struct apply
-          : boost::is_convertible<
-                T
-              , typename boost::graph_traits<
-                    typename boost::parameter::value_type<
-                        Args
-                      , graphs::graph
-                    >::type
-                >::vertex_descriptor
+          : boost::mpl::if_<
+                boost::is_convertible<
+                    T
+                  , typename boost::graph_traits<
+                        typename boost::parameter::value_type<
+                            Args
+                          , graphs::graph
+                        >::type
+                    >::vertex_descriptor
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
             >
         {
         };
@@ -949,14 +957,18 @@ classes provide the necessary checks.
     {
         template <typename T, typename Args>
         struct apply
-          : boost::mpl::and_<
+          : boost::mpl::eval_if<
                 boost::is_convertible<
                     typename boost::graph_traits<T>::traversal_category
                   , boost::incidence_graph_tag
                 >
-              , boost::is_convertible<
-                    typename boost::graph_traits<T>::traversal_category
-                  , boost::vertex_list_graph_tag
+              , boost::mpl::if_<
+                    boost::is_convertible<
+                        typename boost::graph_traits<T>::traversal_category
+                      , boost::vertex_list_graph_tag
+                    >
+                  , boost::mpl::true_
+                  , boost::mpl::false_
                 >
             >
         {
@@ -967,18 +979,22 @@ classes provide the necessary checks.
     {
         template <typename T, typename Args>
         struct apply
-          : boost::mpl::and_<
+          : boost::mpl::eval_if<
                 boost::is_integral<
                     typename boost::property_traits<T>::value_type
                 >
-              , boost::is_same<
-                    typename boost::property_traits<T>::key_type
-                  , typename boost::graph_traits<
-                        typename boost::parameter::value_type<
-                            Args
-                          , graphs::graph
-                        >::type
-                    >::vertex_descriptor
+              , boost::mpl::if_<
+                    boost::is_same<
+                        typename boost::property_traits<T>::key_type
+                      , typename boost::graph_traits<
+                            typename boost::parameter::value_type<
+                                Args
+                              , graphs::graph
+                            >::type
+                        >::vertex_descriptor
+                    >
+                  , boost::mpl::true_
+                  , boost::mpl::false_
                 >
             >
         {
@@ -989,14 +1005,18 @@ classes provide the necessary checks.
     {
         template <typename T, typename Args>
         struct apply
-          : boost::is_same<
-                typename boost::property_traits<T>::key_type
-              , typename boost::graph_traits<
-                    typename boost::parameter::value_type<
-                        Args
-                      , graphs::graph
-                    >::type
-                >::vertex_descriptor
+          : boost::mpl::if_<
+                boost::is_same<
+                    typename boost::property_traits<T>::key_type
+                  , typename boost::graph_traits<
+                        typename boost::parameter::value_type<
+                            Args
+                          , graphs::graph
+                        >::type
+                    >::vertex_descriptor
+                >
+              , boost::mpl::true_
+              , boost::mpl::false_
             >
         {
         };
@@ -1080,6 +1100,10 @@ by an asterix*, as follows:
     {
     }
 
+    #include <boost/core/lightweight_test.hpp>
+    #include <boost/graph/adjacency_list.hpp>
+    #include <utility>
+
     int main()
     {
         typedef boost::adjacency_list<
@@ -1095,11 +1119,11 @@ by an asterix*, as follows:
 
         depth_first_search(g);
         depth_first_search(g, _root_vertex = static_cast<int>(x));
-        return 0;
+        return boost::report_errors();
     }
 ''')
 
-.. @test('compile')
+.. @test('run')
 
 It usually isn't necessary to so completely encode the type requirements on
 arguments to generic functions.  However, doing so is worth the effort: your
@@ -1203,10 +1227,14 @@ follows:
 
 .. parsed-literal::
 
-    namespace mpl = boost::mpl;
+    char const*& blank_char_ptr()
+    {
+        static char const* larr = "";
+        return larr;
+    }
 
     BOOST_PARAMETER_FUNCTION(
-        (void), def, tag,
+        (bool), def, tag,
 
         (required (name, (char const\*)) (func,\*) )  // nondeduced
 
@@ -1216,18 +1244,23 @@ follows:
 
                 (keywords
                     // see [#is_keyword_expression]_
-                  , \*(is_keyword_expression<mpl::_>)
+                  , \*(is_keyword_expression<boost::mpl::_>)
                   , no_keywords()
                 )
 
                 (policies
-                  , \*(mpl::not_<
-                        mpl::or_<
-                            boost::is_convertible<mpl::_, char const\*>
-                            // see [#is_keyword_expression]_
-                          , is_keyword_expression<mpl::_>
+                  , \*(
+                        boost::mpl::eval_if<
+                            boost::is_convertible<boost::mpl::_,char const\*>
+                          , boost::mpl::false_
+                          , boost::mpl::if_<
+                                // see [#is_keyword_expression]_
+                                is_keyword_expression<boost::mpl::_>
+                              , boost::mpl::false_
+                              , boost::mpl::true_
+                            >
                         >
-                    >)
+                    )
                   , default_call_policies()
                 )
             )
@@ -1237,7 +1270,7 @@ follows:
         *…*
     }
 
-.. @example.replace_emphasis('')
+.. @example.replace_emphasis('return true;')
 
 .. @example.prepend('''
     #include <boost/parameter.hpp>
@@ -1278,6 +1311,11 @@ follows:
     {
     }
 
+    #include <boost/mpl/placeholders.hpp>
+    #include <boost/mpl/if.hpp>
+    #include <boost/mpl/eval_if.hpp>
+    #include <boost/type_traits/is_convertible.hpp>
+
 ''')
 
 .. Admonition:: Syntax Note
@@ -1290,8 +1328,19 @@ With the declaration above, the following two calls are equivalent:
 
 .. parsed-literal::
 
-    def("f", &f, **some_policies**, **"Documentation for f"**);
-    def("f", &f, **"Documentation for f"**, **some_policies**);
+    char const\* f_name = "f";
+    def(
+        f_name
+      , &f
+      , **some_policies**
+      , **"Documentation for f"**
+    );
+    def(
+        f_name
+      , &f
+      , **"Documentation for f"**
+      , **some_policies**
+    );
 
 .. @example.prepend('''
     int main()
@@ -1305,8 +1354,10 @@ name explicitly, as follows:
 .. parsed-literal::
 
     def(
-        "f", &f
-      , **_policies = some_policies**, "Documentation for f"
+        f_name
+      , &f
+      , **_policies = some_policies**
+      , "Documentation for f"
     );
 
 .. @example.append('}')
@@ -1346,13 +1397,23 @@ the body of a class::
         }
     };
 
+    #include <boost/core/lightweight_test.hpp>
+
+    int main()
+    {
+        callable2 c2;
+        callable2 const& c2_const = c2;
+        c2_const.call(1, 2);
+        return boost::report_errors();
+    }
+
 .. @example.prepend('''
     #include <boost/parameter.hpp>
     #include <iostream>
     using namespace boost::parameter;
 ''')
 
-.. @test('compile')
+.. @test('run')
 
 These macros don't directly allow a function's interface to be separated from
 its implementation, but you can always forward arguments on to a separate
@@ -1364,7 +1425,7 @@ implementation function::
             (void), call, tag, (required (arg1,(int))(arg2,(int)))
         )
         {
-            call_impl(arg1,arg2);
+            call_impl(arg1, arg2);
         }
 
      private:
@@ -1401,13 +1462,22 @@ before the function name:
         }
     };
 
+    #include <boost/core/lightweight_test.hpp>
+
+    int main()
+    {
+        somebody::f();
+        somebody::f(4);
+        return boost::report_errors();
+    }
+
 .. @example.prepend('''
     #include <boost/parameter.hpp>
     #include <iostream>
     using namespace boost::parameter;
 ''')
 
-.. @test('compile')
+.. @test('run')
 
 -----------------------------------------
 Parameter-Enabled Function Call Operators
@@ -1434,13 +1504,23 @@ function objects::
         }
     };
 
+    #include <boost/core/lightweight_test.hpp>
+
+    int main()
+    {
+        callable2 c2;
+        callable2 const& c2_const = c2;
+        c2_const(1, 2);
+        return boost::report_errors();
+    }
+
 .. @example.prepend('''
     #include <boost/parameter.hpp>
     #include <iostream>
     using namespace boost::parameter;
 ''')
 
-.. @test('compile')
+.. @test('run')
 
 ------------------------------
 Parameter-Enabled Constructors
@@ -1451,7 +1531,7 @@ The lack of a “delegating constructor” feature in C++
 limits somewhat the quality of interface this library can provide
 for defining parameter-enabled constructors.  The usual workaround
 for a lack of constructor delegation applies: one must factor the
-common logic into a base class.  
+common logic into one or more base classes.  
 
 Let's build a parameter-enabled constructor that simply prints its
 arguments.  The first step is to write a base class whose
@@ -1501,7 +1581,11 @@ only ``name`` is required.  We can exercise our new interface as follows::
     myclass y(_index = 12, _name = "sally");  // named
     myclass z("june");                        // positional/defaulted
 
-.. @example.wrap('int main() {', ' return 0; }')
+.. @example.wrap('''
+    #include <boost/core/lightweight_test.hpp>
+
+    int main() {
+''', ' return boost::report_errors(); }')
 .. @test('run', howmany='all')
 
 For more on |ArgumentPack| manipulation, see the `Advanced Topics`_ section.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2098,7 +2098,8 @@ The simplest |ArgumentPack| is the result of assigning into a keyword object::
     template <typename ArgumentPack>
     int print_index(ArgumentPack const& args)
     {
-        std::cout << "index = " << args[_index] << std::endl;
+        std::cout << "index = " << args[_index];
+        std::cout << std::endl;
         return 0;
     }
 
@@ -2118,7 +2119,8 @@ arguments to ``print_name_and_index``::
     template <typename ArgumentPack>
     int print_name_and_index(ArgumentPack const& args)
     {
-        std::cout << "name = " << args[_name] << "; ";
+        std::cout << "name = " << args[_name];
+        std::cout << "; ";
         return print_index(args);
     }
 
@@ -2585,7 +2587,7 @@ the Parameter library to see how it fares on your favorite
 compiler.  Additionally, you may need to be aware of the following
 issues and workarounds for particular compilers.
 
-.. _`regression test results`: http://www.boost.org/regression/release/user/parameter.html
+.. _`regression test results`: http\://www.boost.org/regression/release/user/parameter.html
 
 --------------------------
 Perfect Forwarding Support
@@ -2595,13 +2597,13 @@ If your compiler supports `perfect forwarding`_, then the Parameter library
 will ``#define`` the macro ``BOOST_PARAMETER_HAS_PERFECT_FORWARDING`` unless
 you disable it manually.  If your compiler does not provide this support, then
 ``parameter::parameters::operator()`` will treat rvalue references as lvalue
-const references to work around the `forwarding problem`_, so in certain cases
-you must wrap |boost_ref|_ or |std_ref|_ around any arguments that will be
-bound to out parameters.  The |evaluate_category|_ and
+``const`` references to work around the `forwarding problem`_, so in certain
+cases you must wrap |boost_ref|_ or |std_ref|_ around any arguments that will
+be bound to out parameters.  The |evaluate_category|_ and
 |preprocessor_eval_category|_ test programs demonstrate this support.
 
-.. _`perfect forwarding`: http://www.justsoftwaresolutions.co.uk/cplusplus/rvalue_references_and_perfect_forwarding.html
-.. _`forwarding problem`: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2002/n1385.htm
+.. _`perfect forwarding`: http\://www.justsoftwaresolutions.co.uk/cplusplus/rvalue_references_and_perfect_forwarding.html
+.. _`forwarding problem`: http\://www.open-std.org/jtc1/sc22/wg21/docs/papers/2002/n1385.htm
 .. |boost_ref| replace:: ``boost\:\:ref``
 .. _boost_ref: ../../../core/doc/html/core/ref.html
 .. |std_ref| replace:: ``std\:\:ref``

--- a/test/literate/deduced-parameters0.cpp
+++ b/test/literate/deduced-parameters0.cpp
@@ -44,14 +44,21 @@ void f()
 #include <boost/mpl/eval_if.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
+char const*& blank_char_ptr()
+{
+    static char const* larr = "";
+    return larr;
+}
+
 BOOST_PARAMETER_FUNCTION(
-    (void), def, tag,
+    (bool), def, tag,
     (required (name,(char const*)) (func,*) )  // nondeduced
     (deduced
         (optional
-            (docstring, (char const*), "")
+            (docstring, (char const*), blank_char_ptr())
             (keywords
-              , *(is_keyword_expression<boost::mpl::_>) // see 5
+                // see 5
+              , *(is_keyword_expression<boost::mpl::_>)
               , no_keywords()
             )
             (policies
@@ -60,7 +67,8 @@ BOOST_PARAMETER_FUNCTION(
                         boost::is_convertible<boost::mpl::_,char const*>
                       , boost::mpl::false_
                       , boost::mpl::if_<
-                            is_keyword_expression<boost::mpl::_> // see 5
+                            // see 5
+                            is_keyword_expression<boost::mpl::_>
                           , boost::mpl::false_
                           , boost::mpl::true_
                         >
@@ -72,16 +80,18 @@ BOOST_PARAMETER_FUNCTION(
     )
 )
 {
+    return true;
 }
 
 #include <boost/core/lightweight_test.hpp>
 
 int main()
 {
-    def("f", &f, some_policies, "Documentation for f");
-    def("f", &f, "Documentation for f", some_policies);
+    char const* f_name = "f";
+    def(f_name, &f, some_policies, "Documentation for f");
+    def(f_name, &f, "Documentation for f", some_policies);
     def(
-        "f"
+        f_name
       , &f
       , _policies = some_policies
       , "Documentation for f"

--- a/test/literate/default-expression-evaluation0.cpp
+++ b/test/literate/default-expression-evaluation0.cpp
@@ -10,7 +10,7 @@ BOOST_PARAMETER_NAME(color_map)
 
 #include <boost/graph/depth_first_search.hpp> // for dfs_visitor
 
-BOOST_PARAMETER_FUNCTION((void), depth_first_search, tag,
+BOOST_PARAMETER_FUNCTION((bool), depth_first_search, tag,
     (required
         (graph, *)
         (visitor, *)
@@ -20,20 +20,27 @@ BOOST_PARAMETER_FUNCTION((void), depth_first_search, tag,
     )
 )
 {
-    std::cout << "graph=" << graph << std::endl;
-    std::cout << "visitor=" << visitor << std::endl;
-    std::cout << "root_vertex=" << root_vertex << std::endl;
-    std::cout << "index_map=" << index_map << std::endl;
-    std::cout << "color_map=" << color_map << std::endl;
+    std::cout << "graph=" << graph;
+    std::cout << std::endl;
+    std::cout << "visitor=" << visitor;
+    std::cout << std::endl;
+    std::cout << "root_vertex=" << root_vertex;
+    std::cout << std::endl;
+    std::cout << "index_map=" << index_map;
+    std::cout << std::endl;
+    std::cout << "color_map=" << color_map;
+    std::cout << std::endl;
+    return true;
 }
 
 #include <boost/core/lightweight_test.hpp>
 
 int main()
 {
+    char const* g = "1";
     depth_first_search(1, 2, 3, 4, 5);
     depth_first_search(
-        "1", '2', _color_map = '5'
+        g, '2', _color_map = '5'
       , _index_map = "4", _root_vertex = "3"
     );
     return boost::report_errors();

--- a/test/literate/parameter-enabled-member-functions0.cpp
+++ b/test/literate/parameter-enabled-member-functions0.cpp
@@ -17,3 +17,13 @@ struct callable2
     }
 };
 
+#include <boost/core/lightweight_test.hpp>
+
+int main()
+{
+    callable2 c2;
+    callable2 const& c2_const = c2;
+    c2_const.call(1, 2);
+    return boost::report_errors();
+}
+

--- a/test/literate/static-member-functions0.cpp
+++ b/test/literate/static-member-functions0.cpp
@@ -16,3 +16,12 @@ struct somebody
     }
 };
 
+#include <boost/core/lightweight_test.hpp>
+
+int main()
+{
+    somebody::f();
+    somebody::f(4);
+    return boost::report_errors();
+}
+

--- a/test/literate/top-level0.cpp
+++ b/test/literate/top-level0.cpp
@@ -43,7 +43,8 @@ namespace test {
 
 int main()
 {
-    int x = test::new_window("alert", test::_width=10, test::_titlebar=false);
+    char const* alert_s = "alert";
+    int x = test::new_window(alert_s, test::_width=10, test::_titlebar=false);
     test::Foo* foo = new test::Foo();
     test::smart_ptr<
         test::Foo


### PR DESCRIPTION
* Fix compiler failures showing up on regression test matrix due to void return type.
* Fix gcc-3.4 failures showing up regression test matrix due to binding string literals to non-const references to char const*.
* Update tutorial documentation to match literate tests.