### PR TITLE
Add are_tagged_arguments<>, compose(), and code generation macros

### DIFF
--- a/include/boost/parameter.hpp
+++ b/include/boost/parameter.hpp
@@ -9,6 +9,7 @@
 #define BOOST_PARAMETER_050401_HPP
 
 #include <boost/parameter/parameters.hpp>
+#include <boost/parameter/are_tagged_arguments.hpp>
 #include <boost/parameter/is_argument_pack.hpp>
 #include <boost/parameter/required.hpp>
 #include <boost/parameter/optional.hpp>
@@ -21,7 +22,9 @@
 #include <boost/parameter/macros.hpp>
 #include <boost/parameter/match.hpp>
 #include <boost/parameter/name.hpp>
+#include <boost/parameter/compose.hpp>
 #include <boost/parameter/preprocessor.hpp>
+#include <boost/parameter/preprocessor_no_spec.hpp>
 
 #endif  // include guard
 

--- a/include/boost/parameter/are_tagged_arguments.hpp
+++ b/include/boost/parameter/are_tagged_arguments.hpp
@@ -1,0 +1,125 @@
+// Copyright Cromwell D. Enage 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_HPP
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_HPP
+
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct are_tagged_arguments;
+}} // namespace boost::parameter
+
+#include <boost/parameter/aux_/is_tagged_argument.hpp>
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0>
+    struct are_tagged_arguments<TaggedArg0>
+      : ::boost::parameter::aux::is_tagged_argument<TaggedArg0>
+    {
+    };
+}} // namespace boost::parameter
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct are_tagged_arguments
+      : ::boost::mpl::if_<
+            ::boost::parameter::aux::is_tagged_argument<TaggedArg0>
+          , ::boost::parameter::are_tagged_arguments<TaggedArgs...>
+          , ::boost::mpl::false_
+        >::type
+    {
+    };
+}} // namespace boost::parameter
+
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z(z, n, false_t) , false_t>
+/**/
+
+#include <boost/parameter/aux_/is_tagged_argument.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/preprocessor/cat.hpp>
+
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_BEGIN_Z(z, n, prefix)           \
+    ::boost::mpl::eval_if<                                                   \
+        ::boost::parameter::aux::is_tagged_argument<BOOST_PP_CAT(prefix, n)>,
+/**/
+
+#include <boost/parameter/aux_/void.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/preprocessor/arithmetic/sub.hpp>
+#include <boost/preprocessor/facilities/intercept.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/repetition/enum_trailing_params.hpp>
+
+#define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_OVERLOADS_Z(z, n, prefix)       \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename prefix)>                 \
+    struct are_tagged_arguments<                                             \
+        BOOST_PP_ENUM_PARAMS_Z(z, n, prefix)                                 \
+        BOOST_PP_ENUM_TRAILING_PARAMS_Z(                                     \
+            z                                                                \
+          , BOOST_PP_SUB(BOOST_PARAMETER_MAX_ARITY, n)                       \
+          , ::boost::parameter::void_ BOOST_PP_INTERCEPT                     \
+        )                                                                    \
+    > : BOOST_PP_CAT(BOOST_PP_REPEAT_, z)(                                   \
+            n                                                                \
+          , BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_BEGIN_Z                     \
+          , prefix                                                           \
+        )                                                                    \
+        ::boost::mpl::true_                                                  \
+        BOOST_PP_CAT(BOOST_PP_REPEAT_, z)(                                   \
+            n                                                                \
+          , BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z                       \
+          , ::boost::mpl::false_                                             \
+        )::type                                                              \
+    {                                                                        \
+    };
+/**/
+
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+
+namespace boost { namespace parameter {
+
+    template <
+        BOOST_PP_ENUM_BINARY_PARAMS(
+            BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)
+          , typename TaggedArg
+          , = ::boost::parameter::void_ BOOST_PP_INTERCEPT
+        )
+    >
+    struct are_tagged_arguments;
+}} // namespace boost::parameter
+
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
+namespace boost { namespace parameter {
+
+    BOOST_PP_REPEAT_FROM_TO(
+        1
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)
+      , BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_OVERLOADS_Z
+      , TaggedArg
+    )
+}} // namespace boost::parameter
+
+#undef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_OVERLOADS_Z
+#undef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_BEGIN_Z
+#undef BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z
+
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+#endif  // include guard
+

--- a/include/boost/parameter/aux_/preprocessor/impl/forwarding_overloads.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/forwarding_overloads.hpp
@@ -47,23 +47,29 @@
 // Expands to a 0-arity forwarding function, whose job is to pass an empty
 // pack to the front-end implementation function.
 #define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_0_Z(z, n, data)            \
-    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(3, 1, data))  \
-    inline                                                                   \
-    BOOST_PARAMETER_FUNCTION_RESULT_NAME(BOOST_PP_TUPLE_ELEM(3, 1, data))<   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline BOOST_PARAMETER_FUNCTION_RESULT_NAME(                             \
+        BOOST_PP_TUPLE_ELEM(4, 1, data)                                      \
+      , BOOST_PP_TUPLE_ELEM(4, 3, data)                                      \
+    )<                                                                       \
         ::boost::parameter::aux::argument_pack<                              \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )                                                                \
         >::type                                                              \
     >::type                                                                  \
     BOOST_PARAMETER_MEMBER_FUNCTION_NAME(BOOST_PP_TUPLE_ELEM(3, 0, data))()  \
-    BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(3, 2, data), const)                 \
+    BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)                 \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
-            BOOST_PP_TUPLE_ELEM(3, 1, data)                                  \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                  \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )()()                                                            \
         );                                                                   \
     }
@@ -78,12 +84,15 @@
 // into a pack for the front-end implementation function to take in.
 #define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_1_Z(z, n, data)            \
     template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename ParameterArgumentType)>  \
-    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(3, 1, data))  \
-    inline typename                                                          \
-    BOOST_PARAMETER_FUNCTION_RESULT_NAME(BOOST_PP_TUPLE_ELEM(3, 1, data))<   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(                    \
+        BOOST_PP_TUPLE_ELEM(4, 1, data)                                      \
+      , BOOST_PP_TUPLE_ELEM(4, 3, data)                                      \
+    )<                                                                       \
         typename ::boost::parameter::aux::argument_pack<                     \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )                                                                \
           , BOOST_PP_CAT(BOOST_PP_ENUM_, z)(                                 \
                 n                                                            \
@@ -92,23 +101,27 @@
             )                                                                \
         >::type                                                              \
     >::type                                                                  \
-    BOOST_PARAMETER_MEMBER_FUNCTION_NAME(BOOST_PP_TUPLE_ELEM(3, 0, data))(   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_NAME(BOOST_PP_TUPLE_ELEM(4, 0, data))(   \
         BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, ParameterArgumentType, && a)     \
         BOOST_PARAMETER_FUNCTION_FORWARD_MATCH_Z(                            \
             z                                                                \
           , BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )                                                                \
           , n                                                                \
           , ParameterArgumentType                                            \
         )                                                                    \
-    ) BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(3, 2, data), const)               \
+    ) BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)               \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
-            BOOST_PP_TUPLE_ELEM(3, 1, data)                                  \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                  \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, data)                              \
+                BOOST_PP_TUPLE_ELEM(4, 1, data)                              \
+              , BOOST_PP_TUPLE_ELEM(4, 3, data)                              \
             )()(                                                             \
                 BOOST_PP_CAT(BOOST_PP_ENUM_, z)(                             \
                     n                                                        \
@@ -169,12 +182,21 @@
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
 
 // Helper macro for BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(name, impl, range, c) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(nm, impl, r, is_m, c) \
     BOOST_PP_REPEAT_FROM_TO(                                                 \
-        BOOST_PP_TUPLE_ELEM(2, 0, range)                                     \
-      , BOOST_PP_TUPLE_ELEM(2, 1, range)                                     \
+        BOOST_PP_TUPLE_ELEM(2, 0, r)                                         \
+      , BOOST_PP_TUPLE_ELEM(2, 1, r)                                         \
       , BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_Z                          \
-      , (name, impl, c)                                                      \
+      , (                                                                    \
+            nm                                                               \
+          , impl                                                             \
+          , BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_MEMBER_FUNCTION_IS_STATIC(nm)                \
+              , 0                                                            \
+              , is_m                                                         \
+            )                                                                \
+          , c                                                                \
+        )                                                                    \
     )
 /**/
 
@@ -192,9 +214,9 @@
 
 // Expands to the layer of forwarding functions for the function with the
 // specified name, whose arguments determine the range of arities.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, args, const_) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, a, is_m, c)   \
     BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(                          \
-        name, impl, BOOST_PARAMETER_ARITY_RANGE(args), const_                \
+        name, impl, BOOST_PARAMETER_ARITY_RANGE(a), is_m, c                  \
     )
 /**/
 
@@ -236,41 +258,58 @@
 #define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_0_ARITY(z, n, seq)         \
     BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(                                  \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
     )                                                                        \
     inline BOOST_PARAMETER_FUNCTION_RESULT_NAME(                             \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+        )                                                                    \
+      , BOOST_PP_TUPLE_ELEM(                                                 \
+            4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
     )<                                                                       \
         ::boost::parameter::aux::argument_pack<                              \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
                 BOOST_PP_TUPLE_ELEM(                                         \
-                    3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                    4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                )                                                            \
+              , BOOST_PP_TUPLE_ELEM(                                         \
+                    4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
                 )                                                            \
             )                                                                \
         >::type                                                              \
     >::type                                                                  \
     BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                    \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 0, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 0, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
     )() BOOST_PP_EXPR_IF(                                                    \
         BOOST_PP_TUPLE_ELEM(                                                 \
-            3, 2, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
+            4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))                  \
         )                                                                    \
       , const                                                                \
     )                                                                        \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
+        return BOOST_PP_EXPR_IF(                                             \
             BOOST_PP_TUPLE_ELEM(                                             \
-                3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
+                4, 2, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
+            )                                                                \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                \
+            BOOST_PP_TUPLE_ELEM(                                             \
+                4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
+            )                                                                \
+          , BOOST_PP_TUPLE_ELEM(                                             \
+                4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))              \
             )                                                                \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
                 BOOST_PP_TUPLE_ELEM(                                         \
-                    3, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                    4, 1, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
+                )                                                            \
+              , BOOST_PP_TUPLE_ELEM(                                         \
+                    4, 3, BOOST_PP_SEQ_HEAD(BOOST_PP_SEQ_TAIL(seq))          \
                 )                                                            \
             )()()                                                            \
         );                                                                   \
@@ -332,14 +371,16 @@
         )                                                                    \
     >                                                                        \
     BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(                                  \
-        BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))                    \
+        BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))                    \
     )                                                                        \
     inline typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(                    \
-        BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))                    \
+        BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))                    \
+      , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))                    \
     )<                                                                       \
         typename ::boost::parameter::aux::argument_pack<                     \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))            \
+                BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))            \
+              , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))            \
             )                                                                \
           , BOOST_PARAMETER_AUX_PP_BINARY_SEQ_TO_ARGS(                       \
                 BOOST_PP_SEQ_TAIL(seq), (ParameterArgumentType)              \
@@ -347,27 +388,33 @@
         >::type                                                              \
     >::type                                                                  \
     BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                    \
-        BOOST_PP_TUPLE_ELEM(3, 0, BOOST_PP_SEQ_HEAD(seq))                    \
+        BOOST_PP_TUPLE_ELEM(4, 0, BOOST_PP_SEQ_HEAD(seq))                    \
     )(                                                                       \
         BOOST_PARAMETER_AUX_PP_BINARY_SEQ_TO_ARGS(                           \
             BOOST_PP_SEQ_TAIL(seq), (ParameterArgumentType)(a)               \
         )                                                                    \
         BOOST_PARAMETER_FUNCTION_FORWARD_MATCH(                              \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))            \
