### PR TITLE
Update test suite

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -392,6 +392,16 @@ alias parameter_literate_tests
         :
             <preserve-target-tests>off
     ]
+    [ run literate/parameter-enabled-function-call-operators0.cpp
+        :
+        :
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=2
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=3
+        :
+        :
+            <preserve-target-tests>off
+    ]
     [ run literate/parameter-enabled-member-functions0.cpp
         :
         :
@@ -764,7 +774,7 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_deduced_fail_msvc08
     ]
@@ -779,7 +789,7 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_deduced_fail_msvc09
     ]
@@ -794,7 +804,7 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_deduced_fail_msvc10
     ]
@@ -808,7 +818,7 @@ alias parameter_vendor_specific_fail_tests
     [ compile-fail compose.cpp
         :
             <define>BOOST_PARAMETER_COMPOSE_MAX_ARITY=3
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             compose_fail_msvc11
     ]
@@ -816,7 +826,7 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_deduced_fail_msvc11
     ]
@@ -831,7 +841,7 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             evaluate_category_fail_msvc12
     ]
@@ -839,14 +849,14 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=8
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=9
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_eval_cat_fail_msvc12
     ]
     [ compile-fail preprocessor_eval_cat_no_spec.cpp
         :
             <define>BOOST_PARAMETER_COMPOSE_MAX_ARITY=8
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_eval_cat_no_spec_fail_msvc12
     ]
@@ -861,7 +871,7 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             evaluate_category_fail_msvc14_0
     ]
@@ -869,14 +879,14 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=8
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=9
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_eval_cat_fail_msvc14_0
     ]
     [ compile-fail preprocessor_eval_cat_no_spec.cpp
         :
             <define>BOOST_PARAMETER_COMPOSE_MAX_ARITY=8
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_eval_cat_no_spec_fail_msvc14_0
     ]
@@ -891,7 +901,7 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             evaluate_category_fail_msvc14_1
     ]
@@ -899,14 +909,14 @@ alias parameter_vendor_specific_fail_tests
         :
             <define>BOOST_PARAMETER_MAX_ARITY=8
             <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=9
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_eval_cat_fail_msvc14_1
     ]
     [ compile-fail preprocessor_eval_cat_no_spec.cpp
         :
             <define>BOOST_PARAMETER_COMPOSE_MAX_ARITY=8
-            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC
         :
             preproc_eval_cat_no_spec_fail_msvc14_1
     ]

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/parameter/nested_keyword.hpp>
 #include <boost/parameter/name.hpp>
