### PR TITLE
 Introduce support for Boost.MP11

### DIFF
--- a/include/boost/parameter/config.hpp
+++ b/include/boost/parameter/config.hpp
@@ -15,9 +15,13 @@
 // SFINAE support, needed explicitly by tagged_argument & keyword & cast;
 // correct function template ordering, needed by the code generation macros;
 // rvalue references, needed throughout; variadic templates, needed by
-// parameters; and the ability to handle multiple parameter packs, needed by
-// parameters.  Older versions of GCC either don't have the latter ability or
-// cannot disambiguate between keyword's overloaded operators.
+// parameters; function template default arguments, needed by the code
+// generation macros; and the ability to handle multiple parameter packs,
+// needed by parameters.  Older versions of GCC either don't have the latter
+// ability or cannot disambiguate between keyword's overloaded
+// operators.  Older versions of Clang either fail to compile due to
+// differences in length between parameter packs 'Args' and 'args' or fail at
+// runtime due to segmentation faults.
 // -- Cromwell D. Enage
 #if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
     !defined(BOOST_PARAMETER_DISABLE_PERFECT_FORWARDING) && \
@@ -25,12 +29,31 @@
     !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING) && \
     !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
     !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
-    !BOOST_WORKAROUND(BOOST_GCC, < 40900)
+    !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) && \
+    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && !( \
+        defined(BOOST_CLANG) && (1 == BOOST_CLANG) && ( \
+            (__clang_major__ < 3) || ( \
+                (3 == __clang_major__) && (__clang_minor__ < 2) \
+            ) \
+        ) \
+    ) && !BOOST_WORKAROUND(BOOST_GCC, < 40900)
 #define BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 #endif
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11) && \
+    !defined(BOOST_PARAMETER_DISABLE_MP11_USAGE) && \
+    !defined(BOOST_NO_CXX11_CONSTEXPR) && \
+    !defined(BOOST_NO_CXX11_DECLTYPE_N3276) && \
+    !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && \
+    !defined(BOOST_NO_CXX11_TEMPLATE_ALIASES) && \
+    !defined(BOOST_NO_CXX11_STATIC_ASSERT) && \
+    !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS) && \
+    !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST) && \
+    !defined(BOOST_NO_CXX11_HDR_TUPLE)
+// Boost.MP11 requires C++11. -- Cromwell D. Enage
+#define BOOST_PARAMETER_CAN_USE_MP11
+#endif
 #if !defined(BOOST_PARAMETER_MAX_ARITY)
 // Unlike the variadic MPL sequences provided by Boost.Fusion,
 // boost::mpl::vector has a size limit. -- Cromwell D. Enage

--- a/include/boost/parameter/parameters.hpp
+++ b/include/boost/parameter/parameters.hpp
@@ -74,6 +74,11 @@ namespace boost { namespace parameter { namespace aux {
 #include <boost/mpl/identity.hpp>
 
 #if !defined(BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE)
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl.hpp>
+#define BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE ::boost::mp11::mp_list
+#else
 #include <boost/fusion/container/list/list_fwd.hpp>
 
 // Newer versions of MSVC fail on the evaluate_category and
@@ -98,6 +103,7 @@ namespace boost { namespace parameter { namespace aux {
 #define BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE ::boost::mpl::vector
 #endif  // BOOST_FUSION_HAS_VARIADIC_DEQUE
 #endif  // BOOST_FUSION_HAS_VARIADIC_LIST
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 #endif  // BOOST_PARAMETER_VARIADIC_MPL_SEQUENCE
 
 namespace boost { namespace parameter {


### PR DESCRIPTION
<boost/parameter/config.hpp>
* Introduce configuration macros BOOST_PARAMETER_CAN_USE_MP11 and BOOST_PARAMETER_DISABLE_MP11_USAGE.
* Update perfect forwarding support requirements to fix regressions on test matrix.

<boost/parameter/parameters.hpp>
* Allow mp11::mp_list to be default parameter_spec type if available.