+                BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))            \
+              , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))            \
             )                                                                \
           , BOOST_PP_SEQ_SIZE(BOOST_PP_SEQ_TAIL(seq))                        \
           , ParameterArgumentType                                            \
         )                                                                    \
     ) BOOST_PP_EXPR_IF(                                                      \
-        BOOST_PP_TUPLE_ELEM(3, 2, BOOST_PP_SEQ_HEAD(seq)), const             \
+        BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq)), const             \
     )                                                                        \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_IMPL_NAME(                           \
-            BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))                \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PP_TUPLE_ELEM(4, 2, BOOST_PP_SEQ_HEAD(seq))                \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_IMPL_NAME(                                \
+            BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))                \
+          , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))                \
         )(                                                                   \
             BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(                     \
-                BOOST_PP_TUPLE_ELEM(3, 1, BOOST_PP_SEQ_HEAD(seq))            \
+                BOOST_PP_TUPLE_ELEM(4, 1, BOOST_PP_SEQ_HEAD(seq))            \
+              , BOOST_PP_TUPLE_ELEM(4, 3, BOOST_PP_SEQ_HEAD(seq))            \
             )()(                                                             \
                 BOOST_PP_ENUM_PARAMS(                                        \
                     BOOST_PP_SEQ_SIZE(BOOST_PP_SEQ_TAIL(seq)), a             \
@@ -415,12 +462,21 @@
 /**/
 
 // Helper macro for BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(name, impl, range, c) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(nm, impl, r, is_m, c) \
     BOOST_PP_REPEAT_FROM_TO(                                                 \
-        BOOST_PP_TUPLE_ELEM(2, 0, range)                                     \
-      , BOOST_PP_TUPLE_ELEM(2, 1, range)                                     \
+        BOOST_PP_TUPLE_ELEM(2, 0, r)                                         \
+      , BOOST_PP_TUPLE_ELEM(2, 1, r)                                         \
       , BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOAD_Z                          \
-      , (name, impl, c)                                                      \
+      , (                                                                    \
+            nm                                                               \
+          , impl                                                             \
+          , BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_MEMBER_FUNCTION_IS_STATIC(impl)              \
+              , 0                                                            \
+              , is_m                                                         \
+            )                                                                \
+          , c                                                                \
+        )                                                                    \
     )
 /**/
 
@@ -438,12 +494,13 @@
 
 // Expands to the layer of forwarding functions for the function with the
 // specified name, whose arguments determine the range of arities.
-#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, args, const_) \
+#define BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, a, is_m, c)   \
     BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS_AUX(                          \
         name                                                                 \
       , impl                                                                 \
-      , BOOST_PARAMETER_ARITY_RANGE(args)                                    \
-      , const_                                                               \
+      , BOOST_PARAMETER_ARITY_RANGE(a)                                       \
+      , is_m                                                                 \
+      , c                                                                    \
     )
 /**/
 

--- a/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_layer.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_layer.hpp
@@ -79,6 +79,24 @@
 
 #include <boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp>
 #include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
+#include <boost/preprocessor/control/if.hpp>
+
+// Produces a name for the dispatch functions.
+#define BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, n)                         \
+    BOOST_PP_CAT(                                                            \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                \
+              , boost_param_dispatch_const_                                  \
+              , boost_param_dispatch_                                        \
+            )                                                                \
+          , BOOST_PP_CAT(BOOST_PP_CAT(n, boost_), __LINE__)                  \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                   \
+        )                                                                    \
+    )
+/**/
 
 // Expands to the template parameter list of the dispatch function with all
 // required and first n optional parameters; also extracts the static keyword
@@ -281,7 +299,10 @@
     BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_TPL(n, x)                         \
     inline BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_PRN(n, x, 0, 0)            \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                      \
             static_cast<ResultType(*)()>(BOOST_TTI_DETAIL_NULLPTR)           \
           , args                                                             \
           , 0L                                                               \
@@ -304,7 +325,10 @@
     BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_TPL(n, x)                         \
     inline BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_PRN(n, x, 1, 0)            \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                      \
             static_cast<ResultType(*)()>(BOOST_TTI_DETAIL_NULLPTR)           \
           , args                                                             \
           , 0L                                                               \
@@ -331,7 +355,10 @@
     BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_TPL(n, x)                         \
     inline BOOST_PARAMETER_FUNCTION_DISPATCH_HEAD_PRN(n, x, 0, 1)            \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 1)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 1)(                      \
             static_cast<ResultType(*)()>(BOOST_TTI_DETAIL_NULLPTR)           \
           , (args                                                            \
               , BOOST_PARAMETER_FUNCTION_DISPATCH_DEFAULT(                   \
@@ -357,7 +384,7 @@
 
 // x is a tuple:
 //
-//   (base_name, split_args, is_const, tag_namespace)
+//   (base_name, split_args, is_member, is_const, tag_namespace)
 //
 // Generates all dispatch functions for the function named base_name.  Each
 // dispatch function that takes in n optional parameters passes the default
@@ -391,15 +418,21 @@
         BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
     ) inline typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(                  \
         BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
+      , BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                        \
     )<Args>::type BOOST_PARAMETER_FUNCTION_IMPL_NAME(                        \
         BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
+      , BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                        \
     )(Args const& args)                                                      \
     BOOST_PP_EXPR_IF(BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x), const)   \
     {                                                                        \
-        return BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                 \
+        return BOOST_PP_EXPR_IF(                                             \
+            BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                   \
+          , this->                                                           \
+        ) BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, 0)(                      \
             static_cast<                                                     \
                 typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(               \
                     BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)           \
+                  , BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)            \
                 )<Args>::type(*)()                                           \
             >(BOOST_TTI_DETAIL_NULLPTR)                                      \
           , args                                                             \

--- a/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp
@@ -10,19 +10,23 @@
 
 // Accessor macros for the input tuple to the dispatch macros.
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                       \
-    BOOST_PP_TUPLE_ELEM(4, 0, x)
+    BOOST_PP_TUPLE_ELEM(5, 0, x)
 /**/
 
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_SPLIT_ARGS(x)                      \
-    BOOST_PP_TUPLE_ELEM(4, 1, x)
+    BOOST_PP_TUPLE_ELEM(5, 1, x)
+/**/
+
+#define BOOST_PARAMETER_FUNCTION_DISPATCH_IS_MEMBER(x)                       \
+    BOOST_PP_TUPLE_ELEM(5, 2, x)
 /**/
 
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_IS_CONST(x)                        \
-    BOOST_PP_TUPLE_ELEM(4, 2, x)
+    BOOST_PP_TUPLE_ELEM(5, 3, x)
 /**/
 
 #define BOOST_PARAMETER_FUNCTION_DISPATCH_TAG_NAMESPACE(x)                   \
-    BOOST_PP_TUPLE_ELEM(4, 3, x)
+    BOOST_PP_TUPLE_ELEM(5, 4, x)
 /**/
 
 #endif  // include guard

--- a/include/boost/parameter/aux_/preprocessor/impl/function_name.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_name.hpp
@@ -72,18 +72,64 @@
 /**/
 
 // Produces a name for a parameter specification for the function named base.
-#define BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(base)                    \
+#define BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(base, is_const)          \
     BOOST_PP_CAT(                                                            \
-        BOOST_PP_CAT(boost_param_parameters_, __LINE__)                      \
-      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(name)                           \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_parameters_const_                                \
+              , boost_param_parameters_                                      \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
+    )
+/**/
+
+// Produces a name for a result type metafunction for the no-spec function
+// named base.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(base, is_const)         \
+    BOOST_PP_CAT(                                                            \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_no_spec_result_const_                            \
+              , boost_param_no_spec_result_                                  \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )
 /**/
 
 // Produces a name for a result type metafunction for the function named base.
-#define BOOST_PARAMETER_FUNCTION_RESULT_NAME(base)                           \
+#define BOOST_PARAMETER_FUNCTION_RESULT_NAME(base, is_const)                 \
     BOOST_PP_CAT(                                                            \
-        BOOST_PP_CAT(boost_param_result_, __LINE__)                          \
-      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(name)                           \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_result_const_                                    \
+              , boost_param_result_                                          \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
+    )
+/**/
+
+// Produces a name for the implementation function to which the no-spec
+// function named base forwards its result type and argument pack.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(base, is_const)           \
+    BOOST_PP_CAT(                                                            \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_no_spec_impl_const                               \
+              , boost_param_no_spec_impl                                     \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )
 /**/
 
@@ -92,22 +138,13 @@
 // daniel: what? how is that relevant? the reason for using CAT()
 // is to make sure base is expanded. i'm not sure we need to here,
 // but it's more stable to do it.
-#define BOOST_PARAMETER_FUNCTION_IMPL_NAME(base)                             \
-    BOOST_PP_CAT(boost_param_impl, BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base))
-/**/
-
-#include <boost/parameter/aux_/preprocessor/impl/function_dispatch_tuple.hpp>
-
-// Produces a name for the dispatch functions.
-#define BOOST_PARAMETER_FUNCTION_DISPATCH_NAME(x, n)                         \
+#define BOOST_PARAMETER_FUNCTION_IMPL_NAME(base, is_const)                   \
     BOOST_PP_CAT(                                                            \
         BOOST_PP_CAT(                                                        \
-            BOOST_PP_CAT(boost_param_dispatch_, n)                           \
-          , BOOST_PP_CAT(boost_, __LINE__)                                   \
+            BOOST_PP_IF(is_const, boost_param_impl_const, boost_param_impl)  \
+          , __LINE__                                                         \
         )                                                                    \
-      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                \
-            BOOST_PARAMETER_FUNCTION_DISPATCH_BASE_NAME(x)                   \
-        )                                                                    \
+      , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )
 /**/
 