+#include <boost/parameter/config.hpp>
 
 namespace param {
 
@@ -34,8 +35,6 @@ namespace param {
 #include <boost/mpl/equal_to.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/config.hpp>
-#include <boost/config/workaround.hpp>
 
 #if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function.hpp>
@@ -377,9 +376,9 @@ namespace test {
 
 #include <boost/core/lightweight_test.hpp>
 
-int main()
+void test_compose0()
 {
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails without this workaround.
@@ -393,7 +392,7 @@ int main()
 #endif
     BOOST_TEST_EQ(1, a.i);
     BOOST_TEST_EQ(13, a.j);
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails without this workaround.
@@ -408,7 +407,7 @@ int main()
     BOOST_TEST_EQ(13, b0.j);
     BOOST_TEST_EQ(4.0f, b0.k());
     BOOST_TEST_EQ(2.5, b0.l());
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
     BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // MSVC 11.0 on AppVeyor fails without this workaround.
@@ -459,6 +458,123 @@ int main()
     BOOST_TEST_EQ(p2.second, h1.k.second);
     p1.first = 1;
     BOOST_TEST_EQ(p1.first, h1.j.first);
+}
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) || \
+    (2 < BOOST_PARAMETER_COMPOSE_MAX_ARITY)
+#include <boost/parameter/compose.hpp>
+
+void test_compose1()
+{
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+    // MSVC 11.0 on AppVeyor fails without this workaround.
+    test::A a(boost::parameter::compose(
+        param::a0 = 1
+      , param::a1 = 13
+      , param::_a2 = std::function<double()>(test::D)
+    ));
+#else
+    test::A a(boost::parameter::compose(
+        param::a0 = 1
+      , param::a1 = 13
+      , param::_a2 = test::D
+    ));
+#endif
+    BOOST_TEST_EQ(1, a.i);
+    BOOST_TEST_EQ(13, a.j);
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+    // MSVC 11.0 on AppVeyor fails without this workaround.
+    test::B b0(boost::parameter::compose(
+        param::tag::a1::a_one = 13
+      , param::_a2 = std::function<float()>(test::F)
+    ));
+#else
+    test::B b0(boost::parameter::compose(
+        param::tag::a1::a_one = 13
+      , param::_a2 = test::F
+    ));
+#endif
+    BOOST_TEST_EQ(1, b0.i);
+    BOOST_TEST_EQ(13, b0.j);
+    BOOST_TEST_EQ(4.0f, b0.k());
+    BOOST_TEST_EQ(2.5, b0.l());
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
+    BOOST_WORKAROUND(BOOST_MSVC, >= 1700) && \
+    BOOST_WORKAROUND(BOOST_MSVC, < 1800)
+    // MSVC 11.0 on AppVeyor fails without this workaround.
+    test::B b1(boost::parameter::compose(
+        param::_a3 = std::function<double()>(test::D)
+      , param::a1 = 13
+    ));
+#else
+    test::B b1(boost::parameter::compose(
+        param::_a3 = test::D
+      , param::a1 = 13
+    ));
+#endif
+    BOOST_TEST_EQ(1, b1.i);
+    BOOST_TEST_EQ(13, b1.j);
+    BOOST_TEST_EQ(4.625f, b1.k());
+    BOOST_TEST_EQ(198.9, b1.l());
+    int x = 23;
+    int const y = 42;
+#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_0)
+    test::G g(boost::parameter::compose(
+        param::_lr = 15
+      , param::_rr = 16
+      , param::_lrc = y
+    ));
+#else
+    test::G g(boost::parameter::compose(
+        param::_lr = x
+      , param::_rr = 16
+      , param::_lrc = y
+    ));
+#endif
+    BOOST_TEST_EQ(16, g.i);
+    BOOST_TEST_EQ(23, g.j);
+    BOOST_TEST_EQ(42, g.k);
+    x = 1;
+    BOOST_TEST_EQ(1, g.j);
+    std::pair<int,int> p1(8, 9);
+    std::pair<int,int> const p2(11, 12);
+    test::H h0(boost::parameter::compose(param::_lr = p1, param::_lrc = p2));
+#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_1)
+    test::H h1(boost::parameter::compose(
+        param::_lr = p2
+      , param::_rr = std::make_pair(7, 10)
+      , param::_lrc = p2
+    ));
+#else
+    test::H h1(boost::parameter::compose(
+        param::_lr = p1
+      , param::_rr = std::make_pair(7, 10)
+      , param::_lrc = p2
+    ));
+#endif
+    BOOST_TEST_EQ(h0.i.first, h1.i.first);
+    BOOST_TEST_EQ(h0.i.second, h1.i.second);
+    BOOST_TEST_EQ(p1.first, h1.j.first);
+    BOOST_TEST_EQ(p1.second, h1.j.second);
+    BOOST_TEST_EQ(p2.first, h1.k.first);
+    BOOST_TEST_EQ(p2.second, h1.k.second);
+    p1.first = 1;
+    BOOST_TEST_EQ(p1.first, h1.j.first);
+}
+
+#endif  // can invoke boost::parameter::compose
+
+int main()
+{
+    test_compose0();
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) || \
+    (2 < BOOST_PARAMETER_COMPOSE_MAX_ARITY)
+    test_compose1();
+#endif
     return boost::report_errors();
 }
 

--- a/test/evaluate_category.cpp
+++ b/test/evaluate_category.cpp
@@ -5,17 +5,16 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #if (BOOST_PARAMETER_MAX_ARITY < 4)
 #error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
 #endif
-#if (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
+#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+    (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
 #error Define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY \
 as 5 or greater.
 #endif
-#endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -27,6 +26,12 @@ namespace test {
 #else
     BOOST_PARAMETER_NAME((_rr0, keywords) rr0)
 #endif
+} // namespace test
+
+#include <boost/parameter/parameters.hpp>
+#include <boost/parameter/required.hpp>
+
+namespace test {
 
     struct f_parameters
       : boost::parameter::parameters<
@@ -53,11 +58,11 @@ namespace test {
         {
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , A<T>::evaluate_category(args[test::_lrc0])
+              , test::A<T>::evaluate_category(args[test::_lrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference
-              , A<T>::evaluate_category(args[test::_lr0])
+              , test::A<T>::evaluate_category(args[test::_lr0])
             );
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 
@@ -65,38 +70,39 @@ namespace test {
             {
                 BOOST_TEST_EQ(
                     test::passed_by_lvalue_reference_to_const
-                  , A<T>::evaluate_category(args[test::_rrc0])
+                  , test::A<T>::evaluate_category(args[test::_rrc0])
                 );
                 BOOST_TEST_EQ(
                     test::passed_by_lvalue_reference_to_const
-                  , A<T>::evaluate_category(args[test::_rr0])
+                  , test::A<T>::evaluate_category(args[test::_rr0])
                 );
             }
             else
             {
                 BOOST_TEST_EQ(
                     test::passed_by_rvalue_reference_to_const
-                  , A<T>::evaluate_category(args[test::_rrc0])
+                  , test::A<T>::evaluate_category(args[test::_rrc0])
                 );
                 BOOST_TEST_EQ(
                     test::passed_by_rvalue_reference
-                  , A<T>::evaluate_category(args[test::_rr0])
+                  , test::A<T>::evaluate_category(args[test::_rr0])
                 );
             }
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , A<T>::evaluate_category(args[test::_rrc0])
+              , test::A<T>::evaluate_category(args[test::_rrc0])
             );
             BOOST_TEST_EQ(
                 test::passed_by_lvalue_reference_to_const
-              , A<T>::evaluate_category(args[test::_rr0])
+              , test::A<T>::evaluate_category(args[test::_rr0])
             );
 #endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
         }
     };
 } // namespace test
 
+#include <boost/parameter/deduced.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/if.hpp>
@@ -131,6 +137,7 @@ namespace test {
     };
 } // namespace test
 
