### PR TITLE
 Upgrade code generation macros

### DIFF
--- a/include/boost/parameter/aux_/arg_list.hpp
+++ b/include/boost/parameter/aux_/arg_list.hpp
@@ -144,6 +144,7 @@ namespace boost { namespace parameter { namespace aux {
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -153,9 +154,13 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename TaggedArg
       , typename Next = ::boost::parameter::aux::empty_arg_list
+      , typename EmitErrors = ::boost::mpl::true_
     >
-    struct arg_list : Next
+    class arg_list : public Next
     {
+        TaggedArg arg;      // Stores the argument
+
+     public:
         typedef TaggedArg tagged_arg;
         typedef ::boost::parameter::aux::arg_list<TaggedArg,Next> self;
         typedef typename TaggedArg::key_type key_type;
@@ -175,8 +180,6 @@ namespace boost { namespace parameter { namespace aux {
           , reference
           , typename TaggedArg::value_type
         >::type value_type;
-
-        TaggedArg arg;      // Stores the argument
 
         // Create a new list by prepending arg to a copy of tail.  Used when
         // incrementally building this structure with the comma operator.
@@ -276,16 +279,22 @@ namespace boost { namespace parameter { namespace aux {
         static ::boost::parameter::aux::yes_tag has_key(key_type*);
         using Next::has_key;
 
-        BOOST_MPL_ASSERT_MSG(
+     private:
+        typedef ::boost::mpl::bool_<
             sizeof(
                 Next::has_key(
                     static_cast<key_type*>(BOOST_TTI_DETAIL_NULLPTR)
                 )
             ) == sizeof(::boost::parameter::aux::no_tag)
+        > _has_unique_key;
+
+        BOOST_MPL_ASSERT_MSG(
+            !(EmitErrors::value) || (_has_unique_key::value)
           , duplicate_keyword
           , (key_type)
         );
 
+     public:
         //
         // Begin implementation of indexing operators
         // for looking up specific arguments by name.
@@ -356,11 +365,18 @@ namespace boost { namespace parameter { namespace aux {
         // satisfied by TaggedArg.  Used only for compile-time computation
         // and never really called, so a declaration is enough.
         template <typename HasDefault, typename Predicate, typename ArgPack>
-        static typename ::boost::mpl::apply_wrap2<
-            ::boost::parameter::aux
-            ::augment_predicate<Predicate,reference,key_type>
-          , value_type
-          , ArgPack
+        static typename ::boost::lazy_enable_if<
+            typename ::boost::mpl::if_<
+                EmitErrors
+              , ::boost::mpl::true_
+              , _has_unique_key
+            >::type
+          , ::boost::mpl::apply_wrap2<
+                ::boost::parameter::aux
+                ::augment_predicate<Predicate,reference,key_type>
+              , value_type
+              , ArgPack
+            >
         >::type
             satisfies(
                 ::boost::parameter::aux::parameter_requirements<
@@ -524,6 +540,10 @@ namespace boost { namespace parameter { namespace aux {
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 #include <boost/preprocessor/repetition/enum_shifted_params.hpp>
 
+#if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+#include <boost/core/enable_if.hpp>
+#endif
+
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
 #include <boost/tti/detail/dnullptr.hpp>
 #endif
@@ -535,9 +555,13 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename TaggedArg
       , typename Next = ::boost::parameter::aux::empty_arg_list
+      , typename EmitErrors = ::boost::mpl::true_
     >
-    struct arg_list : Next
+    class arg_list : public Next
     {
+        TaggedArg arg;      // Stores the argument
+
+     public:
         typedef TaggedArg tagged_arg;
         typedef ::boost::parameter::aux::arg_list<TaggedArg,Next> self;
         typedef typename TaggedArg::key_type key_type;
@@ -557,8 +581,6 @@ namespace boost { namespace parameter { namespace aux {
           , reference
           , typename TaggedArg::value_type
         >::type value_type;
-
-        TaggedArg arg;      // Stores the argument
 
         // Create a new list by prepending arg to a copy of tail.  Used when
         // incrementally building this structure with the comma operator.
@@ -613,6 +635,7 @@ namespace boost { namespace parameter { namespace aux {
         static ::boost::parameter::aux::yes_tag has_key(key_type*);
         using Next::has_key;
 
+#if defined(BOOST_NO_SFINAE) || BOOST_WORKAROUND(BOOST_MSVC, < 1800)
         BOOST_MPL_ASSERT_MSG(
             sizeof(
                 Next::has_key(
@@ -622,8 +645,25 @@ namespace boost { namespace parameter { namespace aux {
           , duplicate_keyword
           , (key_type)
         );
-#endif
+#else
+     private:
+        typedef ::boost::mpl::bool_<
+            sizeof(
+                Next::has_key(
+                    static_cast<key_type*>(BOOST_TTI_DETAIL_NULLPTR)
+                )
+            ) == sizeof(::boost::parameter::aux::no_tag)
+        > _has_unique_key;
 
+        BOOST_MPL_ASSERT_MSG(
+            !(EmitErrors::value) || (_has_unique_key::value)
+          , duplicate_keyword
+          , (key_type)
+        );
+#endif
+#endif  // Borland workarounds not needed.
+
+     public:
         //
         // Begin implementation of indexing operators
         // for looking up specific arguments by name.
@@ -786,11 +826,23 @@ namespace boost { namespace parameter { namespace aux {
         // satisfied by TaggedArg.  Used only for compile-time computation
         // and never really called, so a declaration is enough.
         template <typename HasDefault, typename Predicate, typename ArgPack>
-        static typename ::boost::mpl::apply_wrap2<
-            ::boost::parameter::aux
-            ::augment_predicate<Predicate,reference,key_type>
-          , value_type
-          , ArgPack
+        static typename
+#if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+        ::boost::lazy_enable_if<
+            typename ::boost::mpl::if_<
+                EmitErrors
+              , ::boost::mpl::true_
+              , _has_unique_key
+            >::type,
+#endif
+            ::boost::mpl::apply_wrap2<
+                ::boost::parameter::aux
+                ::augment_predicate<Predicate,reference,key_type>
+              , value_type
+              , ArgPack
+#if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+           >
+#endif
         >::type
             satisfies(
                 ::boost::parameter::aux::parameter_requirements<

--- a/include/boost/parameter/aux_/arg_list.hpp
+++ b/include/boost/parameter/aux_/arg_list.hpp
@@ -154,7 +154,7 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename TaggedArg
       , typename Next = ::boost::parameter::aux::empty_arg_list
-      , typename EmitErrors = ::boost::mpl::true_
+      , typename EmitsErrors = ::boost::mpl::true_
     >
     class arg_list : public Next
     {
@@ -289,7 +289,7 @@ namespace boost { namespace parameter { namespace aux {
         > _has_unique_key;
 
         BOOST_MPL_ASSERT_MSG(
-            !(EmitErrors::value) || (_has_unique_key::value)
+            !(EmitsErrors::value) || (_has_unique_key::value)
           , duplicate_keyword
           , (key_type)
         );
@@ -367,7 +367,7 @@ namespace boost { namespace parameter { namespace aux {
         template <typename HasDefault, typename Predicate, typename ArgPack>
         static typename ::boost::lazy_enable_if<
             typename ::boost::mpl::if_<
-                EmitErrors
+                EmitsErrors
               , ::boost::mpl::true_
               , _has_unique_key
             >::type
@@ -555,7 +555,7 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename TaggedArg
       , typename Next = ::boost::parameter::aux::empty_arg_list
-      , typename EmitErrors = ::boost::mpl::true_
+      , typename EmitsErrors = ::boost::mpl::true_
     >
     class arg_list : public Next
     {
@@ -656,7 +656,7 @@ namespace boost { namespace parameter { namespace aux {
         > _has_unique_key;
 
         BOOST_MPL_ASSERT_MSG(
-            !(EmitErrors::value) || (_has_unique_key::value)
+            !(EmitsErrors::value) || (_has_unique_key::value)
           , duplicate_keyword
           , (key_type)
         );
@@ -830,7 +830,7 @@ namespace boost { namespace parameter { namespace aux {
 #if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
         ::boost::lazy_enable_if<
             typename ::boost::mpl::if_<
-                EmitErrors
+                EmitsErrors
               , ::boost::mpl::true_
               , _has_unique_key
             >::type,

--- a/include/boost/parameter/aux_/pack/deduce_tag.hpp
+++ b/include/boost/parameter/aux_/pack/deduce_tag.hpp
@@ -14,6 +14,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
+      , typename EmitErrors
     >
     struct deduce_tag;
 }}} // namespace boost::parameter::aux
@@ -38,6 +39,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
+      , typename EmitErrors
     >
     struct deduce_tag0
     {
@@ -59,9 +61,13 @@ namespace boost { namespace parameter { namespace aux {
                     UsedArgs
                   , typename ::boost::parameter::aux::tag_type<spec>::type
                 >::type
-              , ::boost::mpl::if_<
+              , ::boost::mpl::eval_if<
                     condition
-                  , ::boost::mpl::false_
+                  , ::boost::mpl::if_<
+                        EmitErrors
+                      , ::boost::mpl::false_
+                      , ::boost::mpl::true_
+                    >
                   , ::boost::mpl::true_
                 >
               , ::boost::mpl::true_
@@ -77,6 +83,7 @@ namespace boost { namespace parameter { namespace aux {
               , typename DeducedArgs::tail
               , UsedArgs
               , TagFn
+              , EmitErrors
             >
         >::type type;
     };
@@ -108,6 +115,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
+      , typename EmitErrors
     >
     struct deduce_tag
       : ::boost::mpl::eval_if<
@@ -119,6 +127,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedArgs
               , UsedArgs
               , TagFn
+              , EmitErrors
             >
         >
     {

--- a/include/boost/parameter/aux_/pack/deduce_tag.hpp
+++ b/include/boost/parameter/aux_/pack/deduce_tag.hpp
@@ -14,7 +14,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
-      , typename EmitErrors
+      , typename EmitsErrors
     >
     struct deduce_tag;
 }}} // namespace boost::parameter::aux
@@ -39,32 +39,32 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
-      , typename EmitErrors
+      , typename EmitsErrors
     >
-    struct deduce_tag0
+    class deduce_tag0
     {
-        typedef typename DeducedArgs::spec spec;
+        typedef typename DeducedArgs::spec _spec;
 
         typedef typename ::boost::mpl::apply_wrap2<
             typename ::boost::mpl::lambda<
-                typename spec::predicate
+                typename _spec::predicate
               , ::boost::parameter::aux::lambda_tag
             >::type
           , Argument
           , ArgumentPack
-        >::type condition;
+        >::type _condition;
 
         // Deduced parameter matches several arguments.
         BOOST_MPL_ASSERT((
             typename ::boost::mpl::eval_if<
                 typename ::boost::parameter::aux::has_key_<
                     UsedArgs
-                  , typename ::boost::parameter::aux::tag_type<spec>::type
+                  , typename ::boost::parameter::aux::tag_type<_spec>::type
                 >::type
               , ::boost::mpl::eval_if<
-                    condition
+                    _condition
                   , ::boost::mpl::if_<
-                        EmitErrors
+                        EmitsErrors
                       , ::boost::mpl::false_
                       , ::boost::mpl::true_
                     >
@@ -74,16 +74,18 @@ namespace boost { namespace parameter { namespace aux {
             >::type
         ));
 
+     public:
         typedef typename ::boost::mpl::eval_if<
-            condition
-          , ::boost::parameter::aux::tag_deduced<UsedArgs,spec,Argument,TagFn>
+            _condition
+          , ::boost::parameter::aux
+            ::tag_deduced<UsedArgs,_spec,Argument,TagFn>
           , ::boost::parameter::aux::deduce_tag<
                 Argument
               , ArgumentPack
               , typename DeducedArgs::tail
               , UsedArgs
               , TagFn
-              , EmitErrors
+              , EmitsErrors
             >
         >::type type;
     };
@@ -115,7 +117,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedArgs
       , typename UsedArgs
       , typename TagFn
-      , typename EmitErrors
+      , typename EmitsErrors
     >
     struct deduce_tag
       : ::boost::mpl::eval_if<
@@ -127,7 +129,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedArgs
               , UsedArgs
               , TagFn
-              , EmitErrors
+              , EmitsErrors
             >
         >
     {

--- a/include/boost/parameter/aux_/pack/make_arg_list.hpp
+++ b/include/boost/parameter/aux_/pack/make_arg_list.hpp
@@ -12,11 +12,11 @@ namespace boost { namespace parameter { namespace aux {
         typename List
       , typename DeducedArgs
       , typename TagFn
-      , typename Positional
+      , typename IsPositional
       , typename UsedArgs
       , typename ArgumentPack
       , typename Error
-      , typename EmitErrors
+      , typename EmitsErrors
     >
     struct make_arg_list_aux;
 }}} // namespace boost::parameter::aux
@@ -48,124 +48,126 @@ namespace boost { namespace parameter { namespace aux {
         typename List
       , typename DeducedArgs
       , typename TagFn
-      , typename Positional
+      , typename IsPositional
       , typename UsedArgs
       , typename ArgumentPack
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-      , typename argument
+      , typename _argument
 #endif
       , typename Error
-      , typename EmitErrors
+      , typename EmitsErrors
     >
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-    struct make_arg_list00
+    class make_arg_list00
 #else
-    struct make_arg_list0
+    class make_arg_list0
 #endif
     {
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-        typedef typename List::arg argument;
+        typedef typename List::arg _argument;
 #endif
         typedef typename ::boost::remove_const<
-            typename ::boost::remove_reference<argument>::type
-        >::type arg_type;
-        typedef typename List::spec parameter_spec;
+            typename ::boost::remove_reference<_argument>::type
+        >::type _arg_type;
+        typedef typename List::spec _parameter_spec;
         typedef typename ::boost::parameter::aux
-        ::tag_type<parameter_spec>::type tag_;
+        ::tag_type<_parameter_spec>::type _tag;
         typedef ::boost::parameter::aux
-        ::is_named_argument<argument> is_tagged;
+        ::is_named_argument<_argument> _is_tagged;
 
         // If this argument is either explicitly tagged or a deduced
         // parameter, then turn off positional matching.
         typedef typename ::boost::mpl::eval_if<
-            Positional
+            IsPositional
           , ::boost::mpl::eval_if<
-                ::boost::parameter::aux::is_deduced<parameter_spec>
+                ::boost::parameter::aux::is_deduced<_parameter_spec>
               , ::boost::mpl::false_
               , ::boost::mpl::if_<
-                    is_tagged
+                    _is_tagged
                   , ::boost::mpl::false_
                   , ::boost::mpl::true_
                 >
             >
           , ::boost::mpl::false_
-        >::type positional;
+        >::type _is_positional;
 
         // If this parameter is explicitly tagged, then add it to the
         // used-parmeters set.  We only really need to add parameters
         // that are deduced, but we would need a way to check if
         // a given tag corresponds to a deduced parameter spec.
         typedef typename ::boost::mpl::eval_if<
-            is_tagged
-          , ::boost::parameter::aux::insert_tagged<UsedArgs,arg_type>
+            _is_tagged
+          , ::boost::parameter::aux::insert_tagged<UsedArgs,_arg_type>
           , ::boost::mpl::identity<UsedArgs>
-        >::type used_args;
+        >::type _used_args;
 
         // If this parameter is neither explicitly tagged nor positionally
         // matched, then deduce the tag from the deduced parameter specs.
         typedef typename ::boost::mpl::eval_if<
             typename ::boost::mpl::if_<
-                is_tagged
+                _is_tagged
               , ::boost::mpl::true_
-              , positional
+              , _is_positional
             >::type
-          , ::boost::mpl::pair< ::boost::parameter::void_,used_args>
+          , ::boost::mpl::pair< ::boost::parameter::void_,_used_args>
           , ::boost::parameter::aux::deduce_tag<
-                argument
+                _argument
               , ArgumentPack
               , DeducedArgs
-              , used_args
+              , _used_args
               , TagFn
-              , EmitErrors
+              , EmitsErrors
             >
-        >::type deduced_data;
+        >::type _deduced_data;
 
         // If this parameter is explicitly tagged ...
         typedef typename ::boost::mpl::eval_if<
-            is_tagged
+            _is_tagged
             // ... just use it
-          , ::boost::mpl::identity<arg_type>
+          , ::boost::mpl::identity<_arg_type>
             // ... else ...
           , ::boost::mpl::eval_if<
                 // if positional matching is turned on ...
-                positional
+                _is_positional
                 // ... tag it positionally
-              , ::boost::mpl::apply_wrap2<TagFn,tag_,argument>
+              , ::boost::mpl::apply_wrap2<TagFn,_tag,_argument>
                 // ... else, use the deduced tag
-              , ::boost::mpl::first<deduced_data>
+              , ::boost::mpl::first<_deduced_data>
             >
-        >::type tagged;
+        >::type _tagged;
 
         // Build the arg_list incrementally, prepending new nodes.
         typedef typename ::boost::mpl::if_<
             typename ::boost::mpl::if_<
                 ::boost::is_same<Error,::boost::parameter::void_>
-              , ::boost::is_same<tagged,::boost::parameter::void_>
+              , ::boost::is_same<_tagged,::boost::parameter::void_>
               , ::boost::mpl::false_
             >::type
-          , ::boost::parameter::aux::unmatched_argument<argument>
+          , ::boost::parameter::aux::unmatched_argument<_argument>
           , ::boost::parameter::void_
         >::type error;
 
         typedef typename ::boost::mpl::if_<
-            ::boost::is_same<tagged,::boost::parameter::void_>
+            ::boost::is_same<_tagged,::boost::parameter::void_>
           , ArgumentPack
 #if defined(BOOST_NO_SFINAE) || BOOST_WORKAROUND(BOOST_MSVC, < 1800)
-          , ::boost::parameter::aux::arg_list<tagged,ArgumentPack>
+          , ::boost::parameter::aux::arg_list<_tagged,ArgumentPack>
 #else
-          , ::boost::parameter::aux::arg_list<tagged,ArgumentPack,EmitErrors>
+          , ::boost::parameter::aux
+            ::arg_list<_tagged,ArgumentPack,EmitsErrors>
 #endif
-        >::type argument_pack;
+        >::type _argument_pack;
 
+     public:
         typedef typename ::boost::parameter::aux::make_arg_list_aux<
             typename List::tail
           , DeducedArgs
           , TagFn
-          , positional
-          , typename deduced_data::second
-          , argument_pack
+          , _is_positional
+          , typename _deduced_data::second
+          , _argument_pack
           , error
-          , EmitErrors
+          , EmitsErrors
         >::type type;
     };
 
@@ -174,11 +176,11 @@ namespace boost { namespace parameter { namespace aux {
         typename List
       , typename DeducedArgs
       , typename TagFn
-      , typename Positional
+      , typename IsPositional
       , typename UsedArgs
       , typename ArgumentPack
       , typename Error
-      , typename EmitErrors
+      , typename EmitsErrors
     >
     struct make_arg_list0
     {
@@ -188,23 +190,23 @@ namespace boost { namespace parameter { namespace aux {
                 List
               , DeducedArgs
               , TagFn
-              , Positional
+              , IsPositional
               , UsedArgs
               , ArgumentPack
               , typename List::arg const
               , Error
-              , EmitErrors
+              , EmitsErrors
             >
           , ::boost::parameter::aux::make_arg_list00<
                 List
               , DeducedArgs
               , TagFn
-              , Positional
+              , IsPositional
               , UsedArgs
               , ArgumentPack
               , typename List::arg
               , Error
-              , EmitErrors
+              , EmitsErrors
             >
         >::type type;
     };
@@ -222,7 +224,7 @@ namespace boost { namespace parameter { namespace aux {
     //   TagFn:        A metafunction class used to tag positional or deduced
     //                 arguments with a keyword tag.
     //
-    //   Positional:   An mpl::bool_<> specialization indicating if positional
+    //   IsPositional: An mpl::bool_<> specialization indicating if positional
     //                 matching is to be performed.
     //
     //   DeducedSet:   An mpl::set<> containing the keyword tags used so far.
@@ -233,11 +235,11 @@ namespace boost { namespace parameter { namespace aux {
         typename List
       , typename DeducedArgs
       , typename TagFn
-      , typename Positional
+      , typename IsPositional
       , typename DeducedSet
       , typename ArgumentPack
       , typename Error
-      , typename EmitErrors
+      , typename EmitsErrors
     >
     struct make_arg_list_aux
       : ::boost::mpl::eval_if<
@@ -247,11 +249,11 @@ namespace boost { namespace parameter { namespace aux {
                 List
               , DeducedArgs
               , TagFn
-              , Positional
+              , IsPositional
               , DeducedSet
               , ArgumentPack
               , Error
-              , EmitErrors
+              , EmitsErrors
             >
         >
     {
@@ -268,7 +270,7 @@ namespace boost { namespace parameter { namespace aux {
         typename List
       , typename DeducedArgs
       , typename TagFn
-      , typename EmitErrors = ::boost::mpl::true_
+      , typename EmitsErrors = ::boost::mpl::true_
     >
     struct make_arg_list
       : ::boost::parameter::aux::make_arg_list_aux<
@@ -279,7 +281,7 @@ namespace boost { namespace parameter { namespace aux {
           , ::boost::parameter::aux::set0
           , ::boost::parameter::aux::empty_arg_list
           , ::boost::parameter::void_
-          , EmitErrors
+          , EmitsErrors
         >
     {
     };

--- a/include/boost/parameter/aux_/pack/make_arg_list.hpp
+++ b/include/boost/parameter/aux_/pack/make_arg_list.hpp
@@ -16,6 +16,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename UsedArgs
       , typename ArgumentPack
       , typename Error
+      , typename EmitErrors
     >
     struct make_arg_list_aux;
 }}} // namespace boost::parameter::aux
@@ -54,6 +55,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename argument
 #endif
       , typename Error
+      , typename EmitErrors
     >
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
     struct make_arg_list00
@@ -114,6 +116,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedArgs
               , used_args
               , TagFn
+              , EmitErrors
             >
         >::type deduced_data;
 
@@ -147,7 +150,11 @@ namespace boost { namespace parameter { namespace aux {
         typedef typename ::boost::mpl::if_<
             ::boost::is_same<tagged,::boost::parameter::void_>
           , ArgumentPack
+#if defined(BOOST_NO_SFINAE) || BOOST_WORKAROUND(BOOST_MSVC, < 1800)
           , ::boost::parameter::aux::arg_list<tagged,ArgumentPack>
+#else
+          , ::boost::parameter::aux::arg_list<tagged,ArgumentPack,EmitErrors>
+#endif
         >::type argument_pack;
 
         typedef typename ::boost::parameter::aux::make_arg_list_aux<
@@ -158,6 +165,7 @@ namespace boost { namespace parameter { namespace aux {
           , typename deduced_data::second
           , argument_pack
           , error
+          , EmitErrors
         >::type type;
     };
 
@@ -170,6 +178,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename UsedArgs
       , typename ArgumentPack
       , typename Error
+      , typename EmitErrors
     >
     struct make_arg_list0
     {
@@ -184,6 +193,7 @@ namespace boost { namespace parameter { namespace aux {
               , ArgumentPack
               , typename List::arg const
               , Error
+              , EmitErrors
             >
           , ::boost::parameter::aux::make_arg_list00<
                 List
@@ -194,6 +204,7 @@ namespace boost { namespace parameter { namespace aux {
               , ArgumentPack
               , typename List::arg
               , Error
+              , EmitErrors
             >
         >::type type;
     };
@@ -226,6 +237,7 @@ namespace boost { namespace parameter { namespace aux {
       , typename DeducedSet
       , typename ArgumentPack
       , typename Error
+      , typename EmitErrors
     >
     struct make_arg_list_aux
       : ::boost::mpl::eval_if<
@@ -239,6 +251,7 @@ namespace boost { namespace parameter { namespace aux {
               , DeducedSet
               , ArgumentPack
               , Error
+              , EmitErrors
             >
         >
     {
@@ -266,6 +279,7 @@ namespace boost { namespace parameter { namespace aux {
           , ::boost::parameter::aux::set0
           , ::boost::parameter::aux::empty_arg_list
           , ::boost::parameter::void_
+          , EmitErrors
         >
     {
     };


### PR DESCRIPTION
Enable preprocessor-generated function call operator overloads & overloads of the same name to coexist even with deduced arguments.  SFINAE required.