--- a/include/boost/parameter/aux_/preprocessor/impl/no_spec_overloads.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/no_spec_overloads.hpp
@@ -1,0 +1,321 @@
+// Copyright Cromwell D. Enage 2019.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_NO_SPEC_OVERLOADS_HPP
+#define BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_NO_SPEC_OVERLOADS_HPP
+
+#include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
+
+// Defines the no-spec implementation function header.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_HEAD(name, is_const)           \
+    template <typename ResultType, typename Args>                            \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(name) ResultType                  \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(                          \
+            name, is_const                                                   \
+        )(ResultType(*)(), Args const& args)
+/**/
+
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
+
+// Expands to the result metafunction for the specified no-spec function.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, name, is_const)        \
+    template <typename TaggedArg0, typename ...TaggedArgs>                   \
+    struct BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(name, is_const)      \
+    {                                                                        \
+        typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
+    };
+/**/
+
+#include <boost/parameter/compose.hpp>
+#include <boost/parameter/are_tagged_arguments.hpp>
+#include <boost/core/enable_if.hpp>
+
+// Exapnds to a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The enclosing class must inherit from the
+// specified base class, which in turn must implement a constructor that takes
+// in the argument pack that this one passes on.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(class_, base)                    \
+    template <                                                               \
+        typename TaggedArg0                                                  \
+      , typename ...TaggedArgs                                               \
+      , typename = typename ::boost::enable_if<                              \
+            ::boost::parameter                                               \
+            ::are_tagged_arguments<TaggedArg0,TaggedArgs...>                 \
+        >::type                                                              \
+    > inline explicit                                                        \
+    class_(TaggedArg0 const& arg0, TaggedArgs const&... args)                \
+      : BOOST_PARAMETER_PARENTHESIZED_TYPE(base)(                            \
+            ::boost::parameter::compose(arg0, args...)                       \
+        )                                                                    \
+    {                                                                        \
+    }
+/**/
+
+// Exapnds to a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The specified function must be able to
+// take in the argument pack that this constructor passes on.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(class_, func)            \
+    template <                                                               \
+        typename TaggedArg0                                                  \
+      , typename ...TaggedArgs                                               \
+      , typename = typename ::boost::enable_if<                              \
+            ::boost::parameter                                               \
+            ::are_tagged_arguments<TaggedArg0,TaggedArgs...>                 \
+        >::type                                                              \
+    > inline explicit                                                        \
+    class_(TaggedArg0 const& arg0, TaggedArgs const&... args)                \
+    {                                                                        \
+        func(::boost::parameter::compose(arg0, args...));                    \
+    }
+/**/
+
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/preprocessor/control/expr_if.hpp>
+
+// Exapnds to a variadic function that is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD(name, impl, is_m, c)       \
+    template <typename TaggedArg0, typename ...TaggedArgs>                   \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(impl)                             \
+    inline typename ::boost::lazy_enable_if<                                 \
+        ::boost::parameter                                                   \
+        ::are_tagged_arguments<TaggedArg0,TaggedArgs...>                     \
+      , BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(                        \
+            impl, c                                                          \
+        )<TaggedArg0,TaggedArgs...>                                          \
+    >::type BOOST_PARAMETER_MEMBER_FUNCTION_NAME(name)                       \
+    (TaggedArg0 const& arg0, TaggedArgs const&... args)                      \
+    BOOST_PP_EXPR_IF(c, const)                                               \
+    {                                                                        \
+        return BOOST_PP_EXPR_IF(is_m, this->)                                \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(impl, c)(                 \
+            static_cast<                                                     \
+                typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(       \
+                    impl, c                                                  \
+                )<TaggedArg0,TaggedArgs...>::type(*)()                       \
+            >(BOOST_TTI_DETAIL_NULLPTR)                                      \
+          , ::boost::parameter::compose(arg0, args...)                       \
+        );                                                                   \
+    }
+/**/
+
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+#include <boost/parameter/aux_/void.hpp>
+#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
+#include <boost/preprocessor/facilities/intercept.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+
+// Expands to the result metafunction for the specified no-spec function.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, name, is_const)        \
+    template <                                                               \
+        BOOST_PP_ENUM_BINARY_PARAMS(                                         \
+            BOOST_PARAMETER_MAX_ARITY                                        \
+          , typename TaggedArg                                               \
+          , = ::boost::parameter::void_ BOOST_PP_INTERCEPT                   \
+        )                                                                    \
+    >                                                                        \
+    struct BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(name, is_const)      \
+    {                                                                        \
+        typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
+    };
+/**/
+
+#include <boost/parameter/compose.hpp>
+#include <boost/preprocessor/comparison/equal.hpp>
+#include <boost/preprocessor/control/expr_if.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/tuple/elem.hpp>
+
+#if defined(BOOST_NO_SFINAE)
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the base class delegate constructor.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR_OVERLOAD_Z(z, n, data)           \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+    ) : BOOST_PARAMETER_PARENTHESIZED_TYPE(BOOST_PP_TUPLE_ELEM(2, 1, data))( \
+            ::boost::parameter::compose(BOOST_PP_ENUM_PARAMS_Z(z, n, arg))   \
+        )                                                                    \
+    {                                                                        \
+    }
+/**/
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the delegate function.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR_OVERLOAD_Z(z, n, data)   \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& a)             \
+    )                                                                        \
+    {                                                                        \
+        BOOST_PP_TUPLE_ELEM(2, 1, data)(                                     \
+            ::boost::parameter::compose(BOOST_PP_ENUM_PARAMS_Z(z, n, a))     \
+        );                                                                   \
+    }
+/**/
+
+#include <boost/tti/detail/dnullptr.hpp>
+
+// Exapnds to a tagged-argument function overload.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD_Z(z, n, data)              \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(            \
+        BOOST_PP_TUPLE_ELEM(4, 1, data)                                      \
+      , BOOST_PP_TUPLE_ELEM(4, 3, data)                                      \
+    )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>::type                         \
+        BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                                \
+            BOOST_PP_TUPLE_ELEM(4, 0, data)                                  \
+        )(BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg))        \
+        BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)             \
+    {                                                                        \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(                          \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
+        )(                                                                   \
+            static_cast<                                                     \
+                typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(       \
+                    BOOST_PP_TUPLE_ELEM(4, 1, data)                          \
+                  , BOOST_PP_TUPLE_ELEM(4, 3, data)                          \
+                )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>::type(*)()        \
+            >(BOOST_TTI_DETAIL_NULLPTR)                                      \
+          , ::boost::parameter::compose(BOOST_PP_ENUM_PARAMS_Z(z, n, arg))   \
+        );                                                                   \
+    }
+/**/
+
+#else   // !defined(BOOST_NO_SFINAE)
+
+#include <boost/parameter/are_tagged_arguments.hpp>
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the base class delegate constructor.  This constructor is enabled
+// if and only if all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR_OVERLOAD_Z(z, n, data)           \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg)           \
+      , typename ::boost::enable_if<                                         \
+            ::boost::parameter::are_tagged_arguments<                        \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)                      \
+            >                                                                \
+        >::type* = BOOST_TTI_DETAIL_NULLPTR                                  \
+    ) : BOOST_PARAMETER_PARENTHESIZED_TYPE(BOOST_PP_TUPLE_ELEM(2, 1, data))( \
+            ::boost::parameter::compose(BOOST_PP_ENUM_PARAMS_Z(z, n, arg))   \
+        )                                                                    \
+    {                                                                        \
+    }
+/**/
+
+// Exapnds to a tagged-argument constructor overload that passes the argument
+// pack to the delegate function.  This constructor is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR_OVERLOAD_Z(z, n, data)   \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PP_EXPR_IF(BOOST_PP_EQUAL(n, 1), explicit) inline                  \
+    BOOST_PP_TUPLE_ELEM(2, 0, data)(                                         \
+        BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& a)             \
+      , typename ::boost::enable_if<                                         \
+            ::boost::parameter::are_tagged_arguments<                        \
+                BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)                      \
+            >                                                                \
+        >::type* = BOOST_TTI_DETAIL_NULLPTR                                  \
+    )                                                                        \
+    {                                                                        \
+        BOOST_PP_TUPLE_ELEM(2, 1, data)(                                     \
+            ::boost::parameter::compose(BOOST_PP_ENUM_PARAMS_Z(z, n, a))     \
+        );                                                                   \
+    }
+/**/
+
+// Exapnds to a function overload that is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD_Z(z, n, data)              \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename TaggedArg)>              \
+    BOOST_PARAMETER_MEMBER_FUNCTION_STATIC(BOOST_PP_TUPLE_ELEM(4, 1, data))  \
+    inline typename ::boost::lazy_enable_if<                                 \
+        ::boost::parameter                                                   \
+        ::are_tagged_arguments<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>      \
+      , BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(                        \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
+        )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>                           \
+    >::type BOOST_PARAMETER_MEMBER_FUNCTION_NAME(                            \
+        BOOST_PP_TUPLE_ELEM(4, 0, data)                                      \
+    )(BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, TaggedArg, const& arg))            \
+    BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 3, data), const)                 \
+    {                                                                        \
+        return BOOST_PP_EXPR_IF(BOOST_PP_TUPLE_ELEM(4, 2, data), this->)     \
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_NAME(                          \
+            BOOST_PP_TUPLE_ELEM(4, 1, data)                                  \
+          , BOOST_PP_TUPLE_ELEM(4, 3, data)                                  \
+        )(                                                                   \
+            static_cast<                                                     \
+                typename BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(       \
+                    BOOST_PP_TUPLE_ELEM(4, 1, data)                          \
+                  , BOOST_PP_TUPLE_ELEM(4, 3, data)                          \
+                )<BOOST_PP_ENUM_PARAMS_Z(z, n, TaggedArg)>::type(*)()        \
+            >(BOOST_TTI_DETAIL_NULLPTR)                                      \
+          , ::boost::parameter::compose(BOOST_PP_ENUM_PARAMS_Z(z, n, arg))   \
+        );                                                                   \
+    }
+/**/
+
+#endif  // BOOST_NO_SFINAE
+
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
+// Emulates a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The enclosing class must inherit from the
+// specified base class, which in turn must implement a constructor that takes
+// in the argument pack that this one passes on.
+#define BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(class_, base)                    \
+    BOOST_PP_REPEAT_FROM_TO(                                                 \
+        1                                                                    \
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)                              \
+      , BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR_OVERLOAD_Z                       \
+      , (class_, base)                                                       \
+    )
+/**/
+
+// Emulates a variadic constructor that is enabled if and only if all its
+// arguments are tagged arguments.  The specified function must be able to
+// take in the argument pack that this constructor passes on.
+#define BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(class_, func)            \
+    BOOST_PP_REPEAT_FROM_TO(                                                 \
+        1                                                                    \
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)                              \
+      , BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR_OVERLOAD_Z               \
+      , (class_, func)                                                       \
+    )
+/**/
+
+// Emulates a variadic function that is enabled if and only if
+// all its arguments are tagged arguments.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD(name, impl, is_m, c)       \
+    BOOST_PP_REPEAT_FROM_TO(                                                 \
+        1                                                                    \
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)                              \
+      , BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD_Z                          \
+      , (name, impl, is_m, c)                                                \
+    )
+/**/
+
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+#endif  // include guard
+

--- a/include/boost/parameter/aux_/preprocessor/impl/specification.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/specification.hpp
@@ -67,15 +67,23 @@
 
 #include <boost/parameter/parameters.hpp>
 #include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
+#include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 
 // Expands to a boost::parameter::parameters<> specialization for the
 // function named base.  Used by BOOST_PARAMETER_CONSTRUCTOR_AUX and
 // BOOST_PARAMETER_FUNCTION_HEAD for their respective ParameterSpec models.