+#include <boost/parameter/value_type.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
 namespace test {
@@ -236,7 +243,7 @@ int main()
     char baz_arr[4] = "qux";
     typedef char char_arr[4];
 
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
     // MSVC-12+ treats static_cast<char_arr&&>(baz_arr) as an lvalue.
 #else

--- a/test/literate/parameter-enabled-function-call-operators0.cpp
+++ b/test/literate/parameter-enabled-function-call-operators0.cpp
@@ -1,0 +1,29 @@
+
+#include <boost/parameter.hpp>
+#include <iostream>
+
+using namespace boost::parameter;
+
+BOOST_PARAMETER_NAME(arg1)
+BOOST_PARAMETER_NAME(arg2)
+
+struct callable2
+{
+    BOOST_PARAMETER_CONST_FUNCTION_CALL_OPERATOR(
+        (void), tag, (required (arg1,(int))(arg2,(int)))
+    )
+    {
+        std::cout << arg1 << ", " << arg2 << std::endl;
+    }
+};
+
+#include <boost/core/lightweight_test.hpp>
+
+int main()
+{
+    callable2 c2;
+    callable2 const& c2_const = c2;
+    c2_const(1, 2);
+    return boost::report_errors();
+}
+

--- a/test/preprocessor_deduced.cpp
+++ b/test/preprocessor_deduced.cpp
@@ -209,7 +209,7 @@ namespace test {
         return 0;
     }
 
-#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) || \
+#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) || \
     !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     // Test support for two different Boost.Parameter-enabled
     // function call operator overloads.
@@ -349,7 +349,7 @@ int main()
     char const* keys[] = {"foo", "bar", "baz"};
     BOOST_TEST_EQ(1, test::sfinae(keys[0]));
     BOOST_TEST_EQ(0, test::sfinae(0));
-#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) || \
+#if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) || \
     !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
     std::map<char const*,std::string> k2s;
     k2s[keys[0]] = std::string("qux");

--- a/test/preprocessor_eval_cat_no_spec.cpp
+++ b/test/preprocessor_eval_cat_no_spec.cpp
@@ -158,7 +158,7 @@ namespace test {
 
     struct B
     {
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
         B()
         {
@@ -262,7 +262,7 @@ namespace test {
 
     struct C : B
     {
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
         C() : B()
         {
@@ -400,7 +400,7 @@ int main()
     char baz_arr[4] = "qux";
     typedef char char_arr[4];
 
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && ( \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && ( \
         BOOST_WORKAROUND(BOOST_GCC, < 40000) || \
         BOOST_WORKAROUND(BOOST_MSVC, >= 1800) \
     )
@@ -426,7 +426,7 @@ int main()
       , test::_lrc0 = test::lvalue_const_str()[0]
     );
 
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
     // MSVC-12+ treats static_cast<char_arr&&>(baz_arr) as an lvalue.
     test::C cp0;

--- a/test/preprocessor_eval_category.cpp
+++ b/test/preprocessor_eval_category.cpp
@@ -5,17 +5,16 @@
 
 #include <boost/parameter/config.hpp>
 
-#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 #if (BOOST_PARAMETER_MAX_ARITY < 4)
 #error Define BOOST_PARAMETER_MAX_ARITY as 4 or greater.
 #endif
-#if (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
+#if !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) && \
+    (BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY < 5)
 #error Define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY \
 as 5 or greater.
 #endif
-#endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -29,6 +28,8 @@ namespace test {
 #endif
 } // namespace test
 
+#include <boost/parameter/preprocessor.hpp>
+#include <boost/parameter/value_type.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/type_traits/is_scalar.hpp>
 #include <boost/type_traits/remove_const.hpp>
@@ -230,7 +231,7 @@ namespace test {
 
     struct B
     {
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
         B()
         {
@@ -282,7 +283,7 @@ namespace test {
             (deduced
                 (optional
                     (rrc0, (float), 0.0f)
-                    (lr0, (char const*), baz)
+                    (lr0, (char const*), test::baz)
                     (rr0
                       , *(test::string_predicate<test::kw::lr0>)
                       , std::string(lr0)
@@ -393,7 +394,7 @@ namespace test {
 
     struct C : B
     {
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
         C() : B()
         {
@@ -490,7 +491,7 @@ int main()
     char baz_arr[4] = "qux";
     typedef char char_arr[4];
 
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
     // MSVC-12+ treats static_cast<char_arr&&>(baz_arr) as an lvalue.
 #else
@@ -523,7 +524,7 @@ int main()
       , test::rvalue_const_float()
     );
 
-#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC) && \
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC) && \
     BOOST_WORKAROUND(BOOST_MSVC, >= 1800)
     // MSVC-12+ treats static_cast<char_arr&&>(baz_arr) as an lvalue.
     test::C cp0;


### PR DESCRIPTION
* Add "test/literate/parameter-enabled-function-call-operators0.cpp" to test suite under alias 'parameter_literate_tests'.
* Add compose() test routine to "test/compose.cpp"
* Replace LIBS_PARAMETER_TEST_COMPILE_FAILURE_MSVC with LIBS_PARAMETER_TEST_COMPILE_FAILURE_VENDOR_SPECIFIC in case compilers other than MSVC start exhibiting errant behavior.
* Adjust for the fact that BOOST_PARAMETER_MAX_ARITY is defined regardless of whether or not BOOST_PARAMETER_HAS_PERFECT_FORWARDING is defined.
* Use minimal file headers to #include vice <boost/parameter.hpp>.