### PR TITLE
 Qualify applicable constructors & functions with BOOST_CONSTEXPR

### DIFF
--- a/include/boost/parameter/aux_/arg_list.hpp
+++ b/include/boost/parameter/aux_/arg_list.hpp
@@ -69,7 +69,7 @@ namespace boost { namespace parameter { namespace aux {
 
         // Variadic constructor also serves as default constructor.
         template <typename ...Args>
-        inline empty_arg_list(Args&&...)
+        inline BOOST_CONSTEXPR empty_arg_list(Args&&...)
         {
         }
 
@@ -87,20 +87,20 @@ namespace boost { namespace parameter { namespace aux {
 
         // Terminator for has_key, indicating that the keyword is unique.
         template <typename KW>
-        static ::boost::parameter::aux::no_tag has_key(KW*);
+        static BOOST_CONSTEXPR ::boost::parameter::aux::no_tag has_key(KW*);
 
         // If either of these operators are called, it means there is no
         // argument in the list that matches the supplied keyword.  Just
         // return the default value.
         template <typename K, typename Default>
-        inline Default&
+        inline BOOST_CONSTEXPR Default&
             operator[](::boost::parameter::aux::default_<K,Default> x) const
         {
             return x.value;
         }
 
         template <typename K, typename Default>
-        inline Default&&
+        inline BOOST_CONSTEXPR Default&&
             operator[](::boost::parameter::aux::default_r_<K,Default> x) const
         {
             return ::std::forward<Default>(x.value);
@@ -110,7 +110,8 @@ namespace boost { namespace parameter { namespace aux {
         // list that matches the supplied keyword.  Just evaluate and return
         // the default value.
         template <typename K, typename F>
-        inline typename ::boost::parameter::aux::result_of0<F>::type
+        inline BOOST_CONSTEXPR
+        typename ::boost::parameter::aux::result_of0<F>::type
             operator[](BOOST_PARAMETER_lazy_default_fallback<K,F> x) const
         {
             return x.compute_default();
@@ -121,7 +122,7 @@ namespace boost { namespace parameter { namespace aux {
         // has a default, we indicate that the actual arguments don't
         // match the function's requirements.
         template <typename ParameterRequirements, typename ArgPack>
-        static typename ParameterRequirements::has_default
+        static BOOST_CONSTEXPR typename ParameterRequirements::has_default
             satisfies(ParameterRequirements*, ArgPack*);
 
         // MPL sequence support
@@ -183,8 +184,10 @@ namespace boost { namespace parameter { namespace aux {
 
         // Create a new list by prepending arg to a copy of tail.  Used when
         // incrementally building this structure with the comma operator.
-        inline arg_list(TaggedArg const& head, Next const& tail)
-          : Next(tail), arg(head)
+        inline BOOST_CONSTEXPR arg_list(
+            TaggedArg const& head
+          , Next const& tail
+        ) : Next(tail), arg(head)
         {
         }
 
@@ -193,7 +196,7 @@ namespace boost { namespace parameter { namespace aux {
         // to the Next constructor, or store the first argument and forward
         // the rest. -- Cromwell D. Enage
         template <typename A0>
-        inline arg_list(
+        inline BOOST_CONSTEXPR arg_list(
             ::boost::parameter::aux::value_type_is_not_void
           , A0&& a0
         ) : Next(
@@ -211,7 +214,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename ...Args>
-        inline arg_list(
+        inline BOOST_CONSTEXPR arg_list(
             ::boost::parameter::aux::value_type_is_void
           , Args&&... args
         ) : Next(
@@ -230,7 +233,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename A0, typename A1, typename ...Args>
-        inline arg_list(
+        inline BOOST_CONSTEXPR arg_list(
             ::boost::parameter::aux::value_type_is_not_void
           , A0&& a0
           , A1&& a1
@@ -302,13 +305,15 @@ namespace boost { namespace parameter { namespace aux {
 
         // Helpers that handle the case when TaggedArg is empty<T>.
         template <typename D>
-        inline reference get_default(D const&, ::boost::mpl::false_) const
+        inline BOOST_CONSTEXPR reference
+            get_default(D const&, ::boost::mpl::false_) const
         {
             return this->arg.get_value();
         }
 
         template <typename D>
-        inline reference get_default(D const& d, ::boost::mpl::true_) const
+        inline BOOST_CONSTEXPR reference
+            get_default(D const& d, ::boost::mpl::true_) const
         {
             return (
                 this->arg.get_value()
@@ -317,15 +322,24 @@ namespace boost { namespace parameter { namespace aux {
             );
         }
 
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](::boost::parameter::keyword<key_type> const&) const
         {
+#if !defined(BOOST_NO_CXX14_CONSTEXPR) && \
+    !defined(BOOST_NO_CXX11_STATIC_ASSERT)
+            static_assert(!holds_maybe::value, "must not hold maybe");
+#elif !( \
+        BOOST_WORKAROUND(BOOST_GCC, >= 40700) && \
+        BOOST_WORKAROUND(BOOST_GCC, < 40900) \
+    ) && !BOOST_WORKAROUND(BOOST_GCC, >= 50000) && \
+    !BOOST_WORKAROUND(BOOST_MSVC, < 1910)
             BOOST_MPL_ASSERT_NOT((holds_maybe));
+#endif
             return this->arg.get_value();
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::default_<key_type,Default> const& d
             ) const
@@ -334,7 +348,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::default_r_<key_type,Default> const& d
             ) const
@@ -343,12 +357,21 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 BOOST_PARAMETER_lazy_default_fallback<key_type,Default> const&
             ) const
         {
+#if !defined(BOOST_NO_CXX14_CONSTEXPR) && \
+    !defined(BOOST_NO_CXX11_STATIC_ASSERT)
+            static_assert(!holds_maybe::value, "must not hold maybe");
+#elif !( \
+        BOOST_WORKAROUND(BOOST_GCC, >= 40700) && \
+        BOOST_WORKAROUND(BOOST_GCC, < 40900) \
+    ) && !BOOST_WORKAROUND(BOOST_GCC, >= 50000) && \
+    !BOOST_WORKAROUND(BOOST_MSVC, < 1910)
             BOOST_MPL_ASSERT_NOT((holds_maybe));
+#endif
             return this->arg.get_value();
         }
 
@@ -365,7 +388,7 @@ namespace boost { namespace parameter { namespace aux {
         // satisfied by TaggedArg.  Used only for compile-time computation
         // and never really called, so a declaration is enough.
         template <typename HasDefault, typename Predicate, typename ArgPack>
-        static typename ::boost::lazy_enable_if<
+        static BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
             typename ::boost::mpl::if_<
                 EmitsErrors
               , ::boost::mpl::true_
@@ -394,7 +417,7 @@ namespace boost { namespace parameter { namespace aux {
         // Comma operator to compose argument list without using parameters<>.
         // Useful for argument lists with undetermined length.
         template <typename KW, typename T2>
-        inline ::boost::parameter::aux::arg_list<
+        inline BOOST_CONSTEXPR ::boost::parameter::aux::arg_list<
             ::boost::parameter::aux::tagged_argument<KW,T2>
           , self
         >
@@ -409,7 +432,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename T2>
-        inline ::boost::parameter::aux::arg_list<
+        inline BOOST_CONSTEXPR ::boost::parameter::aux::arg_list<
             ::boost::parameter::aux::tagged_argument_rref<KW,T2>
           , self
         >
@@ -443,13 +466,13 @@ namespace boost { namespace parameter { namespace aux {
     // feel for what's really happening here.
     struct empty_arg_list
     {
-        inline empty_arg_list()
+        inline BOOST_CONSTEXPR empty_arg_list()
         {
         }
 
         // Constructor taking BOOST_PARAMETER_COMPOSE_MAX_ARITY empty_arg_list
         // arguments; this makes initialization.
-        inline empty_arg_list(
+        inline BOOST_CONSTEXPR empty_arg_list(
             BOOST_PP_ENUM_PARAMS(
                 BOOST_PARAMETER_COMPOSE_MAX_ARITY
               , ::boost::parameter::void_ BOOST_PP_INTERCEPT
@@ -472,7 +495,7 @@ namespace boost { namespace parameter { namespace aux {
 
         // Terminator for has_key, indicating that the keyword is unique.
         template <typename KW>
-        static ::boost::parameter::aux::no_tag has_key(KW*);
+        static BOOST_CONSTEXPR ::boost::parameter::aux::no_tag has_key(KW*);
 
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
         // The overload set technique doesn't work with these older compilers,
@@ -494,7 +517,7 @@ namespace boost { namespace parameter { namespace aux {
         // argument in the list that matches the supplied keyword.  Just
         // return the default value.
         template <typename K, typename Default>
-        inline Default&
+        inline BOOST_CONSTEXPR Default&
             operator[](::boost::parameter::aux::default_<K,Default> x) const
         {
             return x.value;
@@ -504,7 +527,8 @@ namespace boost { namespace parameter { namespace aux {
         // list that matches the supplied keyword.  Just evaluate and return
         // the default value.
         template <typename K, typename F>
-        inline typename ::boost::parameter::aux::result_of0<F>::type
+        inline BOOST_CONSTEXPR
+        typename ::boost::parameter::aux::result_of0<F>::type
             operator[](BOOST_PARAMETER_lazy_default_fallback<K,F> x) const
         {
             return x.compute_default();
@@ -515,7 +539,7 @@ namespace boost { namespace parameter { namespace aux {
         // has a default, we indicate that the actual arguments don't
         // match the function's requirements.
         template <typename ParameterRequirements, typename ArgPack>
-        static typename ParameterRequirements::has_default
+        static BOOST_CONSTEXPR typename ParameterRequirements::has_default
             satisfies(ParameterRequirements*, ArgPack*);
 
         // MPL sequence support
@@ -584,8 +608,10 @@ namespace boost { namespace parameter { namespace aux {
 
         // Create a new list by prepending arg to a copy of tail.  Used when
         // incrementally building this structure with the comma operator.
-        inline arg_list(TaggedArg const& head, Next const& tail)
-          : Next(tail), arg(head)
+        inline BOOST_CONSTEXPR arg_list(
+            TaggedArg const& head
+          , Next const& tail
+        ) : Next(tail), arg(head)
         {
         }
 
@@ -597,7 +623,7 @@ namespace boost { namespace parameter { namespace aux {
               , typename A
             )
         >
-        inline arg_list(
+        inline BOOST_CONSTEXPR arg_list(
             // A0& a0, A1& a1, ...
             BOOST_PP_ENUM_BINARY_PARAMS(
                 BOOST_PARAMETER_COMPOSE_MAX_ARITY
@@ -681,13 +707,15 @@ namespace boost { namespace parameter { namespace aux {
 
         // Helpers that handle the case when TaggedArg is empty<T>.
         template <typename D>
-        inline reference get_default(D const&, ::boost::mpl::false_) const
+        inline BOOST_CONSTEXPR reference
+            get_default(D const&, ::boost::mpl::false_) const
         {
             return this->arg.get_value();
         }
 
         template <typename D>
-        inline reference get_default(D const& d, ::boost::mpl::true_) const
+        inline BOOST_CONSTEXPR reference
+            get_default(D const& d, ::boost::mpl::true_) const
         {
             return (
                 this->arg.get_value()
@@ -723,7 +751,7 @@ namespace boost { namespace parameter { namespace aux {
         // Outer indexing operators that dispatch to the right node's
         // get() function.
         template <typename KW>
-        inline typename ::boost::mpl::apply_wrap3<
+        inline BOOST_CONSTEXPR typename ::boost::mpl::apply_wrap3<
             binding
           , KW
           , ::boost::parameter::void_
@@ -737,7 +765,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename Default>
-        inline typename ::boost::mpl::apply_wrap3<
+        inline BOOST_CONSTEXPR typename ::boost::mpl::apply_wrap3<
             binding
           , KW
           , Default&
@@ -753,7 +781,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename F>
-        inline typename ::boost::mpl::apply_wrap3<
+        inline BOOST_CONSTEXPR typename ::boost::mpl::apply_wrap3<
             binding
           , KW
           , typename ::boost::parameter::aux::result_of0<F>::type
@@ -772,7 +800,7 @@ namespace boost { namespace parameter { namespace aux {
         // indicating no matching argument was passed, the default is
         // returned, or if no default_ or lazy_default was passed, compilation
         // fails.
-        inline reference
+        inline BOOST_CONSTEXPR reference
             get(::boost::parameter::keyword<key_type> const&) const
         {
             BOOST_MPL_ASSERT_NOT((holds_maybe));
@@ -780,7 +808,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             get(
                 ::boost::parameter::aux::default_<key_type,Default> const& d
             ) const
@@ -789,7 +817,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             get(
                 BOOST_PARAMETER_lazy_default_fallback<key_type,Default> const&
             ) const
@@ -797,7 +825,7 @@ namespace boost { namespace parameter { namespace aux {
             return this->arg.get_value();
         }
 #else   // !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](::boost::parameter::keyword<key_type> const&) const
         {
             BOOST_MPL_ASSERT_NOT((holds_maybe));
@@ -805,7 +833,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::default_<key_type,Default> const& d
             ) const
@@ -814,7 +842,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 BOOST_PARAMETER_lazy_default_fallback<key_type,Default> const&
             ) const
@@ -836,7 +864,7 @@ namespace boost { namespace parameter { namespace aux {
         // satisfied by TaggedArg.  Used only for compile-time computation
         // and never really called, so a declaration is enough.
         template <typename HasDefault, typename Predicate, typename ArgPack>
-        static typename
+        static BOOST_CONSTEXPR typename
 #if !defined(BOOST_NO_SFINAE) && !BOOST_WORKAROUND(BOOST_MSVC, < 1800)
         ::boost::lazy_enable_if<
             typename ::boost::mpl::if_<
@@ -871,7 +899,7 @@ namespace boost { namespace parameter { namespace aux {
         // Comma operator to compose argument list without using parameters<>.
         // Useful for argument lists with undetermined length.
         template <typename KW, typename T2>
-        inline ::boost::parameter::aux::arg_list<
+        inline BOOST_CONSTEXPR ::boost::parameter::aux::arg_list<
             ::boost::parameter::aux::tagged_argument<KW,T2>
           , self
         >

--- a/include/boost/parameter/aux_/default.hpp
+++ b/include/boost/parameter/aux_/default.hpp
@@ -14,7 +14,7 @@ namespace boost { namespace parameter { namespace aux {
     template <typename Keyword, typename Value>
     struct default_
     {
-        inline default_(Value& x) : value(x)
+        inline BOOST_CONSTEXPR default_(Value& x) : value(x)
         {
         }
 
@@ -36,7 +36,7 @@ namespace boost { namespace parameter { namespace aux {
     template <typename KW, typename DefaultComputer>
     struct lazy_default_base
     {
-        inline lazy_default_base(DefaultComputer& x)
+        inline BOOST_CONSTEXPR lazy_default_base(DefaultComputer& x)
           : compute_default(x)
         {
         }
@@ -48,7 +48,7 @@ namespace boost { namespace parameter { namespace aux {
     struct lazy_default
       : ::boost::parameter::aux::lazy_default_base<KW,DefaultComputer>
     {
-        inline lazy_default(DefaultComputer& x)
+        inline BOOST_CONSTEXPR lazy_default(DefaultComputer& x)
           : ::boost::parameter::aux::lazy_default_base<KW,DefaultComputer>(x)
         {
         }
@@ -57,7 +57,8 @@ namespace boost { namespace parameter { namespace aux {
     template <typename KW, typename DefaultComputer>
     struct lazy_default
     {
-        inline lazy_default(DefaultComputer& x) : compute_default(x)
+        inline BOOST_CONSTEXPR lazy_default(DefaultComputer& x)
+          : compute_default(x)
         {
         }
 
@@ -85,7 +86,8 @@ namespace boost { namespace parameter { namespace aux {
     template <typename Keyword, typename Value>
     struct default_r_
     {
-        inline default_r_(Value&& x) : value(::std::forward<Value>(x))
+        inline BOOST_CONSTEXPR default_r_(Value&& x)
+          : value(::std::forward<Value>(x))
         {
         }
 

--- a/include/boost/parameter/aux_/tagged_argument.hpp
+++ b/include/boost/parameter/aux_/tagged_argument.hpp
@@ -122,11 +122,12 @@ namespace boost { namespace parameter { namespace aux {
         >::type value;
 
      public:
-        inline explicit tagged_argument(reference x) : value(x)
+        inline explicit BOOST_CONSTEXPR tagged_argument(reference x)
+          : value(x)
         {
         }
 
-        inline tagged_argument(tagged_argument const& copy)
+        inline BOOST_CONSTEXPR tagged_argument(tagged_argument const& copy)
           : value(copy.value)
         {
         }
@@ -150,7 +151,7 @@ namespace boost { namespace parameter { namespace aux {
         // Comma operator to compose argument list without using parameters<>.
         // Useful for argument lists with undetermined length.
         template <typename Keyword2, typename Arg2>
-        inline ::boost::parameter::aux::arg_list<
+        inline BOOST_CONSTEXPR ::boost::parameter::aux::arg_list<
             ::boost::parameter::aux::tagged_argument<Keyword,Arg>
           , ::boost::parameter::aux::arg_list<
                 ::boost::parameter::aux::tagged_argument<Keyword2,Arg2>
@@ -175,7 +176,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Keyword2, typename Arg2>
-        inline ::boost::parameter::aux::arg_list<
+        inline BOOST_CONSTEXPR ::boost::parameter::aux::arg_list<
             ::boost::parameter::aux::tagged_argument<Keyword,Arg>
           , ::boost::parameter::aux::arg_list<
                 ::boost::parameter::aux::tagged_argument_rref<Keyword2,Arg2>
@@ -201,19 +202,19 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         // Accessor interface.
-        inline reference get_value() const
+        inline BOOST_CONSTEXPR reference get_value() const
         {
             return this->value;
         }
 
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](::boost::parameter::keyword<Keyword> const&) const
         {
             return this->get_value();
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::default_<key_type,Default> const&
             ) const
@@ -222,7 +223,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename F>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::lazy_default<key_type,F> const&
             ) const
@@ -231,7 +232,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename Default>
-        inline Default&
+        inline BOOST_CONSTEXPR Default&
             operator[](
                 ::boost::parameter::aux::default_<KW,Default> const& x
             ) const
@@ -240,7 +241,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename Default>
-        inline Default&&
+        inline BOOST_CONSTEXPR Default&&
             operator[](
                 ::boost::parameter::aux::default_r_<KW,Default> const& x
             ) const
@@ -249,7 +250,8 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename F>
-        inline typename ::boost::parameter::aux::result_of0<F>::type
+        inline BOOST_CONSTEXPR
+        typename ::boost::parameter::aux::result_of0<F>::type
             operator[](
                 ::boost::parameter::aux::lazy_default<KW,F> const& x
             ) const
@@ -258,11 +260,12 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename ParameterRequirements>
-        static typename ParameterRequirements::has_default
+        static BOOST_CONSTEXPR typename ParameterRequirements::has_default
             satisfies(ParameterRequirements*);
 
         template <typename HasDefault, typename Predicate>
-        static typename ::boost::mpl::apply_wrap1<Predicate,value_type>::type
+        static BOOST_CONSTEXPR
+        typename ::boost::mpl::apply_wrap1<Predicate,value_type>::type
             satisfies(
                 ::boost::parameter::aux::parameter_requirements<
                     key_type
@@ -301,13 +304,14 @@ namespace boost { namespace parameter { namespace aux {
         reference value;
 
      public:
-        inline explicit tagged_argument_rref(reference x)
+        inline explicit BOOST_CONSTEXPR tagged_argument_rref(reference x)
           : value(::std::forward<Arg>(x))
         {
         }
 
-        inline tagged_argument_rref(tagged_argument_rref const& copy)
-          : value(::std::forward<Arg>(copy.value))
+        inline BOOST_CONSTEXPR tagged_argument_rref(
+            tagged_argument_rref const& copy
+        ) : value(::std::forward<Arg>(copy.value))
         {
         }
 
@@ -330,7 +334,7 @@ namespace boost { namespace parameter { namespace aux {
         // Comma operator to compose argument list without using parameters<>.
         // Useful for argument lists with undetermined length.
         template <typename Keyword2, typename Arg2>
-        inline ::boost::parameter::aux::arg_list<
+        inline BOOST_CONSTEXPR ::boost::parameter::aux::arg_list<
             ::boost::parameter::aux::tagged_argument_rref<Keyword,Arg>
           , ::boost::parameter::aux::arg_list<
                 ::boost::parameter::aux::tagged_argument<Keyword2,Arg2>
@@ -355,7 +359,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Keyword2, typename Arg2>
-        inline ::boost::parameter::aux::arg_list<
+        inline BOOST_CONSTEXPR ::boost::parameter::aux::arg_list<
             ::boost::parameter::aux::tagged_argument_rref<Keyword,Arg>
           , ::boost::parameter::aux::arg_list<
                 ::boost::parameter::aux::tagged_argument_rref<Keyword2,Arg2>
@@ -384,19 +388,19 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         // Accessor interface.
-        inline reference get_value() const
+        inline BOOST_CONSTEXPR reference get_value() const
         {
             return ::std::forward<Arg>(this->value);
         }
 
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](::boost::parameter::keyword<Keyword> const&) const
         {
             return this->get_value();
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::default_<key_type,Default> const&
             ) const
@@ -405,7 +409,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::default_r_<key_type,Default> const&
             ) const
@@ -414,7 +418,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename F>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::lazy_default<key_type,F> const&
             ) const
@@ -423,7 +427,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename Default>
-        inline Default&
+        inline BOOST_CONSTEXPR Default&
             operator[](
                 ::boost::parameter::aux::default_<KW,Default> const& x
             ) const
@@ -432,7 +436,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename Default>
-        inline Default&&
+        inline BOOST_CONSTEXPR Default&&
             operator[](
                 ::boost::parameter::aux::default_r_<KW,Default> const& x
             ) const
@@ -441,7 +445,8 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename F>
-        inline typename ::boost::parameter::aux::result_of0<F>::type
+        inline BOOST_CONSTEXPR
+        typename ::boost::parameter::aux::result_of0<F>::type
             operator[](
                 ::boost::parameter::aux::lazy_default<KW,F> const& x
             ) const
@@ -450,11 +455,12 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename ParameterRequirements>
-        static typename ParameterRequirements::has_default
+        static BOOST_CONSTEXPR typename ParameterRequirements::has_default
             satisfies(ParameterRequirements*);
 
         template <typename HasDefault, typename Predicate>
-        static typename ::boost::mpl::apply_wrap1<Predicate,value_type>::type
+        static BOOST_CONSTEXPR
+        typename ::boost::mpl::apply_wrap1<Predicate,value_type>::type
             satisfies(
                 ::boost::parameter::aux::parameter_requirements<
                     key_type
@@ -524,11 +530,12 @@ namespace boost { namespace parameter { namespace aux {
         >::type value;
 
      public:
-        inline explicit tagged_argument(reference x) : value(x)
+        inline explicit BOOST_CONSTEXPR tagged_argument(reference x)
+          : value(x)
         {
         }
 
-        inline tagged_argument(tagged_argument const& copy)
+        inline BOOST_CONSTEXPR tagged_argument(tagged_argument const& copy)
           : value(copy.value)
         {
         }
@@ -577,12 +584,12 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         // Accessor interface.
-        inline reference get_value() const
+        inline BOOST_CONSTEXPR reference get_value() const
         {
             return this->value;
         }
 
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](::boost::parameter::keyword<Keyword> const&) const
         {
             return this->get_value();
@@ -591,7 +598,7 @@ namespace boost { namespace parameter { namespace aux {
 #if defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING) || \
     BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
         template <typename KW, typename Default>
-        inline Default&
+        inline BOOST_CONSTEXPR Default&
             get_with_default(
                 ::boost::parameter::aux::default_<KW,Default> const& x
               , int
@@ -601,7 +608,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             get_with_default(
                 ::boost::parameter::aux::default_<key_type,Default> const&
               , long
@@ -611,7 +618,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename Default>
-        inline typename ::boost::mpl::apply_wrap3<
+        inline BOOST_CONSTEXPR typename ::boost::mpl::apply_wrap3<
             binding
           , KW
           , Default&
@@ -625,7 +632,8 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename F>
-        inline typename ::boost::parameter::aux::result_of0<F>::type
+        inline BOOST_CONSTEXPR
+        typename ::boost::parameter::aux::result_of0<F>::type
             get_with_lazy_default(
                 ::boost::parameter::aux::lazy_default<KW,F> const& x
               , int
@@ -635,7 +643,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename F>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             get_with_lazy_default(
                 ::boost::parameter::aux::lazy_default<key_type,F> const&
               , long
@@ -645,7 +653,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename F>
-        inline typename ::boost::mpl::apply_wrap3<
+        inline BOOST_CONSTEXPR typename ::boost::mpl::apply_wrap3<
             binding
           , KW
           , typename ::boost::parameter::aux::result_of0<F>::type
@@ -659,7 +667,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 #else   // No function template ordering or Borland workarounds needed.
         template <typename Default>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::default_<key_type,Default> const&
             ) const
@@ -668,7 +676,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename F>
-        inline reference
+        inline BOOST_CONSTEXPR reference
             operator[](
                 ::boost::parameter::aux::lazy_default<key_type,F> const&
             ) const
@@ -677,7 +685,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename Default>
-        inline Default&
+        inline BOOST_CONSTEXPR Default&
             operator[](
                 ::boost::parameter::aux::default_<KW,Default> const& x
             ) const
@@ -686,7 +694,8 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename KW, typename F>
-        inline typename ::boost::parameter::aux::result_of0<F>::type
+        inline BOOST_CONSTEXPR
+        typename ::boost::parameter::aux::result_of0<F>::type
             operator[](
                 ::boost::parameter::aux::lazy_default<KW,F> const& x
             ) const
@@ -695,11 +704,12 @@ namespace boost { namespace parameter { namespace aux {
         }
 
         template <typename ParameterRequirements>
-        static typename ParameterRequirements::has_default
+        static BOOST_CONSTEXPR typename ParameterRequirements::has_default
             satisfies(ParameterRequirements*);
 
         template <typename HasDefault, typename Predicate>
-        static typename ::boost::mpl::apply_wrap1<Predicate,value_type>::type
+        static BOOST_CONSTEXPR
+        typename ::boost::mpl::apply_wrap1<Predicate,value_type>::type
             satisfies(
                 ::boost::parameter::aux::parameter_requirements<
                     key_type

--- a/include/boost/parameter/aux_/use_default_tag.hpp
+++ b/include/boost/parameter/aux_/use_default_tag.hpp
@@ -6,11 +6,19 @@
 #ifndef BOOST_PARAMETER_USE_DEFAULT_TAG_HPP
 #define BOOST_PARAMETER_USE_DEFAULT_TAG_HPP
 
+#include <boost/config.hpp>
+
 namespace boost { namespace parameter { namespace aux {
 
     struct use_default_tag
     {
-        inline use_default_tag operator()() const
+        inline BOOST_CONSTEXPR BOOST_DEFAULTED_FUNCTION(use_default_tag(), {})
+
+        inline BOOST_CONSTEXPR BOOST_DEFAULTED_FUNCTION(
+            use_default_tag(use_default_tag const&), {}
+        )
+
+        inline BOOST_CONSTEXPR use_default_tag operator()() const
         {
             return *this;
         }

--- a/include/boost/parameter/compose.hpp
+++ b/include/boost/parameter/compose.hpp
@@ -10,7 +10,7 @@
 
 namespace boost { namespace parameter {
 
-    inline ::boost::parameter::aux::empty_arg_list compose()
+    inline BOOST_CONSTEXPR ::boost::parameter::aux::empty_arg_list compose()
     {
         return ::boost::parameter::aux::empty_arg_list();
     }
@@ -48,7 +48,7 @@ namespace boost { namespace parameter { namespace aux {
 namespace boost { namespace parameter {
 
     template <typename TaggedArg0, typename ...TaggedArgs>
-    inline typename ::boost::lazy_enable_if<
+    inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
         ::boost::parameter::are_tagged_arguments<TaggedArg0,TaggedArgs...>
       , ::boost::parameter::aux
         ::compose_arg_list<TaggedArg0,TaggedArgs...>
@@ -95,7 +95,7 @@ namespace boost { namespace parameter {
 #if defined(BOOST_NO_SFINAE)
 #define BOOST_PARAMETER_compose_arg_list_function_overload(z, n, prefix)     \
     template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename prefix)>                 \
-    inline                                                                   \
+    inline BOOST_CONSTEXPR                                                   \
     BOOST_PARAMETER_compose_arg_list_type(z, n, prefix)                      \
         compose(BOOST_PP_ENUM_BINARY_PARAMS_Z(z, n, prefix, const& a))       \
     {                                                                        \
@@ -115,7 +115,7 @@ namespace boost { namespace parameter {
 
 #define BOOST_PARAMETER_compose_arg_list_function_overload(z, n, prefix)     \
     template <BOOST_PP_ENUM_PARAMS_Z(z, n, typename prefix)>                 \
-    inline typename ::boost::enable_if<                                      \
+    inline BOOST_CONSTEXPR typename ::boost::enable_if<                      \
         ::boost::parameter                                                   \
         ::are_tagged_arguments<BOOST_PP_ENUM_PARAMS_Z(z, n, prefix)>         \
       , BOOST_PARAMETER_compose_arg_list_type(z, n, prefix)                  \

--- a/include/boost/parameter/keyword.hpp
+++ b/include/boost/parameter/keyword.hpp
@@ -45,8 +45,12 @@ namespace boost { namespace parameter {
     {
         typedef Tag tag;
 
+        inline BOOST_CONSTEXPR keyword()
+        {
+        }
+
         template <typename T>
-        inline typename ::boost::lazy_enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<T>
               , ::boost::mpl::true_
@@ -67,7 +71,7 @@ namespace boost { namespace parameter {
                 >
             >::type
           , ::boost::parameter::aux::tag<Tag,T const&>
-        >::type BOOST_CONSTEXPR
+        >::type
             operator=(T const& x) const
         {
             typedef typename ::boost::parameter::aux
@@ -76,7 +80,7 @@ namespace boost { namespace parameter {
         }
 
         template <typename Default>
-        inline typename ::boost::enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::enable_if<
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<Default>
               , ::boost::mpl::true_
@@ -104,7 +108,7 @@ namespace boost { namespace parameter {
         }
 
         template <typename T>
-        inline typename ::boost::lazy_enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
             typename ::boost::mpl::eval_if<
                 typename ::boost::mpl::if_<
                     ::boost::is_same<
@@ -125,7 +129,7 @@ namespace boost { namespace parameter {
               , ::boost::mpl::false_
             >::type
           , ::boost::parameter::aux::tag<Tag,T&>
-        >::type BOOST_CONSTEXPR
+        >::type
             operator=(T& x) const
         {
             typedef typename ::boost::parameter::aux
@@ -134,7 +138,7 @@ namespace boost { namespace parameter {
         }
 
         template <typename Default>
-        inline typename ::boost::enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::enable_if<
             typename ::boost::mpl::eval_if<
                 typename ::boost::mpl::if_<
                     ::boost::is_same<
@@ -162,7 +166,8 @@ namespace boost { namespace parameter {
         }
 
         template <typename Default>
-        inline ::boost::parameter::aux::lazy_default<Tag,Default const>
+        inline BOOST_CONSTEXPR
+        ::boost::parameter::aux::lazy_default<Tag,Default const>
             operator||(Default const& d) const
         {
             return ::boost::parameter::aux
@@ -170,14 +175,15 @@ namespace boost { namespace parameter {
         }
 
         template <typename Default>
-        inline ::boost::parameter::aux::lazy_default<Tag,Default>
+        inline BOOST_CONSTEXPR
+        ::boost::parameter::aux::lazy_default<Tag,Default>
             operator||(Default& d) const
         {
             return ::boost::parameter::aux::lazy_default<Tag,Default>(d);
         }
 
         template <typename T>
-        inline typename ::boost::lazy_enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<T>
               , ::boost::mpl::false_
@@ -198,7 +204,7 @@ namespace boost { namespace parameter {
                 >
             >::type
           , ::boost::parameter::aux::tag<Tag,T const>
-        >::type BOOST_CONSTEXPR
+        >::type
             operator=(T const&& x) const
         {
             typedef typename ::boost::parameter::aux
@@ -207,7 +213,7 @@ namespace boost { namespace parameter {
         }
 
         template <typename T>
-        inline typename ::boost::lazy_enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<T>
               , ::boost::mpl::false_
@@ -228,7 +234,7 @@ namespace boost { namespace parameter {
                 >
             >::type
           , ::boost::parameter::aux::tag<Tag,T>
-        >::type BOOST_CONSTEXPR
+        >::type
             operator=(T&& x) const
         {
             typedef typename ::boost::parameter::aux::tag<Tag,T>::type result;
@@ -236,7 +242,7 @@ namespace boost { namespace parameter {
         }
 
         template <typename Default>
-        inline typename ::boost::enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::enable_if<
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<Default>
               , ::boost::mpl::false_
@@ -266,7 +272,7 @@ namespace boost { namespace parameter {
         }
 
         template <typename Default>
-        inline typename ::boost::enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::enable_if<
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<Default>
               , ::boost::mpl::false_
@@ -348,11 +354,15 @@ namespace boost { namespace parameter {
     {
         typedef Tag tag;
 
+        inline BOOST_CONSTEXPR keyword()
+        {
+        }
+
         template <typename T>
 #if defined(BOOST_NO_SFINAE)
         inline typename ::boost::parameter::aux::tag<Tag,T const&>::type
 #else
-        inline typename ::boost::lazy_enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<T>
               , ::boost::mpl::true_
@@ -373,7 +383,7 @@ namespace boost { namespace parameter {
                 >
             >::type
           , ::boost::parameter::aux::tag<Tag,T const&>
-        >::type BOOST_CONSTEXPR
+        >::type
 #endif  // BOOST_NO_SFINAE
             operator=(T const& x) const
         {
@@ -386,7 +396,7 @@ namespace boost { namespace parameter {
 #if defined(BOOST_NO_SFINAE)
         inline ::boost::parameter::aux::default_<Tag,Default const>
 #else
-        inline typename ::boost::enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::enable_if<
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<Default>
               , ::boost::mpl::true_
@@ -418,7 +428,7 @@ namespace boost { namespace parameter {
 #if defined(BOOST_NO_SFINAE)
         inline typename ::boost::parameter::aux::tag<Tag,T&>::type
 #else
-        inline typename ::boost::lazy_enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
             typename ::boost::mpl::eval_if<
                 typename ::boost::mpl::if_<
                     ::boost::is_same<
@@ -439,7 +449,7 @@ namespace boost { namespace parameter {
               , ::boost::mpl::false_
             >::type
           , ::boost::parameter::aux::tag<Tag,T&>
-        >::type BOOST_CONSTEXPR
+        >::type
 #endif  // BOOST_NO_SFINAE
             operator=(T& x) const
         {
@@ -452,7 +462,7 @@ namespace boost { namespace parameter {
 #if defined(BOOST_NO_SFINAE)
         inline ::boost::parameter::aux::default_<Tag,Default>
 #else
-        inline typename ::boost::enable_if<
+        inline BOOST_CONSTEXPR typename ::boost::enable_if<
             typename ::boost::mpl::eval_if<
                 typename ::boost::mpl::if_<
                     ::boost::is_same<
@@ -481,7 +491,8 @@ namespace boost { namespace parameter {
         }
 
         template <typename Default>
-        inline ::boost::parameter::aux::lazy_default<Tag,Default const>
+        inline BOOST_CONSTEXPR
+        ::boost::parameter::aux::lazy_default<Tag,Default const>
             operator||(Default const& d) const
         {
             return ::boost::parameter::aux
@@ -489,7 +500,8 @@ namespace boost { namespace parameter {
         }
 
         template <typename Default>
-        inline ::boost::parameter::aux::lazy_default<Tag,Default>
+        inline BOOST_CONSTEXPR
+        ::boost::parameter::aux::lazy_default<Tag,Default>
             operator||(Default& d) const
         {
             return ::boost::parameter::aux::lazy_default<Tag,Default>(d);
@@ -528,7 +540,7 @@ namespace boost { namespace parameter {
     {                                                                        \
         struct name                                                          \
         {                                                                    \
-            static char const* keyword_name()                                \
+            static BOOST_CONSTEXPR char const* keyword_name()                \
             {                                                                \
                 return #name;                                                \
             }                                                                \

--- a/include/boost/parameter/name.hpp
+++ b/include/boost/parameter/name.hpp
@@ -8,6 +8,7 @@
 #define BOOST_PARAMETER_NAME_060806_HPP
 
 #include <boost/parameter/aux_/name.hpp>
+#include <boost/parameter/config.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
 #define BOOST_PARAMETER_NAME_TAG(tag_namespace, tag, q)                      \
@@ -15,7 +16,7 @@
     {                                                                        \
         struct tag                                                           \
         {                                                                    \
-            static char const* keyword_name()                                \
+            static BOOST_CONSTEXPR char const* keyword_name()                \
             {                                                                \
                 return BOOST_PP_STRINGIZE(tag);                              \
             }                                                                \

--- a/include/boost/parameter/nested_keyword.hpp
+++ b/include/boost/parameter/nested_keyword.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/parameter/aux_/name.hpp>
 #include <boost/parameter/keyword.hpp>
+#include <boost/parameter/config.hpp>
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
@@ -17,7 +18,7 @@
         template <int Dummy = 0>                                             \
         struct BOOST_PP_CAT(name, _)                                         \
         {                                                                    \
-            static char const* keyword_name()                                \
+            static BOOST_CONSTEXPR char const* keyword_name()                \
             {                                                                \
                 return BOOST_PP_STRINGIZE(name);                             \
             }                                                                \

--- a/include/boost/parameter/parameters.hpp
+++ b/include/boost/parameter/parameters.hpp
@@ -31,7 +31,8 @@ namespace boost { namespace parameter { namespace aux {
     struct arg_list_factory<ArgList>
     {
         template <typename ...ReversedArgs>
-        static inline ArgList reverse(ReversedArgs&&... reversed_args)
+        static inline BOOST_CONSTEXPR ArgList
+            reverse(ReversedArgs&&... reversed_args)
         {
             return ArgList(
                 typename ::boost::mpl::if_<
@@ -51,7 +52,7 @@ namespace boost { namespace parameter { namespace aux {
     struct arg_list_factory<ArgList,A0,Args...>
     {
         template <typename ...ReversedArgs>
-        static inline ArgList
+        static inline BOOST_CONSTEXPR ArgList
             reverse(A0&& a0, Args&&... args, ReversedArgs&&... reversed_args)
         {
             return ::boost::parameter::aux


### PR DESCRIPTION
The reference documentation specifies this for some of the constructors and functions.