-#define BOOST_PARAMETER_SPECIFICATION(tag_ns, base, split_args)              \
+#define BOOST_PARAMETER_SPECIFICATION(tag_ns, base, split_args, is_const)    \
     template <typename BoostParameterDummy>                                  \
     struct BOOST_PP_CAT(                                                     \
-        BOOST_PP_CAT(boost_param_params_, __LINE__)                          \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_params_const_                                    \
+              , boost_param_params_                                          \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
       , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     ) : ::boost::parameter::parameters<                                      \
             BOOST_PP_SEQ_FOR_EACH_I(                                         \
@@ -85,7 +93,14 @@
     {                                                                        \
     };                                                                       \
     typedef BOOST_PP_CAT(                                                    \
-        BOOST_PP_CAT(boost_param_params_, __LINE__)                          \
+        BOOST_PP_CAT(                                                        \
+            BOOST_PP_IF(                                                     \
+                is_const                                                     \
+              , boost_param_params_const_                                    \
+              , boost_param_params_                                          \
+            )                                                                \
+          , __LINE__                                                         \
+        )                                                                    \
       , BOOST_PARAMETER_MEMBER_FUNCTION_NAME(base)                           \
     )<int>
 /**/

--- a/include/boost/parameter/compose.hpp
+++ b/include/boost/parameter/compose.hpp
@@ -1,0 +1,157 @@
+// Copyright Cromwell D. Enage 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_COMPOSE_HPP
+#define BOOST_PARAMETER_COMPOSE_HPP
+
+#include <boost/parameter/aux_/arg_list.hpp>
+
+namespace boost { namespace parameter {
+
+    inline ::boost::parameter::aux::empty_arg_list compose()
+    {
+        return ::boost::parameter::aux::empty_arg_list();
+    }
+}} // namespace boost::parameter
+
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct compose_arg_list;
+
+    template <typename TaggedArg0>
+    struct compose_arg_list<TaggedArg0>
+    {
+        typedef ::boost::parameter::aux::arg_list<TaggedArg0> type;
+    };
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    struct compose_arg_list
+    {
+        typedef ::boost::parameter::aux::arg_list<
+            TaggedArg0
+          , typename ::boost::parameter::aux
+            ::compose_arg_list<TaggedArgs...>::type
+        > type;
+    };
+}}} // namespace boost::parameter::aux
+
+#include <boost/parameter/are_tagged_arguments.hpp>
+#include <boost/core/enable_if.hpp>
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    inline typename ::boost::lazy_enable_if<
+        ::boost::parameter::are_tagged_arguments<TaggedArg0,TaggedArgs...>
+      , ::boost::parameter::aux
+        ::compose_arg_list<TaggedArg0,TaggedArgs...>
+    >::type
+        compose(TaggedArg0 const& arg0, TaggedArgs const&... args)
+    {
+        return typename ::boost::parameter::aux
+        ::compose_arg_list<TaggedArg0,TaggedArgs...>::type(
+            ::boost::parameter::aux::value_type_is_not_void()
+          , arg0
+          , args...
+        );
+    }
+}} // namespace boost::parameter
+
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+
+#define BOOST_PARAMETER_compose_arg_list_type_suffix(z, n, suffix) suffix
+
+#include <boost/preprocessor/cat.hpp>
+
+#define BOOST_PARAMETER_compose_arg_list_type_prefix(z, n, prefix)           \
+    ::boost::parameter::aux::arg_list<BOOST_PP_CAT(prefix, n)
+/**/
+
+#include <boost/preprocessor/facilities/intercept.hpp>
+#include <boost/preprocessor/repetition/enum.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+
+#define BOOST_PARAMETER_compose_arg_list_type(z, n, prefix)                  \
+    BOOST_PP_CAT(BOOST_PP_ENUM_, z)(                                         \
+        n, BOOST_PARAMETER_compose_arg_list_type_prefix, prefix              \
+    ) BOOST_PP_CAT(BOOST_PP_REPEAT_, z)(                                     \
+        n, BOOST_PARAMETER_compose_arg_list_type_suffix, >                   \
+    )
+/**/
+
+#include <boost/parameter/aux_/void.hpp>
+#include <boost/preprocessor/arithmetic/sub.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp>
+#include <boost/preprocessor/repetition/enum_binary_params.hpp>
+#include <boost/preprocessor/repetition/enum_trailing_params.hpp>
+
+#if defined(BOOST_NO_SFINAE)
+#define BOOST_PARAMETER_compose_arg_list_function_overload(z, n, prefix)     \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename prefix)>                 \
+    inline                                                                   \
+    BOOST_PARAMETER_compose_arg_list_type(z, n, prefix)                      \
+        compose(BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, prefix, const& a))       \
+    {                                                                        \
+        return BOOST_PARAMETER_compose_arg_list_type(z, n, prefix)(          \
+            BOOST_PP_ENUM_PARAMS_Z(z, n, a)                                  \
+            BOOST_PP_ENUM_TRAILING_PARAMS_Z(                                 \
+                z                                                            \
+              , BOOST_PP_SUB(BOOST_PARAMETER_MAX_ARITY, n)                   \
+              , ::boost::parameter::aux::void_reference() BOOST_PP_INTERCEPT \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+#else   // !defined(BOOST_NO_SFINAE)
+#include <boost/parameter/are_tagged_arguments.hpp>
+#include <boost/core/enable_if.hpp>
+
+#define BOOST_PARAMETER_compose_arg_list_function_overload(z, n, prefix)     \
+    template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename prefix)>                 \
+    inline typename ::boost::enable_if<                                      \
+        ::boost::parameter                                                   \
+        ::are_tagged_arguments<BOOST_PP_ENUM_PARAMS_Z(z, n, prefix)>         \
+      , BOOST_PARAMETER_compose_arg_list_type(z, n, prefix)                  \
+    >::type                                                                  \
+        compose(BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, prefix, const& a))       \
+    {                                                                        \
+        return BOOST_PARAMETER_compose_arg_list_type(z, n, prefix)(          \
+            BOOST_PP_ENUM_PARAMS_Z(z, n, a)                                  \
+            BOOST_PP_ENUM_TRAILING_PARAMS_Z(                                 \
+                z                                                            \
+              , BOOST_PP_SUB(BOOST_PARAMETER_MAX_ARITY, n)                   \
+              , ::boost::parameter::aux::void_reference() BOOST_PP_INTERCEPT \
+            )                                                                \
+        );                                                                   \
+    }
+/**/
+#endif  // BOOST_NO_SFINAE
+
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+
+namespace boost { namespace parameter {
+
+    BOOST_PP_REPEAT_FROM_TO(
+        1
+      , BOOST_PP_INC(BOOST_PARAMETER_MAX_ARITY)
+      , BOOST_PARAMETER_compose_arg_list_function_overload
+      , TaggedArg
+    )
+}} // namespace boost::parameter
+
+#undef BOOST_PARAMETER_compose_arg_list_function_overload
+#undef BOOST_PARAMETER_compose_arg_list_type
+#undef BOOST_PARAMETER_compose_arg_list_type_prefix
+#undef BOOST_PARAMETER_compose_arg_list_type_suffix
+
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+#endif  // include guard
+

--- a/include/boost/parameter/preprocessor.hpp
+++ b/include/boost/parameter/preprocessor.hpp
@@ -13,7 +13,7 @@
 
 // Helper macro for BOOST_PARAMETER_CONSTRUCTOR.
 #define BOOST_PARAMETER_CONSTRUCTOR_AUX(class_, base, tag_namespace, args)   \
-    BOOST_PARAMETER_SPECIFICATION(tag_namespace, ctor, args)                 \
+    BOOST_PARAMETER_SPECIFICATION(tag_namespace, ctor, args, 0)              \
         BOOST_PP_CAT(constructor_parameters, __LINE__);                      \
     BOOST_PARAMETER_CONSTRUCTOR_OVERLOADS(class_, base, args)
 /**/
@@ -21,42 +21,46 @@
 #include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
 
 // Defines the implementation function header.
-#define BOOST_PARAMETER_FUNCTION_IMPL_HEAD(name)                             \
+#define BOOST_PARAMETER_FUNCTION_IMPL_HEAD(name, is_const)                   \
     template <typename Args>                                                 \
-    typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(name)<                     \
+    typename BOOST_PARAMETER_FUNCTION_RESULT_NAME(name, is_const)<           \
         Args                                                                 \
-    >::type BOOST_PARAMETER_FUNCTION_IMPL_NAME(name)(Args const& args)
+    >::type BOOST_PARAMETER_FUNCTION_IMPL_NAME(name, is_const)(              \
+        Args const& args                                                     \
+    )
 /**/
 
 #include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
 
 // Expands to the result metafunction and the parameters specialization.
-#define BOOST_PARAMETER_FUNCTION_HEAD(result, name, tag_namespace, args)     \
+#define BOOST_PARAMETER_FUNCTION_HEAD(result, name, tag_ns, args, is_const)  \
     template <typename Args>                                                 \
-    struct BOOST_PARAMETER_FUNCTION_RESULT_NAME(name)                        \
+    struct BOOST_PARAMETER_FUNCTION_RESULT_NAME(name, is_const)              \
     {                                                                        \
         typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
     };                                                                       \
-    BOOST_PARAMETER_SPECIFICATION(tag_namespace, name, args)                 \
-        BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(name);
+    BOOST_PARAMETER_SPECIFICATION(tag_ns, name, args, is_const)              \
+        BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(name, is_const);
 /**/
 
 // Helper macro for BOOST_PARAMETER_BASIC_FUNCTION.
 #define BOOST_PARAMETER_BASIC_FUNCTION_AUX(result, name, tag_ns, args)       \
-    BOOST_PARAMETER_FUNCTION_HEAD(result, name, tag_ns, args)                \
-    BOOST_PARAMETER_FUNCTION_IMPL_HEAD(name);                                \
-    BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, name, args, 0)          \
-    BOOST_PARAMETER_FUNCTION_IMPL_HEAD(name)
+    BOOST_PARAMETER_FUNCTION_HEAD(result, name, tag_ns, args, 0)             \
+    BOOST_PARAMETER_FUNCTION_IMPL_HEAD(name, 0);                             \
+    BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, name, args, 0, 0)       \
+    BOOST_PARAMETER_FUNCTION_IMPL_HEAD(name, 0)
 /**/
 
 #include <boost/preprocessor/control/expr_if.hpp>
 
-// Helper macro for BOOST_PARAMETER_BASIC_MEMBER_FUNCTION
-// and BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION.
-#define BOOST_PARAMETER_BASIC_MEMBER_FUNCTION_AUX(r, name, tag_ns, args, c)  \
-    BOOST_PARAMETER_FUNCTION_HEAD(r, name, tag_ns, args)                     \
-    BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, name, args, c)          \
-    BOOST_PARAMETER_FUNCTION_IMPL_HEAD(name) BOOST_PP_EXPR_IF(c, const)
+// Helper macro for BOOST_PARAMETER_BASIC_MEMBER_FUNCTION,
+// BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION,
+// BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR, and
+// BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR.
+#define BOOST_PARAMETER_BASIC_MEMBER_FUNCTION_AUX(r, n, i, tag_ns, args, c)  \
+    BOOST_PARAMETER_FUNCTION_HEAD(r, i, tag_ns, args, c)                     \
+    BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(n, i, args, 1, c)             \
+    BOOST_PARAMETER_FUNCTION_IMPL_HEAD(i, c) BOOST_PP_EXPR_IF(c, const)
 /**/
 
 #include <boost/parameter/aux_/preprocessor/impl/flatten.hpp>
@@ -83,7 +87,7 @@
 // are accessible via args and keywords only.
 #define BOOST_PARAMETER_BASIC_MEMBER_FUNCTION(result, name, tag_ns, args)    \
     BOOST_PARAMETER_BASIC_MEMBER_FUNCTION_AUX(                               \
-        result, name, tag_ns                                                 \
+        result, name, name, tag_ns                                           \
       , BOOST_PARAMETER_AUX_PP_FLATTEN(2, 2, 3, args), 0                     \
     )
 /**/
@@ -92,7 +96,25 @@
 // header.  All arguments are accessible via args and keywords only.
 #define BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION(r, name, tag_ns, args)   \
     BOOST_PARAMETER_BASIC_MEMBER_FUNCTION_AUX(                               \
-        r, name, tag_ns                                                      \
+        r, name, name, tag_ns                                                \
+      , BOOST_PARAMETER_AUX_PP_FLATTEN(2, 2, 3, args), 1                     \
+    )
+/**/
+
+// Expands to a Boost.Parameter-enabled function call operator header.  All
+// arguments are accessible via args and keywords only.
+#define BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR(result, tag_ns, args)   \
+    BOOST_PARAMETER_BASIC_MEMBER_FUNCTION_AUX(                               \
+        result, operator(), operator, tag_ns                                 \
+      , BOOST_PARAMETER_AUX_PP_FLATTEN(2, 2, 3, args), 0                     \
+    )
+/**/
+
+// Expands to a Boost.Parameter-enabled const-qualified function call
+// operator header.  All arguments are accessible via args and keywords only.
+#define BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR(r, tag_ns, args)  \
+    BOOST_PARAMETER_BASIC_MEMBER_FUNCTION_AUX(                               \
+        r, operator(), operator, tag_ns                                      \
       , BOOST_PARAMETER_AUX_PP_FLATTEN(2, 2, 3, args), 1                     \
     )
 /**/
@@ -101,11 +123,11 @@
 
 // Helper macro for BOOST_PARAMETER_FUNCTION.
 #define BOOST_PARAMETER_FUNCTION_AUX(result, name, tag_ns, args)             \
-    BOOST_PARAMETER_FUNCTION_HEAD(result, name, tag_ns, args)                \
-    BOOST_PARAMETER_FUNCTION_IMPL_HEAD(name);                                \
-    BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, name, args, 0)          \
+    BOOST_PARAMETER_FUNCTION_HEAD(result, name, tag_ns, args, 0)             \
+    BOOST_PARAMETER_FUNCTION_IMPL_HEAD(name, 0);                             \
+    BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, name, args, 0, 0)       \
     BOOST_PARAMETER_FUNCTION_DISPATCH_LAYER(                                 \
-        1, (name, BOOST_PARAMETER_FUNCTION_SPLIT_ARGS(args), 0, tag_ns)      \
+        1, (name, BOOST_PARAMETER_FUNCTION_SPLIT_ARGS(args), 0, 0, tag_ns)   \
     )
 /**/
 
@@ -118,15 +140,27 @@
     )
 /**/
 
+#include <boost/preprocessor/control/if.hpp>
+
 // Helper macro for BOOST_PARAMETER_MEMBER_FUNCTION
 // BOOST_PARAMETER_CONST_MEMBER_FUNCTION,
 // BOOST_PARAMETER_FUNCTION_CALL_OPERATOR, and
 // BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR.
 #define BOOST_PARAMETER_MEMBER_FUNCTION_AUX(r, name, impl, tag_ns, c, args)  \
-    BOOST_PARAMETER_FUNCTION_HEAD(r, impl, tag_ns, args)                     \
-    BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, args, c)          \
+    BOOST_PARAMETER_FUNCTION_HEAD(r, impl, tag_ns, args, c)                  \
+    BOOST_PARAMETER_FUNCTION_FORWARD_OVERLOADS(name, impl, args, 1, c)       \
     BOOST_PARAMETER_FUNCTION_DISPATCH_LAYER(                                 \
-        0, (impl, BOOST_PARAMETER_FUNCTION_SPLIT_ARGS(args), c, tag_ns)      \
+        0, (                                                                 \
+            impl                                                             \
+          , BOOST_PARAMETER_FUNCTION_SPLIT_ARGS(args)                        \
+          , BOOST_PP_IF(                                                     \
+                BOOST_PARAMETER_MEMBER_FUNCTION_IS_STATIC(impl)              \
+              , 0                                                            \
+              , 1                                                            \
+            )                                                                \
+          , c                                                                \
+          , tag_ns                                                           \
+        )                                                                    \
     )
 /**/
 

--- a/include/boost/parameter/preprocessor_no_spec.hpp
+++ b/include/boost/parameter/preprocessor_no_spec.hpp
@@ -1,0 +1,74 @@
+// Copyright Cromwell D. Enage 2019.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_PREPROCESSOR_NO_SPEC_HPP
+#define BOOST_PARAMETER_PREPROCESSOR_NO_SPEC_HPP
+
+#include <boost/parameter/aux_/preprocessor/impl/function_name.hpp>
+#include <boost/parameter/aux_/preprocessor/impl/no_spec_overloads.hpp>
+
+// Exapnds to a variadic function header that is enabled if and only if all
+// its arguments are tagged arguments.  All arguments are accessible via args
+// and keywords only.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION(result, name)                       \
+    BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, name, 0)                   \
+    BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_HEAD(name, 0);                     \
+    BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD(name, name, 0, 0)              \
+    BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_HEAD(name, 0)
+/**/
+
+#include <boost/preprocessor/control/expr_if.hpp>
+#include <boost/preprocessor/control/if.hpp>
+
+// Helper macro for BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION,
+// BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION,
+// BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR, and
+// and BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR.
+#define BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION_AUX(result, name, impl, c)   \
+    BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, impl, c)                   \
+    BOOST_PARAMETER_NO_SPEC_FUNCTION_OVERLOAD(                               \
+        name                                                                 \
+      , impl                                                                 \
+      , BOOST_PP_IF(BOOST_PARAMETER_MEMBER_FUNCTION_IS_STATIC(impl), 0, 1)   \
+      , c                                                                    \
+    )                                                                        \
+    BOOST_PARAMETER_NO_SPEC_FUNCTION_IMPL_HEAD(impl, c)                      \
+    BOOST_PP_EXPR_IF(c, const)
+/**/
+
+// Exapnds to a variadic member function header that is enabled if and only if
+// all its arguments are tagged arguments.  All arguments are accessible via
+// args and keywords only.
+#define BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION(result, name)                \
+    BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION_AUX(result, name, name, 0)
+/**/
+
+// Exapnds to a const-qualified variadic member function header that is
+// enabled if and only if all its arguments are tagged arguments.  All
+// arguments are accessible via args and keywords only.
+#define BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION(result, name)          \
+    BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION_AUX(result, name, name, 1)
+/**/
+
+// Exapnds to a variadic function call operator header that is enabled if and
+// only if all its arguments are tagged arguments.  All arguments are
+// accessible via args and keywords only.
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR(result)               \
+    BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION_AUX(                             \
+        result, operator(), operator, 0                                      \
+    )
+/**/
+
+// Exapnds to a const-qualified variadic function call operator header that is
+// enabled if and only if all its arguments are tagged arguments.  All
+// arguments are accessible via args and keywords only.
+#define BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR(result)         \
+    BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION_AUX(                             \
+        result, operator(), operator, 1                                      \
+    )
+/**/
+
+#endif  // include guard
+

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -32,16 +32,6 @@ alias parameter_standard_tests
         :
             <preserve-target-tests>off
     ]
-    [ run optional_deduced_sfinae.cpp
-        :
-        :
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=2
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=2
-        :
-        :
-            <preserve-target-tests>off
-    ]
     [ run efficiency.cpp
         :
         :
@@ -67,6 +57,34 @@ alias parameter_standard_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=16
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run parameterized_inheritance.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=3
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run preprocessor_eval_cat_no_spec.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run optional_deduced_sfinae.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=2
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=2
         :
         :
             <preserve-target-tests>off
@@ -102,26 +120,6 @@ alias parameter_standard_tests
             <preserve-target-tests>off
     ]
     [ run mpl.cpp
-        :
-        :
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=4
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-        :
-        :
-            <preserve-target-tests>off
-    ]
-    [ run earwicker.cpp
-        :
-        :
-        :
-            <define>BOOST_PARAMETER_MAX_ARITY=4
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-        :
-        :
-            <preserve-target-tests>off
-    ]
-    [ run macros.cpp
         :
         :
         :
@@ -171,19 +169,44 @@ alias parameter_standard_tests
         :
             <preserve-target-tests>off
     ]
+    [ run earwicker.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
+        :
+        :
+            <preserve-target-tests>off
+    ]
+    [ run macros.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
+        :
+        :
+            <preserve-target-tests>off
+    ]
     [ compile unwrap_cv_reference.cpp ]
     [ compile ntp.cpp
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
     ]
     [ compile function_type_tpl_param.cpp ]
     [ compile-fail duplicates.cpp
         :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
         :
             duplicates_fail
     ]
     [ compile-fail deduced_unmatched_arg.cpp
         :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
         :
             deduced_unmatched_arg_fail
     ]
@@ -217,6 +240,8 @@ alias parameter_standard_tests
     ]
     [ compile-fail deduced.cpp
         :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE
         :
             deduced_fail
@@ -567,6 +592,16 @@ alias parameter_macros_eval_category
 
 alias parameter_evaluate_category_10
     :
+    [ run evaluate_category_10.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
+        :
+            evaluate_category_10_gcc_4_8_linux
+        :
+            <preserve-target-tests>off
+    ]
     :
         <target-os>linux
         <toolset>gcc
@@ -575,16 +610,16 @@ alias parameter_evaluate_category_10
 
 alias parameter_evaluate_category_10
     :
-    :
-        # This test fails for xcode 7.3.0 on osx
-        # so we turn off this test for this compiler for now
-        <target-os>darwin
-        <cxxstd>03
-        # TODO: Differentiate by xcode version or by clang version
-    ;
-
-alias parameter_evaluate_category_10
-    :
+    [ run evaluate_category_10.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
+        :
+            evaluate_category_10_mingw
+        :
+            <preserve-target-tests>off
+    ]
     :
         <target-os>windows
         <toolset>gcc
@@ -596,8 +631,6 @@ alias parameter_evaluate_category_10
         :
         :
         :
-            <define>BOOST_PARAMETER_MAX_ARITY=10
-            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
         :
             evaluate_category_10_cxx98
         :
@@ -613,7 +646,6 @@ alias parameter_evaluate_category_10
         :
         :
         :
-            <define>BOOST_PARAMETER_MAX_ARITY=10
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
         :
             evaluate_category_10_cxx03
@@ -640,40 +672,17 @@ alias parameter_evaluate_category_10
 
 alias parameter_preprocessor_eval_cat_8
     :
-    :
-        <target-os>linux
-        <toolset>gcc
-        <toolset-gcc:version>4.8
-    ;
-
-alias parameter_preprocessor_eval_cat_8
-    :
-    :
-        <target-os>linux
-        <toolset>gcc
-        <toolset-gcc:version>4.9
-    ;
-
-alias parameter_preprocessor_eval_cat_8
-    :
-    :
-        <target-os>linux
-        <toolset>gcc
-        <cxxstd>03
-    ;
-
-alias parameter_preprocessor_eval_cat_8
-    :
-    :
-        # This test fails for xcode 7.3.0 and xcode 8.3.0 on osx
-        # so we turn off this test for this compiler for now
-        <target-os>darwin
-        <cxxstd>03
-        # TODO: Differentiate by xcode version or by clang version
-    ;
-
-alias parameter_preprocessor_eval_cat_8
-    :
+    [ run preprocessor_eval_cat_8.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=0
+        :
+            preproc_eval_cat_8_mingw
+        :
+            <preserve-target-tests>off
+    ]
     :
         <target-os>windows
         <toolset>gcc
@@ -722,22 +731,22 @@ alias parameter_preprocessor_eval_cat_fail
     ]
     ;
 
-alias parameter_msvc_fail_tests ;
+alias parameter_vendor_specific_fail_tests ;
 
-alias parameter_msvc_fail_tests
+alias parameter_vendor_specific_fail_tests
     :
     [ compile-fail compose.cpp
         :
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
-            compose_msvc11_fail_11
+            compose_fail_msvc11
     ]
     :
         <toolset>msvc
         <toolset-msvc:version>11.0
     ;
 
-alias parameter_msvc_fail_tests
+alias parameter_vendor_specific_fail_tests
     :
     [ compile-fail evaluate_category.cpp
         :
@@ -745,7 +754,7 @@ alias parameter_msvc_fail_tests
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
-            evaluate_category_msvc12_fail
+            evaluate_category_fail_msvc12
     ]
     [ compile-fail preprocessor_eval_category.cpp
         :
@@ -753,14 +762,21 @@ alias parameter_msvc_fail_tests
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=9
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
-            preproc_eval_cat_msvc12_fail
+            preproc_eval_cat_fail_msvc12
+    ]
+    [ compile-fail preprocessor_eval_cat_no_spec.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_eval_cat_no_spec_fail_msvc12
     ]
     :
         <toolset>msvc
         <toolset-msvc:version>12.0
     ;
 
-alias parameter_msvc_fail_tests
+alias parameter_vendor_specific_fail_tests
     :
     [ compile-fail evaluate_category.cpp
         :
@@ -768,7 +784,7 @@ alias parameter_msvc_fail_tests
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
-            evaluate_category_msvc14_0_fail
+            evaluate_category_fail_msvc14_0
     ]
     [ compile-fail preprocessor_eval_category.cpp
         :
@@ -776,14 +792,21 @@ alias parameter_msvc_fail_tests
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=9
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
-            preproc_eval_cat_msvc14_0_fail
+            preproc_eval_cat_fail_msvc14_0
+    ]
+    [ compile-fail preprocessor_eval_cat_no_spec.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_eval_cat_no_spec_fail_msvc14_0
     ]
     :
         <toolset>msvc
         <toolset-msvc:version>14.0
     ;
 
-alias parameter_msvc_fail_tests
+alias parameter_vendor_specific_fail_tests
     :
     [ compile-fail evaluate_category.cpp
         :
@@ -791,7 +814,7 @@ alias parameter_msvc_fail_tests
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
-            evaluate_category_msvc14_1_fail
+            evaluate_category_fail_msvc14_1
     ]
     [ compile-fail preprocessor_eval_category.cpp
         :
@@ -799,7 +822,14 @@ alias parameter_msvc_fail_tests
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=9
             <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
         :
-            preproc_eval_cat_msvc14_1_fail
+            preproc_eval_cat_fail_msvc14_1
+    ]
+    [ compile-fail preprocessor_eval_cat_no_spec.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=8
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+        :
+            preproc_eval_cat_no_spec_fail_msvc14_1
     ]
     :
         <toolset>msvc
@@ -816,5 +846,5 @@ test-suite "parameter"
         parameter_standard_tests
         parameter_literate_tests
         parameter_python_test
-        parameter_msvc_fail_tests
+        parameter_vendor_specific_fail_tests
     ;

--- a/test/evaluate_category_10.cpp
+++ b/test/evaluate_category_10.cpp
@@ -5,12 +5,19 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_MAX_ARITY < 10)
+#if ( \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+        !defined(__MINGW32__) \
+    ) || ( \
+        !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+        (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY) \
+    )
+#if (BOOST_PARAMETER_MAX_ARITY < 10)
 #error Define BOOST_PARAMETER_MAX_ARITY as 10 or greater.
 #endif
+#endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -28,6 +35,20 @@ namespace test {
     BOOST_PARAMETER_NAME((_lrc2, keywords) in(lrc2))
     BOOST_PARAMETER_NAME((_lr2, keywords) out(lr2))
     BOOST_PARAMETER_NAME((_rr2, keywords) rr2)
+} // namespace test
+
+#if ( \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+        !defined(__MINGW32__) \
+    ) || ( \
+        !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+        (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY) \
+    )
+#include <boost/parameter/parameters.hpp>
+#include <boost/parameter/required.hpp>
+#include <boost/parameter/optional.hpp>
+
+namespace test {
 
     struct g_parameters
       : boost::parameter::parameters<
@@ -46,6 +67,8 @@ namespace test {
     };
 } // namespace test
 
+#endif
+
 #include <boost/core/lightweight_test.hpp>
 #include "evaluate_category.hpp"
 
@@ -58,67 +81,67 @@ namespace test {
         {
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_lrc0])
+              , test::U::evaluate_category<0>(args[test::_lrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<0>(args[test::_lr0])
+              , test::U::evaluate_category<0>(args[test::_lr0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_lrc1])
+              , test::U::evaluate_category<1>(args[test::_lrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<1>(args[test::_lr1])
+              , test::U::evaluate_category<1>(args[test::_lr1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_lrc2 | test::lvalue_const_bitset<2>()]
                 )
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_lr2 || test::lvalue_bitset_function<2>()]
                 )
             );
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rrc0])
+              , test::U::evaluate_category<0>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference
-              , U::evaluate_category<0>(args[test::_rr0])
+              , test::U::evaluate_category<0>(args[test::_rr0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_rrc1])
+              , test::U::evaluate_category<1>(args[test::_rrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_rvalue_reference
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_rr2 || test::rvalue_bitset_function<2>()]
                 )
             );
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rrc0])
+              , test::U::evaluate_category<0>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(args[test::_rr0])
+              , test::U::evaluate_category<0>(args[test::_rr0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<1>(args[test::_rrc1])
+              , test::U::evaluate_category<1>(args[test::_rrc1])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(
+              , test::U::evaluate_category<2>(
                     args[test::_rr2 || test::rvalue_bitset_function<2>()]
                 )
             );
@@ -129,13 +152,34 @@ namespace test {
 
 #if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #include <boost/parameter/aux_/as_lvalue.hpp>
-#include <boost/core/ref.hpp>
 #endif
 
 int main()
 {
-#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) || \
-    (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY)
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if defined(__MINGW32__)
+    test::C::evaluate((
+        test::_rrc1 = test::rvalue_const_bitset<1>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<0>()
+      , test::_rrc0 = test::rvalue_const_bitset<0>()
+      , test::_rr0 = test::rvalue_bitset<0>()
+      , test::_lrc1 = test::lvalue_const_bitset<1>()
+      , test::_lr1 = test::lvalue_bitset<1>()
+    ));
+    test::C::evaluate((
+        test::_lr0 = test::lvalue_bitset<0>()
+      , test::_rrc0 = test::rvalue_const_bitset<0>()
+      , test::_rr0 = test::rvalue_bitset<0>()
+      , test::_lrc1 = test::lvalue_const_bitset<1>()
+      , test::_lr1 = test::lvalue_bitset<1>()
+      , test::_rrc1 = test::rvalue_const_bitset<1>()
+      , test::_lrc2 = test::lvalue_const_bitset<2>()
+      , test::_lr2 = test::lvalue_bitset<2>()
+      , test::_rr2 = test::rvalue_bitset<2>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+    ));
+#else   // !defined(__MINGW32__)
     test::C::evaluate(
         test::g_parameters()(
             test::lvalue_const_bitset<0>()
@@ -161,33 +205,64 @@ int main()
           , test::rvalue_bitset<2>()
         )
     );
-#else   // no perfect forwarding support and no exponential overloads
+#endif  // __MINGW32__
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY)
     test::C::evaluate(
         test::g_parameters()(
             test::lvalue_const_bitset<0>()
-          , boost::ref(test::lvalue_bitset<0>())
+          , test::lvalue_bitset<0>()
           , test::rvalue_const_bitset<0>()
           , boost::parameter::aux::as_lvalue(test::rvalue_bitset<0>())
           , test::lvalue_const_bitset<1>()
-          , boost::ref(test::lvalue_bitset<1>())
+          , test::lvalue_bitset<1>()
           , test::rvalue_const_bitset<1>()
         )
     );
     test::C::evaluate(
         test::g_parameters()(
             test::lvalue_const_bitset<0>()
-          , boost::ref(test::lvalue_bitset<0>())
+          , test::lvalue_bitset<0>()
           , test::rvalue_const_bitset<0>()
           , boost::parameter::aux::as_lvalue(test::rvalue_bitset<0>())
           , test::lvalue_const_bitset<1>()
-          , boost::ref(test::lvalue_bitset<1>())
+          , test::lvalue_bitset<1>()
           , test::rvalue_const_bitset<1>()
           , test::lvalue_const_bitset<2>()
-          , boost::ref(test::lvalue_bitset<2>())
+          , test::lvalue_bitset<2>()
           , boost::parameter::aux::as_lvalue(test::rvalue_bitset<2>())
         )
     );
-#endif  // perfect forwarding support, or exponential overloads
+#else   // !(10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY)
+    test::C::evaluate((
+        test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<0>()
+      , test::_rrc0 = test::rvalue_const_bitset<0>()
+      , test::_rr0 = boost::parameter::aux::as_lvalue(
+            test::rvalue_bitset<0>()
+        )
+      , test::_lrc1 = test::lvalue_const_bitset<1>()
+      , test::_lr1 = test::lvalue_bitset<1>()
+      , test::_rrc1 = test::rvalue_const_bitset<1>()
+    ));
+    test::C::evaluate((
+        test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<0>()
+      , test::_rrc0 = test::rvalue_const_bitset<0>()
+      , test::_rr0 = boost::parameter::aux::as_lvalue(
+            test::rvalue_bitset<0>()
+        )
+      , test::_lrc1 = test::lvalue_const_bitset<1>()
+      , test::_lr1 = test::lvalue_bitset<1>()
+      , test::_rrc1 = test::rvalue_const_bitset<1>()
+      , test::_lrc2 = test::lvalue_const_bitset<2>()
+      , test::_lr2 = test::lvalue_bitset<2>()
+      , test::_rr2 = boost::parameter::aux::as_lvalue(
+            test::rvalue_bitset<2>()
+        )
+    ));
+#endif  // (10 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY)
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
     return boost::report_errors();
 }
 

--- a/test/parameterized_inheritance.cpp
+++ b/test/parameterized_inheritance.cpp
@@ -1,0 +1,263 @@
+// Copyright Cromwell D. Enage 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/parameter/config.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 3)
+#error Define BOOST_PARAMETER_MAX_ARITY as 3 or greater.
+#endif
+
+#include <boost/parameter/name.hpp>
+
+namespace test {
+
+    BOOST_PARAMETER_NAME(a0)
+    BOOST_PARAMETER_NAME(a1)
+    BOOST_PARAMETER_NAME(a2)
+}
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/parameter/is_argument_pack.hpp>
+#include <boost/type_traits/is_convertible.hpp>
+#include <boost/core/enable_if.hpp>
+#endif
+
+namespace test {
+
+#if !defined(BOOST_NO_SFINAE)
+    struct _enabler
+    {
+    };
+#endif
+
+    template <typename T>
+    class backend0
+    {
+        T _a0;
+
+     public:
+        template <typename ArgPack>
+        explicit backend0(
+            ArgPack const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::enable_if<
+                boost::parameter::is_argument_pack<ArgPack>
+              , test::_enabler
+            >::type = test::_enabler()
+#endif
+        ) : _a0(args[test::_a0])
+        {
+        }
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename U>
+        backend0(
+            backend0<U> const& copy
+          , typename boost::enable_if<
+                boost::is_convertible<U,T>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : _a0(copy.get_a0())
+        {
+        }
+#endif
+
+        template <typename Iterator>
+        backend0(Iterator itr, Iterator itr_end) : _a0(itr, itr_end)
+        {
+        }
+
+        T const& get_a0() const
+        {
+            return this->_a0;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            this->_a0 = args[test::_a0];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend1 : public B
+    {
+        T _a1;
+
+     public:
+        template <typename ArgPack>
+        explicit backend1(
+            ArgPack const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::enable_if<
+                boost::parameter::is_argument_pack<ArgPack>
+              , test::_enabler
+            >::type = test::_enabler()
+#endif
+        ) : B(args), _a1(args[test::_a1])
+        {
+        }
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename Derived>
+        backend1(
+            Derived const& copy
+          , typename boost::disable_if<
+                boost::parameter::is_argument_pack<Derived>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : B(copy), _a1(copy.get_a1())
+        {
+        }
+#endif
+
+        T const& get_a1() const
+        {
+            return this->_a1;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->_a1 = args[test::_a1];
+        }
+    };
+
+    template <typename B, typename T>
+    class backend2 : public B
+    {
+        T _a2;
+
+     public:
+        template <typename ArgPack>
+        explicit backend2(
+            ArgPack const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::enable_if<
+                boost::parameter::is_argument_pack<ArgPack>
+              , test::_enabler
+            >::type = test::_enabler()
+#endif
+        ) : B(args), _a2(args[test::_a2])
+        {
+        }
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename Derived>
+        backend2(
+            Derived const& copy
+          , typename boost::disable_if<
+                boost::parameter::is_argument_pack<Derived>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : B(copy), _a2(copy.get_a2())
+        {
+        }
+#endif
+
+        T const& get_a2() const
+        {
+            return this->_a2;
+        }
+
+     protected:
+        template <typename ArgPack>
+        void initialize_impl(ArgPack const& args)
+        {
+            B::initialize_impl(args);
+            this->_a2 = args[test::_a2];
+        }
+    };
+}
+
+#include <boost/parameter/preprocessor_no_spec.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/parameter/are_tagged_arguments.hpp>
+#endif
+
+namespace test {
+
+    template <typename B>
+    struct frontend : public B
+    {
+        BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(frontend, (B))
+
+#if !defined(BOOST_NO_SFINAE)
+        template <typename Iterator>
+        frontend(
+            Iterator itr
+          , Iterator itr_end
+          , typename boost::disable_if<
+                boost::parameter::are_tagged_arguments<Iterator>
+              , test::_enabler
+            >::type = test::_enabler()
+        ) : B(itr, itr_end)
+        {
+        }
+
+        template <typename O>
+        frontend(frontend<O> const& copy) : B(copy)
+        {
+        }
+#endif
+
+        BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((void), initialize)
+        {
+            this->initialize_impl(args);
+        }
+
+        BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR((void))
+        {
+            this->initialize_impl(args);
+        }
+    };
+} // namespace test
+
+#include <boost/core/lightweight_test.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <string>
+#endif
+
+int main()
+{
+    char const* p = "foo";
+    char const* q = "bar";
+    test::frontend<
+        test::backend2<test::backend1<test::backend0<char const*>, char>, int>
+    > composed_obj0(test::_a2 = 4, test::_a1 = ' ', test::_a0 = p);
+#if defined(BOOST_NO_SFINAE)
+    test::frontend<
+        test::backend1<test::backend2<test::backend0<char const*>, int>, char>
+    > composed_obj1(test::_a0 = p, test::_a1 = ' ', test::_a2 = 4);
+#else
+    test::frontend<
+        test::backend1<test::backend2<test::backend0<char const*>, int>, char>
+    > composed_obj1(composed_obj0);
+#endif
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+    composed_obj0.initialize(test::_a0 = q, test::_a1 = '!', test::_a2 = 8);
+    composed_obj1.initialize(test::_a2 = 8, test::_a1 = '!', test::_a0 = q);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+    composed_obj0(test::_a2 = 8, test::_a1 = '!', test::_a0 = q);
+    composed_obj1(test::_a0 = q, test::_a1 = '!', test::_a2 = 8);
+    BOOST_TEST_EQ(composed_obj0.get_a0(), composed_obj1.get_a0());
+    BOOST_TEST_EQ(composed_obj0.get_a1(), composed_obj1.get_a1());
+    BOOST_TEST_EQ(composed_obj0.get_a2(), composed_obj1.get_a2());
+#if !defined(BOOST_NO_SFINAE)
+    test::frontend<test::backend0<std::string> > string_wrap(p, p + 3);
+    BOOST_TEST_EQ(string_wrap.get_a0(), std::string(p));
+#endif
+    return boost::report_errors();
+}
+

--- a/test/preprocessor.cpp
+++ b/test/preprocessor.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/parameter/config.hpp>
 #include <boost/parameter/preprocessor.hpp>
-#include <boost/parameter/keyword.hpp>
+#include <boost/parameter/binding.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -46,6 +46,7 @@ namespace test {
     }
 } // namespace test
 
+#include <boost/parameter/value_type.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
 namespace test {
@@ -195,6 +196,18 @@ namespace test {
                 (index, *)
             )
         )
+
+        BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR((int), test::tag,
+            (optional
+                (value, *)
+                (index, *)
+            )
+        )
+        {
+            this->f = args[test::_value | 2.f];
+            this->i = args[test::_index | 1];
+            return 1;
+        }
     };
 
     struct base_1
@@ -391,6 +404,16 @@ namespace test {
             >
         {
         };
+
+        BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR((bool), test::tag,
+            (required
+                (value, *)
+                (index, *)
+            )
+        )
+        {
+            return args[test::_value] < args[test::_index];
+        }
     };
 
     BOOST_PARAMETER_FUNCTION((int), sfinae1, test::tag,
@@ -423,12 +446,6 @@ namespace test {
     }
 #endif  // BOOST_NO_SFINAE
 
-    template <typename T>
-    T const& as_lvalue(T const& x)
-    {
-        return x;
-    }
-
     struct udt
     {
         udt(int foo_, int bar_) : foo(foo_), bar(bar_)
@@ -452,6 +469,10 @@ namespace test {
         return 0;
     }
 } // namespace test
+
+#if BOOST_WORKAROUND(BOOST_MSVC, == 1300)
+#include <boost/parameter/aux_/as_lvalue.hpp>
+#endif
 
 #include <boost/core/lightweight_test.hpp>
 
@@ -487,7 +508,7 @@ int main()
       , std::string("foo")
       , 1.f
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1300)
-      , test::as_lvalue(2)
+      , boost::parameter::aux::as_lvalue(2)
 #else
       , 2
 #endif
@@ -498,7 +519,7 @@ int main()
       , std::string("foo")
       , 1.f
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1300)
-      , test::as_lvalue(2)
+      , boost::parameter::aux::as_lvalue(2)
 #else
       , 2
 #endif
@@ -514,6 +535,11 @@ int main()
 
     BOOST_TEST(2 == u.i);
     BOOST_TEST(1.f == u.f);
+
+    u();
+
+    BOOST_TEST(1 == u.i);
+    BOOST_TEST(2.f == u.f);
 
     test::class_1 x(
         test::values(std::string("foo"), 1.f, 2)
@@ -563,22 +589,33 @@ int main()
       , test::_name = std::string("foo")
     );
 
+    test::predicate p;
+    test::predicate const& p_const = p;
+
+    BOOST_TEST(p_const(3, 4));
+    BOOST_TEST(!p_const(4, 3));
+    BOOST_TEST(!p_const(test::_index = 3, test::_value = 4));
+
 #if !defined(BOOST_NO_SFINAE) && \
     !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
-    BOOST_TEST(test::sfinae("foo") == 1);
+    // GCC 3- tries to bind string literals
+    // to non-const references to char const*.
+    // BOOST_TEST(test::sfinae("foo") == 1);
+    char const* foo_str = "foo";
+    BOOST_TEST(test::sfinae(foo_str) == 1);
     BOOST_TEST(test::sfinae(1) == 0);
 
 #if !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
     // Sun actually eliminates the desired overload for some reason.
     // Disabling this part of the test because SFINAE abilities are
     // not the point of this test.
-    BOOST_TEST(test::sfinae1("foo") == 1);
+    BOOST_TEST(test::sfinae1(foo_str) == 1);
 #endif
-    
+
     BOOST_TEST(test::sfinae1(1) == 0);
 #endif
 
-    test::lazy_defaults(test::_name = test::udt(0,1));
+    test::lazy_defaults(test::_name = test::udt(0, 1));
     test::lazy_defaults(test::_name = 0, test::_value = 1, test::_index = 2);
 
     return boost::report_errors();

--- a/test/preprocessor_eval_cat_8.cpp
+++ b/test/preprocessor_eval_cat_8.cpp
@@ -5,12 +5,11 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
-    (BOOST_PARAMETER_MAX_ARITY < 8)
+#if (BOOST_PARAMETER_MAX_ARITY < 8)
 #error Define BOOST_PARAMETER_MAX_ARITY as 8 or greater.
 #endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -35,14 +34,23 @@ namespace test {
 #include <boost/type_traits/is_convertible.hpp>
 #include "evaluate_category.hpp"
 
-#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if !defined(__MINGW32__) && defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#include <boost/parameter/preprocessor.hpp>
 #include <utility>
+#elif defined(BOOST_MSVC)
+#include <boost/parameter/preprocessor.hpp>
+#else
+#include <boost/parameter/preprocessor_no_spec.hpp>
 #endif
 
 namespace test {
 
     struct C
     {
+#if ( \
+        !defined(__MINGW32__) && \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) \
+    ) || defined(BOOST_MSVC)
         typedef boost::mpl::if_<
             boost::is_convertible<boost::mpl::_,std::bitset<1> >
           , boost::mpl::true_
@@ -100,57 +108,130 @@ namespace test {
                 )
             )
         )
+#else
+        BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR((bool))
+#endif  // msvc, or perfect forwarding support and not mingw
         {
+#if ( \
+        !defined(__MINGW32__) && \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) \
+    ) || defined(BOOST_MSVC)
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<0>(lrc0)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<0>(lrc0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference
-              , U::evaluate_category<1>(lr0)
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<1>(lr0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<4>(lrc1)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<4>(lrc1)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference
-              , U::evaluate_category<5>(lr1)
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<5>(lr1)
             );
+#else   // mingw, or no perfect forwarding support and not msvc
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<0>(args[test::_lrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<1>(args[test::_lr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<4>(args[test::_lrc1])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<5>(
+                    args[test::_lr1 | test::lvalue_bitset<5>()]
+                )
+            );
+#endif  // msvc, or perfect forwarding support and not mingw
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if defined(__MINGW32__)
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference_to_const
-              , U::evaluate_category<2>(std::forward<rrc0_type>(rrc0))
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference
-              , U::evaluate_category<3>(std::forward<rr0_type>(rr0))
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<3>(args[test::_rr0])
             );
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference_to_const
-              , U::evaluate_category<6>(std::forward<rrc1_type>(rrc1))
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
             );
             BOOST_TEST_EQ(
-                passed_by_rvalue_reference
-              , U::evaluate_category<7>(std::forward<rr1_type>(rr1))
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
             );
+#else   // !defined(__MINGW32__)
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<2>(std::forward<rrc0_type>(rrc0))
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<3>(std::forward<rr0_type>(rr0))
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<6>(std::forward<rrc1_type>(rrc1))
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<7>(std::forward<rr1_type>(rr1))
+            );
+#endif  // __MINGW32__
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if defined(BOOST_MSVC)
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<2>(rrc0)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<2>(rrc0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<3>(rr0)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<3>(rr0)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<6>(rrc1)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<6>(rrc1)
             );
             BOOST_TEST_EQ(
-                passed_by_lvalue_reference_to_const
-              , U::evaluate_category<7>(rr1)
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<7>(rr1)
             );
+#else   // !defined(BOOST_MSVC)
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<3>(args[test::_rr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
+            );
+#endif  // BOOST_MSVC
 #endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 
             return true;
@@ -163,6 +244,10 @@ int main()
     test::C cp0;
     test::C cp1;
 
+#if ( \
+        !defined(__MINGW32__) && \
+        defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) \
+    ) || defined(BOOST_MSVC)
     cp0(
         test::lvalue_const_bitset<4>()
       , test::lvalue_const_bitset<0>()
@@ -188,6 +273,33 @@ int main()
       , test::rvalue_bitset<7>()
       , test::lvalue_const_bitset<0>()
     );
+#else   // mingw, or no perfect forwarding support and not msvc
+    cp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    cp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    cp1(
+        test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+      , test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lr1 = test::lvalue_bitset<5>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_rr1 = test::rvalue_bitset<7>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+    );
+#endif  // msvc, or perfect forwarding support and not mingw
     return boost::report_errors();
 }
 

--- a/test/preprocessor_eval_cat_no_spec.cpp
+++ b/test/preprocessor_eval_cat_no_spec.cpp
@@ -1,0 +1,524 @@
+// Copyright Cromwell D. Enage 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/parameter/config.hpp>
+
+#if (BOOST_PARAMETER_MAX_ARITY < 8)
+#error Define BOOST_PARAMETER_MAX_ARITY as 8 or greater.
+#endif
+
+#include <boost/parameter/name.hpp>
+
+namespace test {
+
+    BOOST_PARAMETER_NAME((_lrc0, kw0) in(lrc0))
+    BOOST_PARAMETER_NAME((_lr0, kw1) in_out(lr0))
+    BOOST_PARAMETER_NAME((_rrc0, kw2) in(rrc0))
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+    BOOST_PARAMETER_NAME((_rr0, kw3) consume(rr0))
+#else
+    BOOST_PARAMETER_NAME((_rr0, kw3) rr0)
+#endif
+    BOOST_PARAMETER_NAME((_lrc1, kw4) in(lrc1))
+    BOOST_PARAMETER_NAME((_lr1, kw5) out(lr1))
+    BOOST_PARAMETER_NAME((_rrc1, kw6) in(rrc1))
+    BOOST_PARAMETER_NAME((_rr1, kw7) rr1)
+} // namespace test
+
+#include <boost/parameter/preprocessor_no_spec.hpp>
+#include <boost/parameter/value_type.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/type_traits/is_scalar.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include "evaluate_category.hpp"
+
+namespace test {
+
+    BOOST_PARAMETER_NO_SPEC_FUNCTION((bool), evaluate)
+    {
+        BOOST_TEST((
+            test::passed_by_lvalue_reference_to_const == test::A<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw0::lrc0
+                    >::type
+                >::type
+            >::evaluate_category(args[test::_lrc0])
+        ));
+        BOOST_TEST((
+            test::passed_by_lvalue_reference == test::A<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw1::lr0
+                    >::type
+                >::type
+            >::evaluate_category(args[test::_lr0])
+        ));
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+        if (
+            boost::is_scalar<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw2::rrc0
+                    >::type
+                >::type
+            >::value
+        )
+        {
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw2::rrc0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rrc0])
+            ));
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw3::rr0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rr0])
+            ));
+        }
+        else // rrc0's value type isn't scalar
+        {
+            BOOST_TEST((
+                test::passed_by_rvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw2::rrc0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rrc0])
+            ));
+            BOOST_TEST((
+                test::passed_by_rvalue_reference == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw3::rr0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rr0])
+            ));
+        }
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+        BOOST_TEST((
+            test::passed_by_lvalue_reference_to_const == test::A<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw2::rrc0
+                    >::type
+                >::type
+            >::evaluate_category(args[test::_rrc0])
+        ));
+        BOOST_TEST((
+            test::passed_by_lvalue_reference_to_const == test::A<
+                typename boost::remove_const<
+                    typename boost::parameter::value_type<
+                        Args
+                      , test::kw3::rr0
+                    >::type
+                >::type
+            >::evaluate_category(args[test::_rr0])
+        ));
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+
+        return true;
+    }
+} // namespace test
+
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/tti/detail/dnullptr.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+#endif
+
+namespace test {
+
+    char const* baz = "baz";
+
+    struct B
+    {
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
+        B()
+        {
+        }
+#endif
+
+        template <typename Args>
+        explicit B(
+            Args const& args
+#if !defined(BOOST_NO_SFINAE)
+          , typename boost::disable_if<
+                typename boost::mpl::if_<
+                    boost::is_base_of<B,Args>
+                  , boost::mpl::true_
+                  , boost::mpl::false_
+                >::type
+            >::type* = BOOST_TTI_DETAIL_NULLPTR
+#endif  // BOOST_NO_SFINAE
+        )
+        {
+            test::evaluate(
+                test::_lrc0 = args[test::_lrc0]
+              , test::_lr0 = args[test::_lr0]
+              , test::_rrc0 = args[test::_rrc0]
+              , test::_rr0 = args[test::_rr0]
+            );
+        }
+
+        BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION((bool), static evaluate)
+        {
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw0::lrc0
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_lrc0])
+            ));
+            BOOST_TEST((
+                test::passed_by_lvalue_reference == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw1::lr0
+                          , char const*
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_lr0 | test::baz])
+            ));
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw2::rrc0
+                          , float
+                        >::type
+                    >::type
+                >::evaluate_category(args[test::_rrc0 | 0.0f])
+            ));
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST((
+                test::passed_by_rvalue_reference == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw3::rr0
+                          , std::string
+                        >::type
+                    >::type
+                >::evaluate_category(
+                    args[
+                        test::_rr0 | std::string(args[test::_lr0 | test::baz])
+                    ]
+                )
+            ));
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST((
+                test::passed_by_lvalue_reference_to_const == test::A<
+                    typename boost::remove_const<
+                        typename boost::parameter::value_type<
+                            Args
+                          , test::kw3::rr0
+                          , std::string
+                        >::type
+                    >::type
+                >::evaluate_category(
+                    args[
+                        test::_rr0 | std::string(args[test::_lr0 | test::baz])
+                    ]
+                )
+            ));
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+
+            return true;
+        }
+    };
+
+    struct C : B
+    {
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
+        C() : B()
+        {
+        }
+#endif
+
+        BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(C, (B))
+    };
+
+    struct D
+    {
+        BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR(D, D::_evaluate)
+
+        BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION((bool), evaluate_m)
+        {
+            return D::_evaluate(args);
+        }
+
+        BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR((bool))
+        {
+            return D::_evaluate(args);
+        }
+
+     private:
+        template <typename Args>
+        static bool _evaluate(Args const& args)
+        {
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<0>(args[test::_lrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<1>(args[test::_lr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<4>(args[test::_lrc1])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference
+              , test::U::evaluate_category<5>(
+                    args[test::_lr1 | test::lvalue_bitset<5>()]
+                )
+            );
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<3>(args[test::_rr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_rvalue_reference
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
+            );
+#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<2>(args[test::_rrc0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<3>(args[test::_rr0])
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<6>(
+                    args[test::_rrc1 | test::rvalue_const_bitset<6>()]
+                )
+            );
+            BOOST_TEST_EQ(
+                test::passed_by_lvalue_reference_to_const
+              , test::U::evaluate_category<7>(
+                    args[test::_rr1 | test::rvalue_bitset<7>()]
+                )
+            );
+#endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
+
+            return true;
+        }
+    };
+} // namespace test
+
+int main()
+{
+    test::evaluate(
+        test::_lr0 = test::lvalue_float()
+      , test::_rrc0 = test::rvalue_const_float()
+      , test::_rr0 = test::rvalue_float()
+      , test::_lrc0 = test::lvalue_const_float()
+    );
+    test::evaluate(
+        test::_lr0 = test::lvalue_char_ptr()
+      , test::_rrc0 = test::rvalue_const_char_ptr()
+      , test::_rr0 = test::rvalue_char_ptr()
+      , test::_lrc0 = test::lvalue_const_char_ptr()
+    );
+    test::evaluate(
+        test::_lr0 = test::lvalue_str()
+      , test::_rrc0 = test::rvalue_const_str()
+      , test::_rr0 = test::rvalue_str()
+      , test::_lrc0 = test::lvalue_const_str()
+    );
+
+    test::C cf1(
+        test::_lr0 = test::lvalue_float()
+      , test::_rrc0 = test::rvalue_const_float()
+      , test::_rr0 = test::rvalue_float()
+      , test::_lrc0 = test::lvalue_const_float()
+    );
+    test::C cc1(
+        test::_lr0 = test::lvalue_char_ptr()
+      , test::_rrc0 = test::rvalue_const_char_ptr()
+      , test::_rr0 = test::rvalue_char_ptr()
+      , test::_lrc0 = test::lvalue_const_char_ptr()
+    );
+    test::C cs1(
+        test::_lr0 = test::lvalue_str()
+      , test::_rrc0 = test::rvalue_const_str()
+      , test::_rr0 = test::rvalue_str()
+      , test::_lrc0 = test::lvalue_const_str()
+    );
+
+    char baz_arr[4] = "qux";
+    typedef char char_arr[4];
+
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && ( \
+        BOOST_WORKAROUND(BOOST_GCC, < 40000) || \
+        BOOST_WORKAROUND(BOOST_MSVC, >= 1800) \
+    )
+    // MSVC-12+ treats static_cast<char_arr&&>(baz_arr) as an lvalue.
+    // GCC 3- tries to bind string literals
+    // to non-const references to char const*.
+#else
+    test::evaluate(
+        test::_lr0 = baz_arr
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+      , test::_rrc0 = static_cast<char_arr const&&>("def")
+      , test::_rr0 = static_cast<char_arr&&>(baz_arr)
+#else
+      , test::_rrc0 = "grl"
+      , test::_rr0 = "grp"
+#endif
+      , test::_lrc0 = "wld"
+    );
+#endif  // MSVC-12+
+    test::B::evaluate(test::_lrc0 = test::lvalue_const_str()[0]);
+    test::C::evaluate(
+        test::_rrc0 = test::rvalue_const_float()
+      , test::_lrc0 = test::lvalue_const_str()[0]
+    );
+
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
+    // MSVC-12+ treats static_cast<char_arr&&>(baz_arr) as an lvalue.
+    test::C cp0;
+    test::C cp1;
+#else
+    test::C cp0(
+        test::_lrc0 = "frd"
+      , test::_lr0 = baz_arr
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+      , test::_rrc0 = static_cast<char_arr const&&>("dfs")
+      , test::_rr0 = static_cast<char_arr&&>(baz_arr)
+#else
+      , test::_rrc0 = "plg"
+      , test::_rr0 = "thd"
+#endif
+    );
+    test::C cp1(
+        test::_lr0 = baz_arr
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+      , test::_rrc0 = static_cast<char_arr const&&>("dgx")
+      , test::_rr0 = static_cast<char_arr&&>(baz_arr)
+#else
+      , test::_rrc0 = "hnk"
+      , test::_rr0 = "xzz"
+#endif
+      , test::_lrc0 = "zts"
+    );
+#endif  // MSVC-12+
+
+    cp0.evaluate(
+        test::_lrc0 = test::lvalue_const_str()[0]
+      , test::_lr0 = test::lvalue_char_ptr()
+      , test::_rr0 = test::rvalue_str()
+      , test::_rrc0 = test::rvalue_const_float()
+    );
+    cp1.evaluate(
+        test::_lrc0 = test::lvalue_const_str()[0]
+      , test::_rr0 = test::rvalue_str()
+      , test::_rrc0 = test::rvalue_const_float()
+      , test::_lr0 = test::lvalue_char_ptr()
+    );
+
+    test::D dp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    test::D dp1(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+
+    dp0.evaluate_m(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    dp1.evaluate_m(
+        test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+      , test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lr1 = test::lvalue_bitset<5>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_rr1 = test::rvalue_bitset<7>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+    );
+    dp0(
+        test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+      , test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+    );
+    dp1(
+        test::_lr0 = test::lvalue_bitset<1>()
+      , test::_rrc0 = test::rvalue_const_bitset<2>()
+      , test::_rr0 = test::rvalue_bitset<3>()
+      , test::_lrc1 = test::lvalue_const_bitset<4>()
+      , test::_lr1 = test::lvalue_bitset<5>()
+      , test::_rrc1 = test::rvalue_const_bitset<6>()
+      , test::_rr1 = test::rvalue_bitset<7>()
+      , test::_lrc0 = test::lvalue_const_bitset<0>()
+    );
+    return boost::report_errors();
+}
+


### PR DESCRIPTION
* Add variadic metafunction boost::parameter::are_tagged_arguments to help improve overload resolution capabilities.  Used by compose() and the new BOOST_PARAMETER_NO_SPEC_* code generation macros.
* Add variadic function template compose() which takes in named arguments and returns them in an argument pack.
* Add code generation macros BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_NO_SPEC_FUNCTION, BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION, BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION, BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR, BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR, and BOOST_PARAMETER_NO_SPEC_NO_BASE_CONSTRUCTOR.