### PR TITLE
 Support Boost.MP11 when feasible

### DIFF
--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -186,14 +186,16 @@ id="id39">5&nbsp;&nbsp;&nbsp;Portability Considerations</a>
 <ul class="auto-toc">
 <li><a class="reference internal" href="#perfect-forwarding-support"
 id="id40">5.1&nbsp;&nbsp;&nbsp;Perfect Forwarding Support</a></li>
+<li><a class="reference internal" href="#boost-mp11-support"
+id="id41">5.1&nbsp;&nbsp;&nbsp;Boost.MP11 Support</a></li>
 <li><a class="reference internal" href="#no-sfinae-support"
-id="id42">5.2&nbsp;&nbsp;&nbsp;No SFINAE Support</a></li>
+id="id42">5.3&nbsp;&nbsp;&nbsp;No SFINAE Support</a></li>
 <li><a class="reference internal" href="#no-support-for-result-of"
-id="id43">5.3&nbsp;&nbsp;&nbsp;No Support for
+id="id43">5.4&nbsp;&nbsp;&nbsp;No Support for
 <tt class="docutils literal">result_of</tt></a></li>
 <li><a class="reference internal"
 href="#compiler-can-t-see-references-in-unnamed-namespace"
-id="id44">5.4&nbsp;&nbsp;&nbsp;Compiler Can't See References In Unnamed
+id="id44">5.5&nbsp;&nbsp;&nbsp;Compiler Can't See References In Unnamed
 Namespace</a></li>
 </ul>
 </li>
@@ -2644,8 +2646,26 @@ href="../../test/preprocessor_eval_category.cpp"
 >test/preprocessor_eval_category.cpp</a> test programs demonstrate this
 support.</p>
 </div>
+<div class="section" id="boost-mp11-support">
+<h2><a class="toc-backref" href="#id41">5.2&nbsp;&nbsp;&nbsp;Boost.MP11
+Support</a></h2>
+<p>If your compiler is sufficiently compliant with the C++11 standard, then
+the Parameter library will <tt class="docutils literal">#define</tt> the macro
+<a class="reference external"
+href="reference.html#boost-parameter-can-use-mp11"><tt
+class="docutils literal">BOOST_PARAMETER_CAN_USE_MP11</tt></a> unless you
+disable it manually.  The <a class="reference external"
+href="../../test/singular.cpp">test/singular.cpp</a>, <a
+class="reference external" href="../../test/compose.cpp">test/compose.cpp</a>,
+<a class="reference external" href="../../test/optional_deduced_sfinae.cpp"
+>test/optional_deduced_sfinae.cpp</a>, and <a class="reference external"
+href="../../test/deduced_dependent_predicate.cpp"
+>test/deduced_dependent_predicate.cpp</a> test programs demonstrate support
+for <a class="reference external" href="../../../mp11/doc/html/mp11.html"
+>Boost.MP11</a>.</p>
+</div>
 <div class="section" id="no-sfinae-support">
-<h2><a class="toc-backref" href="#id42">5.2&nbsp;&nbsp;&nbsp;No SFINAE
+<h2><a class="toc-backref" href="#id42">5.3&nbsp;&nbsp;&nbsp;No SFINAE
 Support</a></h2>
 <p>Some older compilers don't support SFINAE.  If your compiler meets
 that criterion, then Boost headers will
@@ -2655,7 +2675,7 @@ functions won't be removed from the overload set based on their
 signatures.</p>
 </div>
 <div class="section" id="no-support-for-result-of">
-<h2><a class="toc-backref" href="#id43">5.3&nbsp;&nbsp;&nbsp;No Support
+<h2><a class="toc-backref" href="#id43">5.4&nbsp;&nbsp;&nbsp;No Support
 for</a> <a class="reference external"
 href="../../../utility/utility.htm#result_of"
 ><tt class="docutils literal">result_of</tt></a></h2>
@@ -2703,7 +2723,7 @@ are unspecified, the workaround is to use
 .. |BOOST_PARAMETER_MATCH| replace:: ``BOOST_PARAMETER_MATCH`` -->
 </div>
 <div class="section" id="compiler-can-t-see-references-in-unnamed-namespace">
-<h2><a class="toc-backref" href="#id44">5.4&nbsp;&nbsp;&nbsp;Compiler Can't
+<h2><a class="toc-backref" href="#id44">5.5&nbsp;&nbsp;&nbsp;Compiler Can't
 See References In Unnamed Namespace</a></h2>
 <p>If you use Microsoft Visual C++ 6.x, you may find that the compiler has
 trouble finding your keyword objects.  This problem has been observed, but

--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -106,9 +106,15 @@ src="../../../../boost.png" /></a></p>
 <li><a class="reference internal" href="#are-tagged-arguments" id="id49"
 >5.4&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >are_tagged_arguments</tt></a></li>
-<li><a class="reference internal" href="#is-argument-pack" id="id51"
+<li><a class="reference internal" href="#are-tagged-arguments-mp11" id="id49"
 >5.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>are_tagged_arguments_mp11</tt></a></li>
+<li><a class="reference internal" href="#is-argument-pack" id="id51"
+>5.6&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >is_argument_pack</tt></a></li>
+<li><a class="reference internal" href="#is-argument-pack-mp11" id="id52"
+>5.7&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>is_argument_pack_mp11</tt></a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#function-templates" id="id53"
@@ -400,7 +406,12 @@ href="../../../mpl/doc/refmanual/associative-sequence.html"><span
 class="concept">MPL Associative Sequence</span></a> consisting of the <a
 class="reference internal" href="#keyword-tag-type">keyword tag type</a>s in
 its <a class="reference internal" href="#tagged-reference">tagged
-reference</a>s.  The <a class="reference external"
+reference</a>s.  If <a class="reference internal"
+href="#boost-parameter-can-use-mp11"><tt class="docutils literal"
+>BOOST_PARAMETER_CAN_USE_MP11</tt></a> is defined, then every <span
+class="concept">ArgumentPack</span> is also a valid <a
+class="reference external" href="../../../mp11/doc/html/mp11.html"
+>Boost.MP11</a> list.  The <a class="reference external"
 href="../../test/singular.cpp">test/singular.cpp</a>, <a
 class="reference external" href="../../test/compose.cpp"
 >test/compose.cpp</a>, and <a class="reference external"
@@ -1729,8 +1740,91 @@ href="../../../core/doc/html/core/enable_if.html">disable_if</a>&lt;
 </tbody>
 </table>
 </div>
+<div class="section" id="are-tagged-arguments-mp11">
+<h2><a class="toc-backref" href="#id50">5.5&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">are_tagged_arguments_mp11</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/are_tagged_arguments.hpp"
+>boost/parameter/are_tagged_arguments.hpp</a> if <a class="reference internal"
+href="#boost-parameter-can-use-mp11"><tt class="docutils literal"
+>BOOST_PARAMETER_CAN_USE_MP11</tt></a> is defined</td>
+</tr>
+</tbody>
+</table>
+<pre class="literal-block">
+template &lt;typename T0, typename ...Pack&gt;
+struct are_tagged_arguments_mp11  // : mp11::mp_true or mp11::mp_false
+{
+};
+</pre>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Returns:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body"><tt class="docutils literal">mp11::mp_true</tt> if <tt
+class="docutils literal">T0</tt> and all elements in parameter pack <tt
+class="docutils literal">Pack</tt> are <a class="reference internal"
+href="#tagged-reference">tagged reference</a> types, <tt
+class="docutils literal">mp11::mp_false</tt> otherwise.</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">When implementing a Boost.Parameter-enabled constructor for a
+container that conforms to the C++ standard, one needs to remember that the
+standard requires the presence of other constructors that are typically
+defined as templates, such as range constructors.  To avoid overload
+ambiguities between the two constructors, use this metafunction in conjunction
+with <tt class="docutils literal">disable_if</tt> to define the range
+constructor.</p>
+<pre class="first literal-block">
+template &lt;typename B&gt;
+class frontend : public B
+{
+    struct _enabler
+    {
+    };
+
+ public:
+    <a class="reference internal"
+href="#boost-parameter-no-spec-constructor-cls-impl"
+>BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR</a>(frontend, (B))
+
+    template &lt;typename Iterator&gt;
+    frontend(
+        Iterator itr
+      , Iterator itr_end
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>&lt;
+            are_tagged_arguments_mp11&lt;Iterator&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : B(itr, itr_end)
+    {
+    }
+};
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
 <div class="section" id="is-argument-pack">
-<h2><a class="toc-backref" href="#id51">5.5&nbsp;&nbsp;&nbsp;<tt
+<h2><a class="toc-backref" href="#id51">5.6&nbsp;&nbsp;&nbsp;<tt
 class="docutils literal">is_argument_pack</tt></a></h2>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -1808,6 +1902,105 @@ href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
 href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
             boost::<a class="reference external"
 href="../../../type_traits/doc/html/boost_typetraits/is_convertible.html"
+>is_convertible</a>&lt;U,T&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : a0(copy.get_a0())
+    {
+    }
+
+    T const&amp; get_a0() const
+    {
+        return this-&gt;a0;
+    }
+};
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="section" id="is-argument-pack-mp11">
+<h2><a class="toc-backref" href="#id52">5.7&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">is_argument_pack_mp11</tt></a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/is_argument_pack.hpp"
+>boost/parameter/is_argument_pack.hpp</a> if <a class="reference internal"
+href="#boost-parameter-can-use-mp11"><tt class="docutils literal"
+>BOOST_PARAMETER_CAN_USE_MP11</tt></a> is defined</td>
+</tr>
+</tbody>
+</table>
+<pre class="literal-block">
+template &lt;typename T&gt;
+struct is_argument_pack_mp11  // : mp11::mp_true or mp11::mp_false
+{
+};
+</pre>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Returns:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body"><tt class="docutils literal">mp11::mp_true</tt> if <tt
+class="docutils literal">T</tt> is a model of <a class="reference internal"
+href="#argumentpack"><span class="concept">ArgumentPack</span></a>, <tt
+class="docutils literal">mp11::mp_false</tt> otherwise.</td>
+</tr>
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p class="first">To avoid overload ambiguities between a constructor that
+takes in an <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a> and a templated conversion
+constructor, use this metafunction in conjunction with <tt
+class="docutils literal">enable_if</tt>.</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(a0)
+
+template &lt;typename T&gt;
+class backend0
+{
+    struct _enabler
+    {
+    };
+
+    T a0;
+
+ public:
+    template &lt;typename ArgPack&gt;
+    explicit backend0(
+        ArgPack const&amp; args
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            is_argument_pack_mp11&lt;ArgPack&gt;
+          , _enabler
+        &gt;::type = _enabler()
+    ) : a0(args[_a0])
+    {
+    }
+
+    template &lt;typename U&gt;
+    backend0(
+        backend0&lt;U&gt; const&amp; copy
+      , typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+            std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/is_convertible"
 >is_convertible</a>&lt;U,T&gt;
           , _enabler
         &gt;::type = _enabler()
@@ -8700,6 +8893,21 @@ namespace <em>namespace-name</em> {
         typedef <em>unspecified</em> _;
         typedef <em>unspecified</em> _1;
         typedef boost::parameter::<em>qualifier</em> ## _reference qualifier;
+
+        // The following definitions are available only when
+        // <a class="reference internal" href="#boost-parameter-can-use-mp11"
+>BOOST_PARAMETER_CAN_USE_MP11</a> is defined.
+
+        template &lt;typename ArgumentPack&gt;
+        using binding_fn = typename <a class="reference internal"
+href="#binding">binding</a>&lt;
+            ArgumentPack
+          , <em>tag-name</em>
+        &gt;::type;
+
+        template &lt;typename ArgumentPack&gt;
+        using fn = typename <a class="reference internal" href="#value-type"
+>value_type</a>&lt;ArgumentPack, <em>tag-name</em>&gt;::type;
     };
 }
 
@@ -8752,6 +8960,21 @@ namespace tag {
         typedef <em>unspecified</em> _;
         typedef <em>unspecified</em> _1;
         typedef boost::parameter::<em>qualifier</em> ## _reference qualifier;
+
+        // The following definitions are available only when
+        // <a class="reference internal" href="#boost-parameter-can-use-mp11"
+>BOOST_PARAMETER_CAN_USE_MP11</a> is defined.
+
+        template &lt;typename ArgumentPack&gt;
+        using binding_fn = typename <a class="reference internal"
+href="#binding">binding</a>&lt;
+            ArgumentPack
+          , <em>tag-name</em>
+        &gt;::type;
+
+        template &lt;typename ArgumentPack&gt;
+        using fn = typename <a class="reference internal" href="#value-type"
+>value_type</a>&lt;ArgumentPack, <em>tag-name</em>&gt;::type;
     };
 }
 
@@ -8821,6 +9044,21 @@ namespace tag {
         typedef boost::parameter::<em>qualifier</em> ## _reference qualifier;
         static <a class="reference internal" href="#keyword"
 >keyword</a>&lt;<em>tag-name</em>&gt; const& <em>alias</em>;
+
+        // The following definitions are available only when
+        // <a class="reference internal" href="#boost-parameter-can-use-mp11"
+>BOOST_PARAMETER_CAN_USE_MP11</a> is defined.
+
+        template &lt;typename ArgumentPack&gt;
+        using binding_fn = typename <a class="reference internal"
+href="#binding">binding</a>&lt;
+            ArgumentPack
+          , <em>tag-name</em>
+        &gt;::type;
+
+        template &lt;typename ArgumentPack&gt;
+        using fn = typename <a class="reference internal" href="#value-type"
+>value_type</a>&lt;ArgumentPack, <em>tag-name</em>&gt;::type;
     };
 
     <a class="reference internal" href="#keyword">keyword</a>&lt;<em
@@ -9070,6 +9308,21 @@ namespace <strong>n</strong> {
         typedef <em>unspecified</em> _;
         typedef <em>unspecified</em> _1;
         typedef boost::parameter::forward_reference qualifier;
+
+        // The following definitions are available only when
+        // <a class="reference internal" href="#boost-parameter-can-use-mp11"
+>BOOST_PARAMETER_CAN_USE_MP11</a> is defined.
+
+        template &lt;typename ArgumentPack&gt;
+        using binding_fn = typename <a class="reference internal"
+href="#binding">binding</a>&lt;
+            ArgumentPack
+          , <em>k</em>
+        &gt;::type;
+
+        template &lt;typename ArgumentPack&gt;
+        using fn = typename <a class="reference internal" href="#value-type"
+>value_type</a>&lt;ArgumentPack, <em>k</em>&gt;::type;
     };
 }
 
@@ -9189,7 +9442,12 @@ class="docutils literal">BOOST_PARAMETER_CAN_USE_MP11</tt></a> undefined.</p>
 class="docutils literal">BOOST_PARAMETER_CAN_USE_MP11</tt></a></h2>
 <p>Determines whether or not the library can use <a class="reference external"
 href="../../../mp11/doc/html/mp11.html">Boost.MP11</a>, a C++11
-metaprogramming library.  Users can manually disable
+metaprogramming library, and therefore determines whether or not the library
+defines the <a class="reference internal"
+href="#boost-parameter-are-tagged-arguments-mp11"><tt class="docutils literal"
+>are_tagged_arguments_mp11</tt></a> and <a class="reference internal"
+href="#boost-parameter-is-argument-pack-mp11"><tt class="docutils literal"
+>is_argument_pack_mp11</tt></a> metafunctions.  Users can manually disable
 this macro by <tt class="docutils literal">#defining</tt> the <a
 class="reference internal" href="#boost-parameter-disable-mp11-usage"><tt
 class="docutils literal">BOOST_PARAMETER_DISABLE_MP11_USAGE</tt></a> macro or
@@ -9226,6 +9484,16 @@ href="../../../config/doc/html/boost_config/boost_macro_reference.html"
 ><tt class="docutils literal">BOOST_NO_CXX11_HDR_TUPLE</tt></a> are not
 already defined by <a class="reference external"
 href="../../../config/doc/html/index.html">Boost.Config</a>.</p>
+<div class="admonition-syntax-note admonition">
+<p class="first admonition-title">Usage Note</p>
+<p class="last"><a class="reference external"
+href="../../../mp11/doc/html/mp11.html">Boost.MP11</a> and <a
+class="reference external" href="../../../mpl/doc/index.html">Boost.MPL</a>
+are <strong>not</strong> mutually exclusive.  It's perfectly acceptable to
+specify deduced parameters using both quoted metafunctions and metafunction
+classes, for example.  See <a class="reference external"
+href="../../test/evaluate_category.cpp">test/evaluate_category.cpp</a>.</p>
+</div>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -9235,6 +9503,265 @@ href="../../../config/doc/html/index.html">Boost.Config</a>.</p>
 <td class="field-body"><a class="reference external"
 href="../../../../boost/parameter/config.hpp"
 >boost/parameter/config.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name" colspan="2">Example usage:</th>
+</tr>
+<tr>
+<td>&nbsp;</td>
+<td class="field-body">
+<p>Given the following definitions:</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(x)
+
+template &lt;typename A0&gt;
+typename boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>&lt;std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/is_same"
+>is_same</a>&lt;int,A0&gt;,int&gt;::type
+    sfinae(A0 const&amp; a0)
+{
+    return 0;
+}
+</pre>
+<p><a class="reference external" href="../../../mp11/doc/html/mp11.html"
+>Boost.MP11</a> allows deduced parameters to be defined more succinctly:</p>
+<pre class="first literal-block">
+template &lt;typename T, typename Args&gt;
+using predicate = std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/is_convertible"
+>is_convertible</a>&lt;T,char const*&gt;;
+
+<a class="reference internal"
+href="#boost-parameter-function-result-name-tag-namespace-arguments"
+>BOOST_PARAMETER_FUNCTION</a>((int), sfinae, tag,
+    (deduced
+        (optional
+            (x
+              , *(boost::mp11::mp_quote&lt;predicate&gt;)
+              , static_cast&lt;char const*&gt;(std::<a
+class="reference external" href=
+"http://en.cppreference.com/w/cpp/language/nullptr">nullptr</a>)
+            )
+        )
+    )
+)
+{
+    return 1;
+}
+</pre>
+<p>Without <a class="reference external"
+href="../../../mp11/doc/html/mp11.html">Boost.MP11</a>, deduced parameter
+definitions tend to be more verbose:</p>
+<pre class="first literal-block">
+struct predicate
+{
+    template &lt;typename T, typename Args&gt;
+    struct apply
+      : boost::mpl::if_&lt;
+            boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/is_convertible.html"
+>is_convertible</a>&lt;T,char const*&gt;
+          , boost::mpl::true_
+          , boost::mpl::false_
+        &gt;
+    {
+    };
+};
+
+<a class="reference internal"
+href="#boost-parameter-function-result-name-tag-namespace-arguments"
+>BOOST_PARAMETER_FUNCTION</a>((int), sfinae, tag,
+    (deduced
+        (optional
+            (x
+              , *(predicate)
+              , static_cast&lt;char const*&gt;(std::<a
+class="reference external" href=
+"http://en.cppreference.com/w/cpp/language/nullptr">nullptr</a>)
+            )
+        )
+    )
+)
+</pre>
+<p>Either way, the following assertions will succeed:</p>
+<pre class="first literal-block">
+assert(1 == sfinae());
+assert(1 == sfinae(&quot;foo&quot;));
+assert(0 == sfinae(1));
+</pre>
+<p>As another example, given the following declarations and definitions:</p>
+<pre class="first literal-block">
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(x)
+<a class="reference internal" href="#boost-parameter-name-name"
+>BOOST_PARAMETER_NAME</a>(y)
+
+template &lt;typename E, typename Args&gt;
+void check0(E const&amp; e, Args const&amp; args);
+
+template &lt;typename P, typename E, typename Args&gt;
+void check(E const&amp; e, Args const&amp;... args)
+{
+    check0(e, P()(args...));
+}
+</pre>
+<p>Argument packs qualify as <a class="reference external"
+href="../../../mp11/doc/html/mp11.html">Boost.MP11</a>-style lists containing
+<a class="reference internal" href="#keyword-tag-type">keyword tag
+type</a>s:</p>
+<pre class="first literal-block">
+template &lt;typename Args&gt;
+struct some_functor
+{
+    template &lt;typename K&gt;
+    void operator()(K&amp;&amp;) const
+    {
+        // K is one of tag::x, tag::y, etc.
+    }
+};
+
+template &lt;typename E, typename Args&gt;
+void check0(E const&amp; e, Args const&amp; args)
+{
+    boost::mp11::mp_for_each&lt;E&gt;(some_functor&lt;Args&gt;());
+}
+</pre>
+<p>The first check determines whether or not the argument type of <tt
+class="docutils literal">_y</tt> is the same as the reference type of <tt
+class="docutils literal">_x</tt>, while the second check determines whether
+or not the argument type of <tt class="docutils literal">_y</tt> is
+convertible to the value type of <tt class="docutils literal">_x</tt>.  Here,
+it's possible to access the reference and value result types of indexing an
+argument pack a little more directly:</p>
+<pre class="first literal-block">
+// Use mp_bind on tag::x::binding_fn to access the reference type of _x.
+// Here, boost::mp11::_1 will be bound to the argument type of _y.
+// Regardless, boost::mp11::_2 will be bound to the argument pack type.
+check&lt;
+    <a class="reference internal" href="#parameters">parameters</a>&lt;
+        tag::x
+      , <a class="reference internal" href="#optional-required"
+>optional</a>&lt;
+            <a class="reference internal" href="#deduced"
+>deduced</a>&lt;tag::y&gt;
+          , boost::mp11::mp_bind&lt;
+                std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/is_same"
+>is_same</a>
+              , boost::mp11::_1
+              , boost::mp11::mp_bind&lt;
+                    tag::x::binding_fn
+                  , boost::mp11::_2
+                &gt;
+            &gt;
+        &gt;
+    &gt;
+&gt;((_x = 0, _y = 1), 0, 1);
+
+// Use mp_bind_q on tag::x to access the value type of _x.
+check&lt;
+    <a class="reference internal" href="#parameters">parameters</a>&lt;
+        tag::x
+      , <a class="reference internal" href="#optional-required"
+>optional</a>&lt;
+            <a class="reference internal" href="#deduced"
+>deduced</a>&lt;tag::y&gt;
+          , boost::mp11::mp_bind&lt;
+                std::<a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/is_convertible"
+>is_convertible</a>
+              , boost::mp11::_1
+              , boost::mp11::mp_bind_q&lt;tag::x,boost::mp11::_2&gt;
+            &gt;
+        &gt;
+    &gt;
+&gt;((_x = 0U, _y = 1U), 0U, 1U);
+</pre>
+<p>Argument packs still qualify as <a class="reference external"
+href="../../../mpl/doc/index.html">Boost.MPL</a>-style lists containing <a
+class="reference internal" href="#keyword-tag-type">keyword tag type</a>s:</p>
+<pre class="first literal-block">
+template &lt;typename Args&gt;
+struct some_functor
+{
+    template &lt;typename K&gt;
+    void operator()(K) const
+    {
+        // K is one of tag::x, tag::y, etc.
+    }
+};
+
+template &lt;typename E, typename Args&gt;
+void check0(E const&amp; e, Args const&amp; args)
+{
+    boost::mpl::for_each&lt;E&gt;(some_functor&lt;Args&gt;());
+}
+</pre>
+<p>However, without <a class="reference external"
+href="../../../mp11/doc/html/mp11.html">Boost.MP11</a>, the corresponding
+checks become a little more verbose:</p>
+<pre class="last literal-block">
+check&lt;
+    <a class="reference internal" href="#parameters">parameters</a>&lt;
+        tag::x
+      , <a class="reference internal" href="#optional-required"
+>optional</a>&lt;
+            <a class="reference internal" href="#deduced"
+>deduced</a>&lt;tag::y&gt;
+          , boost::mpl::if_&lt;
+                boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/is_same.html"
+>is_same</a>&lt;
+                    boost::<a class="reference external" href=
+"../../../type_traits/doc/html/boost_typetraits/add_lvalue_reference.html"
+>add_lvalue_reference</a>&lt;boost::mpl::_1&gt;
+                  , <a class="reference internal" href="#binding"
+>binding</a>&lt;boost::mpl::_2,tag::x&gt;
+                &gt;
+              , boost::mpl::true_
+              , boost::mpl::false_
+            &gt;
+        &gt;
+    &gt;
+&gt;((_x = 0, _y = 1), 0, 1);
+
+// Use tag::x::_ or tag::x::_1 to access the value type of _x.
+check&lt;
+    <a class="reference internal" href="#parameters">parameters</a>&lt;
+        tag::x
+      , <a class="reference internal" href="#optional-required"
+>optional</a>&lt;
+            <a class="reference internal" href="#deduced"
+>deduced</a>&lt;tag::y&gt;
+          , boost::mpl::if_&lt;
+                boost::<a class="reference external"
+href="../../../type_traits/doc/html/boost_typetraits/is_convertible.html"
+>is_convertible</a>&lt;boost::mpl::_1,tag::x::_1&gt;
+              , boost::mpl::true_
+              , boost::mpl::false_
+            &gt;
+        &gt;
+    &gt;
+&gt;((_x = 0U, _y = 1U), 0U, 1U);
+</pre>
+<p>The <a class="reference external" href="../../test/singular.cpp"
+>test/singular.cpp</a>, <a class="reference external"
+href="../../test/compose.cpp" >test/compose.cpp</a>, <a
+class="reference external" href="../../test/optional_deduced_sfinae.cpp"
+>test/optional_deduced_sfinae.cpp</a>, and <a class="reference external"
+href="../../test/deduced_dependent_predicate.cpp"
+>test/deduced_dependent_predicate.cpp</a> test programs demonstrate proper
+usage of this macro.</p>
+</td>
 </tr>
 </tbody>
 </table>
@@ -9248,7 +9775,12 @@ cannot support it.  Users can <tt class="docutils literal">#define</tt> this
 macro either in their project settings or before including any library header
 files.  Doing so will leave <a class="reference internal"
 href="#boost-parameter-can-use-mp11"><tt class="docutils literal"
->BOOST_PARAMETER_CAN_USE_MP11</tt></a> undefined.</p>
+>BOOST_PARAMETER_CAN_USE_MP11</tt></a> undefined and the <a
+class="reference internal" href="#boost-parameter-are-tagged-arguments-mp11"
+><tt class="docutils literal">are_tagged_arguments_mp11</tt></a> and <a
+class="reference internal" href="#boost-parameter-is-argument-pack-mp11"><tt
+class="docutils literal">is_argument_pack_mp11</tt></a> metafunctions
+unavailable.</p>
 </div>
 <div class="section" id="boost-parameter-variadic-mpl-sequence">
 <h2><a class="toc-backref" href="#id85">8.5&nbsp;&nbsp;&nbsp;<tt

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2613,6 +2613,26 @@ be bound to out parameters.  The |evaluate_category|_ and
 .. |preprocessor_eval_category| replace:: preprocessor_eval_category.cpp
 .. _preprocessor_eval_category: ../../test/preprocessor_eval_category.cpp
 
+------------------
+Boost.MP11 Support
+------------------
+
+If your compiler is sufficiently compliant with the C++11 standard, then the
+Parameter library will ``#define`` the macro ``BOOST_PARAMETER_CAN_USE_MP11``
+unless you disable it manually.  The |singular_cpp|_, |compose_cpp|_,
+|optional_deduced_sfinae_cpp|_, and |deduced_dep_pred_cpp|_ test programs
+demonstrate support for `Boost.MP11`_.
+
+.. _`Boost.MP11`: ../../../mp11/doc/html/mp11.html
+.. |singular_cpp| replace:: singular.cpp
+.. _singular_cpp: ../../test/singular.cpp
+.. |compose_cpp| replace:: compose.cpp
+.. _compose_cpp: ../../test/compose.cpp
+.. |optional_deduced_sfinae_cpp| replace:: optional_deduced_sfinae.cpp
+.. _optional_deduced_sfinae_cpp: ../../test/optional_deduced_sfinae.cpp
+.. |deduced_dep_pred_cpp| replace:: deduced_dependent_predicate.cpp
+.. _deduced_dep_pred_cpp: ../../test/deduced_dependent_predicate.cpp
+
 -----------------
 No SFINAE Support
 -----------------

--- a/include/boost/parameter/are_tagged_arguments.hpp
+++ b/include/boost/parameter/are_tagged_arguments.hpp
@@ -43,6 +43,20 @@ namespace boost { namespace parameter {
     };
 }} // namespace boost::parameter
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+
+namespace boost { namespace parameter {
+
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    using are_tagged_arguments_mp11 = ::boost::mp11::mp_bool<
+        ::boost::parameter
+        ::are_tagged_arguments<TaggedArg0,TaggedArgs...>::value
+    >;
+}} // namespace boost::parameter
+
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
+
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 
 #define BOOST_PARAMETER_ARE_TAGGED_ARGUMENTS_END_Z(z, n, false_t) , false_t>

--- a/include/boost/parameter/aux_/always_true_predicate.hpp
+++ b/include/boost/parameter/aux_/always_true_predicate.hpp
@@ -1,0 +1,42 @@
+// Copyright Cromwell D. Enage 2019.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_AUX_ALWAYS_TRUE_PREDICATE_HPP
+#define BOOST_PARAMETER_AUX_ALWAYS_TRUE_PREDICATE_HPP
+
+#include <boost/parameter/config.hpp>
+#include <boost/mpl/bool.hpp>
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#endif
+#else
+#include <boost/mpl/always.hpp>
+#endif
+
+namespace boost { namespace parameter { namespace aux {
+
+#if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+    struct always_true_predicate
+    {
+        template <typename ...>
+        struct apply
+        {
+            typedef ::boost::mpl::true_ type;
+        };
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        template <typename ...>
+        using fn = ::boost::mp11::mp_true;
+#endif
+    };
+#else
+    typedef ::boost::mpl::always< ::boost::mpl::true_> always_true_predicate;
+#endif  // BOOST_NO_CXX11_VARIADIC_TEMPLATES
+}}} // namespace boost::parameter::aux
+
+#endif  // include guard
+

--- a/include/boost/parameter/aux_/augment_predicate.hpp
+++ b/include/boost/parameter/aux_/augment_predicate.hpp
@@ -7,7 +7,6 @@
 #define BOOST_PARAMETER_AUGMENT_PREDICATE_HPP
 
 #include <boost/parameter/keyword_fwd.hpp>
-#include <boost/parameter/config.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/eval_if.hpp>
@@ -71,31 +70,129 @@ namespace boost { namespace parameter { namespace aux {
 
 namespace boost { namespace parameter { namespace aux {
 
-    template <typename Predicate, typename R, typename Tag>
-    struct augment_predicate
+    template <
+        typename Predicate
+      , typename R
+      , typename Tag
+      , typename T
+      , typename Args
+    >
+    class augment_predicate
     {
         typedef typename ::boost::mpl::lambda<
             Predicate
           , ::boost::parameter::aux::lambda_tag
-        >::type actual_predicate;
+        >::type _actual_predicate;
 
-        template <typename T, typename Args>
-        struct apply
-        {
-            typedef typename ::boost::mpl::eval_if<
-                typename ::boost::mpl::if_<
-                    ::boost::parameter::aux
-                    ::augment_predicate_check_consume_ref<T,R,Tag>
-                  , ::boost::parameter::aux
-                    ::augment_predicate_check_out_ref<T,R,Tag>
-                  , ::boost::mpl::false_
-                >::type
-              , ::boost::mpl::apply_wrap2<actual_predicate,T,Args>
+     public:
+        typedef typename ::boost::mpl::eval_if<
+            typename ::boost::mpl::if_<
+                ::boost::parameter::aux
+                ::augment_predicate_check_consume_ref<T,R,Tag>
+              , ::boost::parameter::aux
+                ::augment_predicate_check_out_ref<T,R,Tag>
               , ::boost::mpl::false_
-            >::type type;
-        };
+            >::type
+          , ::boost::mpl::apply_wrap2<_actual_predicate,T,Args>
+          , ::boost::mpl::false_
+        >::type type;
     };
 }}} // namespace boost::parameter::aux
 
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename V, typename R, typename Tag>
+    using augment_predicate_check_consume_ref_mp11 = ::boost::mp11::mp_if<
+        ::std::is_scalar<V>
+      , ::boost::mp11::mp_true
+      , ::boost::mp11::mp_if<
+            ::std::is_same<
+                typename Tag::qualifier
+              , ::boost::parameter::consume_reference
+            >
+          , ::boost::mp11::mp_if<
+                ::std::is_lvalue_reference<R>
+              , ::boost::mp11::mp_false
+              , ::boost::mp11::mp_true
+            >
+          , boost::mp11::mp_true
+        >
+    >;
+
+    template <typename V, typename R, typename Tag>
+    using augment_predicate_check_out_ref_mp11 = ::boost::mp11::mp_if<
+        ::std::is_same<
+            typename Tag::qualifier
+          , ::boost::parameter::out_reference
+        >
+      , ::boost::mp11::mp_if<
+            ::std::is_lvalue_reference<R>
+          , ::boost::mp11::mp_if<
+                ::std::is_const<V>
+              , ::boost::mp11::mp_false
+              , ::boost::mp11::mp_true
+            >
+          , ::boost::mp11::mp_false
+        >
+      , ::boost::mp11::mp_true
+    >;
+}}} // namespace boost::parameter::aux
+
+#include <boost/mp11/list.hpp>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <
+        typename Predicate
+      , typename R
+      , typename Tag
+      , typename T
+      , typename Args
+    >
+    struct augment_predicate_mp11_impl
+    {
+        using type = ::boost::mp11::mp_if<
+            ::boost::mp11::mp_if<
+                ::boost::parameter::aux
+                ::augment_predicate_check_consume_ref_mp11<T,R,Tag>
+              , ::boost::parameter::aux
+                ::augment_predicate_check_out_ref_mp11<T,R,Tag>
+              , ::boost::mp11::mp_false
+            >
+          , ::boost::mp11
+            ::mp_apply_q<Predicate,::boost::mp11::mp_list<T,Args> >
+          , ::boost::mp11::mp_false
+        >;
+    };
+}}} // namespace boost::parameter::aux
+
+#include <boost/parameter/aux_/has_nested_template_fn.hpp>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <
+        typename Predicate
+      , typename R
+      , typename Tag
+      , typename T
+      , typename Args
+    >
+    using augment_predicate_mp11 = ::boost::mp11::mp_if<
+        ::boost::parameter::aux::has_nested_template_fn<Predicate>
+      , ::boost::parameter::aux
+        ::augment_predicate_mp11_impl<Predicate,R,Tag,T,Args>
+      , ::boost::parameter::aux
+        ::augment_predicate<Predicate,R,Tag,T,Args>
+    >;
+}}} // namespace boost::parameter::aux
+
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 #endif  // include guard
 

--- a/include/boost/parameter/aux_/has_nested_template_fn.hpp
+++ b/include/boost/parameter/aux_/has_nested_template_fn.hpp
@@ -1,0 +1,111 @@
+// Copyright Cromwell D. Enage 2019.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_AUX_HAS_NESTED_TEMPLATE_FN_HPP
+#define BOOST_PARAMETER_AUX_HAS_NESTED_TEMPLATE_FN_HPP
+
+#include <boost/parameter/aux_/yesno.hpp>
+#include <boost/parameter/config.hpp>
+#include <boost/tti/detail/dnullptr.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/utility.hpp>
+#else
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/identity.hpp>
+#endif
+
+namespace boost { namespace parameter { namespace aux {
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    template <template <typename ...> class F>
+    struct has_nested_template_fn_variadic
+    {
+    };
+#else
+    template <template <typename P0, typename P1> class F>
+    struct has_nested_template_fn_arity_2
+    {
+    };
+#endif
+
+    template <typename T>
+    class has_nested_template_fn_impl
+    {
+        template <typename U>
+        static BOOST_CONSTEXPR ::boost::parameter::aux::no_tag _check(...);
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        template <typename U>
+        static BOOST_CONSTEXPR ::boost::parameter::aux::yes_tag
+            _check(
+                ::boost::mp11::mp_identity<U> const volatile*
+              , ::boost::parameter::aux::has_nested_template_fn_variadic<
+                    U::template fn
+                >* = BOOST_TTI_DETAIL_NULLPTR
+            );
+#else
+        template <typename U>
+        static BOOST_CONSTEXPR ::boost::parameter::aux::yes_tag
+            _check(
+                ::boost::mpl::identity<U> const volatile*
+              , ::boost::parameter::aux::has_nested_template_fn_arity_2<
+                    U::template fn
+                >* = BOOST_TTI_DETAIL_NULLPTR
+            );
+#endif
+
+     public:
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_bool<
+#else
+        typedef ::boost::mpl::bool_<
+#endif
+            sizeof(
+                ::boost::parameter::aux::has_nested_template_fn_impl<T>
+                ::template _check<T>(
+                    static_cast<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+                        ::boost::mp11::mp_identity<T> const volatile*
+#else
+                        ::boost::mpl::identity<T> const volatile*
+#endif
+                    >(BOOST_TTI_DETAIL_NULLPTR)
+                )
+            ) == sizeof(::boost::parameter::aux::yes_tag)
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        >;
+#else
+        > type;
+#endif
+    };
+}}} // namespace boost::parameter::aux
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
+#include <boost/type_traits/remove_const.hpp>
+#endif
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename T>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using has_nested_template_fn = typename ::boost::parameter::aux
+    ::has_nested_template_fn_impl<typename ::std::remove_const<T>::type>
+    ::type;
+#else
+    struct has_nested_template_fn
+      : ::boost::parameter::aux::has_nested_template_fn_impl<
+            typename ::boost::remove_const<T>::type
+        >::type
+    {
+    };
+#endif
+}}} // namespace boost::parameter::aux
+
+#endif  // include guard
+

--- a/include/boost/parameter/aux_/is_maybe.hpp
+++ b/include/boost/parameter/aux_/is_maybe.hpp
@@ -13,6 +13,19 @@ namespace boost { namespace parameter { namespace aux {
     };
 }}} // namespace boost::parameter::aux
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename T>
+    using is_maybe = ::std::is_base_of<
+        ::boost::parameter::aux::maybe_base
+      , typename ::std::remove_const<T>::type
+    >;
+}}} // namespace boost::parameter::aux
+
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_base_of.hpp>
@@ -34,5 +47,6 @@ namespace boost { namespace parameter { namespace aux {
     };
 }}} // namespace boost::parameter::aux
 
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 #endif  // include guard
 

--- a/include/boost/parameter/aux_/is_placeholder.hpp
+++ b/include/boost/parameter/aux_/is_placeholder.hpp
@@ -1,0 +1,64 @@
+// Copyright Cromwell D. Enage 2019.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_AUX_IS_PLACEHOLDER_HPP
+#define BOOST_PARAMETER_AUX_IS_PLACEHOLDER_HPP
+
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#else
+#include <boost/mpl/bool.hpp>
+#endif
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename T>
+    struct is_mpl_placeholder
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_false
+#else
+      : ::boost::mpl::false_
+#endif
+    {
+    };
+}}} // namespace boost::parameter::aux
+
+#include <boost/mpl/arg_fwd.hpp>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <int I>
+    struct is_mpl_placeholder< ::boost::mpl::arg<I> >
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_true
+#else
+      : ::boost::mpl::true_
+#endif
+    {
+    };
+}}} // namespace boost::parameter::aux
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/bind.hpp>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename T>
+    struct is_mp11_placeholder : ::boost::mp11::mp_false
+    {
+    };
+
+    template < ::std::size_t I>
+    struct is_mp11_placeholder< ::boost::mp11::mp_arg<I> >
+      : ::boost::mp11::mp_true
+    {
+    };
+}}} // namespace boost::parameter::aux
+
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
+#endif  // include guard
+

--- a/include/boost/parameter/aux_/is_tagged_argument.hpp
+++ b/include/boost/parameter/aux_/is_tagged_argument.hpp
@@ -20,7 +20,6 @@ namespace boost { namespace parameter { namespace aux {
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING) || \
     (0 < BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY)
-
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
@@ -48,7 +47,6 @@ namespace boost { namespace parameter { namespace aux {
 }}} // namespace boost::parameter::aux
 
 #else   // no perfect forwarding support and no exponential overloads
-
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/is_lvalue_reference.hpp>
 
@@ -77,5 +75,21 @@ namespace boost { namespace parameter { namespace aux {
 }}} // namespace boost::parameter::aux
 
 #endif  // perfect forwarding support, or exponential overloads
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename T>
+    using is_tagged_argument_mp11 = ::std::is_base_of<
+        ::boost::parameter::aux::tagged_argument_base
+      , typename ::std::remove_const<
+            typename ::std::remove_reference<T>::type
+        >::type
+    >;
+}}} // namespace boost::parameter::aux
+
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 #endif  // include guard
 

--- a/include/boost/parameter/aux_/maybe.hpp
+++ b/include/boost/parameter/aux_/maybe.hpp
@@ -43,28 +43,42 @@ namespace boost { namespace parameter { namespace aux {
 
 #include <boost/parameter/aux_/is_maybe.hpp>
 #include <boost/optional/optional.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/type_traits/add_lvalue_reference.hpp>
 #include <boost/type_traits/remove_cv.hpp>
-
 #if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
 #include <boost/type_traits/add_const.hpp>
 #endif
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 
 namespace boost { namespace parameter { namespace aux {
 
     template <typename T>
     struct maybe : ::boost::parameter::aux::maybe_base
     {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        typedef typename ::std::add_lvalue_reference<
+            typename ::std::add_const<T>::type
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
         typedef typename ::boost::add_lvalue_reference<
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
             T const
 #else
             typename ::boost::add_const<T>::type
 #endif
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
         >::type reference;
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        typedef typename ::std::remove_cv<
+            typename ::std::remove_reference<reference>::type
+#else
         typedef typename ::boost::remove_cv<
             BOOST_DEDUCED_TYPENAME ::boost::remove_reference<reference>::type
+#endif
         >::type non_cv_value;
 
         inline explicit maybe(T value_) : value(value_), constructed(false)

--- a/include/boost/parameter/aux_/name.hpp
+++ b/include/boost/parameter/aux_/name.hpp
@@ -35,7 +35,6 @@ namespace boost { namespace parameter { namespace aux {
 
 #if !defined(BOOST_NO_SFINAE) && \
     !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
-
 #include <boost/parameter/aux_/lambda_tag.hpp>
 #include <boost/mpl/lambda.hpp>
 #include <boost/mpl/bind.hpp>
@@ -74,5 +73,21 @@ namespace boost { namespace mpl {
     >
 /**/
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#define BOOST_PARAMETER_TAG_MP11_PLACEHOLDER_VALUE(name, tag)                \
+    template <typename ArgumentPack>                                         \
+    using name = typename ::boost::parameter                                 \
+    ::value_type<ArgumentPack,tag,::boost::parameter::void_>::type
+/**/
+
+#include <boost/parameter/binding.hpp>
+
+#define BOOST_PARAMETER_TAG_MP11_PLACEHOLDER_BINDING(name, tag)              \
+    template <typename ArgumentPack>                                         \
+    using name = typename ::boost::parameter                                 \
+    ::binding<ArgumentPack,tag,::boost::parameter::void_>::type
+/**/
+
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 #endif  // include guard
 

--- a/include/boost/parameter/aux_/pack/deduce_tag.hpp
+++ b/include/boost/parameter/aux_/pack/deduce_tag.hpp
@@ -20,15 +20,63 @@ namespace boost { namespace parameter { namespace aux {
 }}} // namespace boost::parameter::aux
 
 #include <boost/parameter/aux_/lambda_tag.hpp>
-#include <boost/parameter/aux_/set.hpp>
-#include <boost/parameter/aux_/pack/tag_type.hpp>
-#include <boost/parameter/aux_/pack/tag_deduced.hpp>
+#include <boost/parameter/config.hpp>
+#include <boost/mpl/apply_wrap.hpp>
+#include <boost/mpl/lambda.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename Predicate, typename Argument, typename ArgumentPack>
+    struct deduce_tag_condition_mpl
+      : ::boost::mpl::apply_wrap2<
+            typename ::boost::mpl::lambda<
+                Predicate
+              , ::boost::parameter::aux::lambda_tag
+            >::type
+          , Argument
+          , ArgumentPack
+        >
+    {
+    };
+}}} // namespace boost::parameter::aux
+
+#include <boost/parameter/aux_/has_nested_template_fn.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/utility.hpp>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename Predicate, typename Argument, typename ArgumentPack>
+    struct deduce_tag_condition_mp11
+    {
+        using type = ::boost::mp11::mp_apply_q<
+            Predicate
+          , ::boost::mp11::mp_list<Argument,ArgumentPack>
+        >;
+    };
+
+    template <typename Predicate, typename Argument, typename ArgumentPack>
+    using deduce_tag_condition = ::boost::mp11::mp_if<
+        ::boost::parameter::aux::has_nested_template_fn<Predicate>
+      , ::boost::parameter::aux
+        ::deduce_tag_condition_mp11<Predicate,Argument,ArgumentPack>
+      , ::boost::parameter::aux
+        ::deduce_tag_condition_mpl<Predicate,Argument,ArgumentPack>
+    >;
+}}} // namespace boost::parameter::aux
+
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/eval_if.hpp>
-#include <boost/mpl/apply_wrap.hpp>
-#include <boost/mpl/lambda.hpp>
 #include <boost/mpl/assert.hpp>
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
+
+#include <boost/parameter/aux_/set.hpp>
+#include <boost/parameter/aux_/pack/tag_type.hpp>
+#include <boost/parameter/aux_/pack/tag_deduced.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -45,15 +93,21 @@ namespace boost { namespace parameter { namespace aux {
     {
         typedef typename DeducedArgs::spec _spec;
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        typedef typename ::boost::parameter::aux::deduce_tag_condition<
+            typename _spec::predicate
+#else
         typedef typename ::boost::mpl::apply_wrap2<
             typename ::boost::mpl::lambda<
                 typename _spec::predicate
               , ::boost::parameter::aux::lambda_tag
             >::type
+#endif
           , Argument
           , ArgumentPack
         >::type _condition;
 
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
         // Deduced parameter matches several arguments.
         BOOST_MPL_ASSERT((
             typename ::boost::mpl::eval_if<
@@ -73,9 +127,14 @@ namespace boost { namespace parameter { namespace aux {
               , ::boost::mpl::true_
             >::type
         ));
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 
      public:
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = typename ::boost::mp11::mp_if<
+#else
         typedef typename ::boost::mpl::eval_if<
+#endif
             _condition
           , ::boost::parameter::aux
             ::tag_deduced<UsedArgs,_spec,Argument,TagFn>
@@ -87,12 +146,22 @@ namespace boost { namespace parameter { namespace aux {
               , TagFn
               , EmitsErrors
             >
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        >::type;
+#else
         >::type type;
+#endif
     };
 }}} // namespace boost::parameter::aux
 
 #include <boost/parameter/aux_/void.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
+#include <boost/mpl/pair.hpp>
 #include <boost/type_traits/is_same.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -120,9 +189,17 @@ namespace boost { namespace parameter { namespace aux {
       , typename EmitsErrors
     >
     struct deduce_tag
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_if<
+            ::std::is_same<DeducedArgs,::boost::parameter::void_>
+          , ::boost::mp11::mp_identity<
+                ::boost::mp11::mp_list< ::boost::parameter::void_,UsedArgs>
+            >
+#else
       : ::boost::mpl::eval_if<
             ::boost::is_same<DeducedArgs,::boost::parameter::void_>
           , ::boost::mpl::pair< ::boost::parameter::void_,UsedArgs>
+#endif
           , ::boost::parameter::aux::deduce_tag0<
                 Argument
               , ArgumentPack

--- a/include/boost/parameter/aux_/pack/is_named_argument.hpp
+++ b/include/boost/parameter/aux_/pack/is_named_argument.hpp
@@ -8,12 +8,26 @@
 
 #include <boost/parameter/aux_/template_keyword.hpp>
 #include <boost/parameter/aux_/is_tagged_argument.hpp>
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/utility.hpp>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
     template <typename T>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using is_named_argument = ::boost::mp11::mp_if<
+        ::boost::parameter::aux::is_template_keyword<T>
+      , ::boost::mp11::mp_true
+      , ::boost::parameter::aux::is_tagged_argument_mp11<T>
+    >;
+#else
     struct is_named_argument
       : ::boost::mpl::if_<
             ::boost::parameter::aux::is_template_keyword<T>
@@ -22,6 +36,7 @@ namespace boost { namespace parameter { namespace aux {
         >::type
     {
     };
+#endif
 }}} // namespace boost::parameter::aux
 
 #endif  // include guard

--- a/include/boost/parameter/aux_/pack/make_deduced_items.hpp
+++ b/include/boost/parameter/aux_/pack/make_deduced_items.hpp
@@ -9,13 +9,31 @@
 #include <boost/parameter/aux_/void.hpp>
 #include <boost/parameter/aux_/pack/deduced_item.hpp>
 #include <boost/parameter/deduced.hpp>
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+#else
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/type_traits/is_same.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
     template <typename Spec, typename Tail>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using make_deduced_items = ::boost::mp11::mp_if<
+        ::std::is_same<Spec,::boost::parameter::void_>
+      , ::boost::mp11::mp_identity< ::boost::parameter::void_>
+      , ::boost::mp11::mp_if<
+            ::boost::parameter::aux::is_deduced<Spec>
+          , ::boost::parameter::aux::make_deduced_item<Spec,Tail>
+          , Tail
+        >
+    >;
+#else
     struct make_deduced_items
       : ::boost::mpl::eval_if<
             ::boost::is_same<Spec,::boost::parameter::void_>
@@ -28,6 +46,7 @@ namespace boost { namespace parameter { namespace aux {
         >
     {
     };
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }}} // namespace boost::parameter::aux
 
 #endif  // include guard

--- a/include/boost/parameter/aux_/pack/make_items.hpp
+++ b/include/boost/parameter/aux_/pack/make_items.hpp
@@ -8,14 +8,28 @@
 
 #include <boost/parameter/aux_/void.hpp>
 #include <boost/parameter/aux_/pack/item.hpp>
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+#else
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/type_traits/is_same.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
     // Creates a item typelist.
     template <typename Spec, typename Arg, typename Tail>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using make_items = ::boost::mp11::mp_if<
+        ::std::is_same<Arg,::boost::parameter::void_>
+      , ::boost::mp11::mp_identity< ::boost::parameter::void_>
+      , ::boost::parameter::aux::make_item<Spec,Arg,Tail>
+    >;
+#else
     struct make_items
       : ::boost::mpl::eval_if<
             ::boost::is_same<Arg,::boost::parameter::void_>
@@ -24,6 +38,7 @@ namespace boost { namespace parameter { namespace aux {
         >
     {
     };
+#endif
 }}} // namespace boost::parameter::aux
 
 #endif  // include guard

--- a/include/boost/parameter/aux_/pack/satisfies.hpp
+++ b/include/boost/parameter/aux_/pack/satisfies.hpp
@@ -6,9 +6,7 @@
 #ifndef BOOST_PARAMETER_AUX_PACK_SATISFIES_HPP
 #define BOOST_PARAMETER_AUX_PACK_SATISFIES_HPP
 
-#include <boost/mpl/bool.hpp>
-#include <boost/config.hpp>
-#include <boost/config/workaround.hpp>
+#include <boost/parameter/config.hpp>
 
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1310)
 #include <boost/parameter/aux_/arg_list.hpp>
@@ -17,22 +15,25 @@
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/apply_wrap.hpp>
 #include <boost/type_traits/is_same.hpp>
+#else   // !BOOST_WORKAROUND(BOOST_MSVC, == 1310)
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
 #else
+#include <boost/mpl/bool.hpp>
+#endif
 #include <boost/parameter/aux_/yesno.hpp>
 #include <boost/tti/detail/dnullptr.hpp>
-#endif
+#endif  // MSVC-7.1 workarounds needed
 
 namespace boost { namespace parameter { namespace aux {
 
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1310)
     template <typename ArgList, typename ParameterRequirements, typename Bound>
     struct satisfies_impl
-      : ::boost::mpl::apply_wrap2<
-            ::boost::parameter::aux::augment_predicate<
-                typename ParameterRequirements::predicate
-              , typename ArgList::reference
-              , typename ArgList::key_type
-            >
+      : ::boost::parameter::aux::augment_predicate<
+            typename ParameterRequirements::predicate
+          , typename ArgList::reference
+          , typename ArgList::key_type
           , Bound
           , ArgList
         >
@@ -43,7 +44,21 @@ namespace boost { namespace parameter { namespace aux {
     // Returns mpl::true_ iff the given ParameterRequirements are satisfied by
     // ArgList.
     template <typename ArgList, typename ParameterRequirements>
-    struct satisfies
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using satisfies = ::boost::mp11::mp_bool<
+        sizeof(
+            ::boost::parameter::aux::to_yesno(
+                ArgList::satisfies(
+                    static_cast<ParameterRequirements*>(
+                        BOOST_TTI_DETAIL_NULLPTR
+                    )
+                  , static_cast<ArgList*>(BOOST_TTI_DETAIL_NULLPTR)
+                )
+            )
+        ) == sizeof(::boost::parameter::aux::yes_tag)
+    >;
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
+    class satisfies
     {
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1310)
         // VC7.1 can't handle the sizeof() implementation below,
@@ -53,10 +68,11 @@ namespace boost { namespace parameter { namespace aux {
           , typename ParameterRequirements::keyword
           , ::boost::parameter::void_
           , ::boost::mpl::false_
-        >::type bound;
+        >::type _bound;
 
+     public:
         typedef typename ::boost::mpl::eval_if<
-            ::boost::is_same<bound,::boost::parameter::void_>
+            ::boost::is_same<_bound,::boost::parameter::void_>
           , typename ParameterRequirements::has_default
           , ::boost::mpl::eval_if<
                 ::boost::is_same<
@@ -67,13 +83,13 @@ namespace boost { namespace parameter { namespace aux {
               , ::boost::parameter::aux::satisfies_impl<
                     ArgList
                   , ParameterRequirements
-                  , bound
+                  , _bound
                 >
             >
         >::type type;
 #else   // !BOOST_WORKAROUND(BOOST_MSVC, == 1310)
         BOOST_STATIC_CONSTANT(
-            bool, value = (
+            bool, _value = (
                 sizeof(
                     ::boost::parameter::aux::to_yesno(
                         ArgList::satisfies(
@@ -87,17 +103,30 @@ namespace boost { namespace parameter { namespace aux {
             )
         );
 
-        typedef ::boost::mpl::bool_<satisfies::value> type;
-#endif  // MSVC 7.1 workarounds needed.
+     public:
+        typedef ::boost::mpl::bool_<
+            ::boost::parameter::aux
+            ::satisfies<ArgList,ParameterRequirements>::_value
+        > type;
+#endif  // MSVC-7.1 workarounds needed
     };
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }}} // namespace boost::parameter::aux
 
 #include <boost/parameter/aux_/pack/as_parameter_requirements.hpp>
 
 namespace boost { namespace parameter { namespace aux {
+
     // Returns mpl::true_ if the requirements of the given ParameterSpec
     // are satisfied by ArgList.
     template <typename ArgList, typename ParameterSpec>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using satisfies_requirements_of = ::boost::parameter::aux::satisfies<
+        ArgList
+      , typename ::boost::parameter::aux
+        ::as_parameter_requirements<ParameterSpec>::type
+    >;
+#else
     struct satisfies_requirements_of
       : ::boost::parameter::aux::satisfies<
             ArgList
@@ -106,6 +135,7 @@ namespace boost { namespace parameter { namespace aux {
         >::type
     {
     };
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }}} // namespace boost::parameter::aux
 
 #endif  // include guard

--- a/include/boost/parameter/aux_/pack/tag_deduced.hpp
+++ b/include/boost/parameter/aux_/pack/tag_deduced.hpp
@@ -8,8 +8,15 @@
 
 #include <boost/parameter/aux_/set.hpp>
 #include <boost/parameter/aux_/pack/tag_type.hpp>
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/utility.hpp>
+#else
 #include <boost/mpl/pair.hpp>
 #include <boost/mpl/apply_wrap.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -19,17 +26,32 @@ namespace boost { namespace parameter { namespace aux {
     template <typename UsedArgs, typename Spec, typename Arg, typename TagFn>
     struct tag_deduced
     {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_list<
+            ::boost::mp11::mp_apply_q<
+                TagFn
+              , ::boost::mp11::mp_list<
+                    typename ::boost::parameter::aux::tag_type<Spec>::type
+                  , Arg
+                >
+            >
+#else
         typedef ::boost::mpl::pair<
             typename ::boost::mpl::apply_wrap2<
                 TagFn
               , typename ::boost::parameter::aux::tag_type<Spec>::type
               , Arg
             >::type
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
           , typename ::boost::parameter::aux::insert_<
                 UsedArgs
               , typename ::boost::parameter::aux::tag_type<Spec>::type
             >::type
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        >;
+#else
         > type;
+#endif
     };
 }}} // namespace boost::parameter::aux
 

--- a/include/boost/parameter/aux_/pack/tag_keyword_arg.hpp
+++ b/include/boost/parameter/aux_/pack/tag_keyword_arg.hpp
@@ -7,6 +7,7 @@
 #define BOOST_PARAMETER_AUX_PACK_TAG_KEYWORD_ARG_HPP
 
 #include <boost/parameter/aux_/tag.hpp>
+#include <boost/parameter/config.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -17,6 +18,11 @@ namespace boost { namespace parameter { namespace aux {
         {
             typedef typename ::boost::parameter::aux::tag<K,T>::type type;
         };
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        template <typename K, typename T>
+        using fn = typename ::boost::parameter::aux::tag<K,T>::type;
+#endif
     };
 }}} // namespace boost::parameter::aux
 

--- a/include/boost/parameter/aux_/pack/tag_keyword_arg_ref.hpp
+++ b/include/boost/parameter/aux_/pack/tag_keyword_arg_ref.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/parameter/aux_/unwrap_cv_reference.hpp>
 #include <boost/parameter/aux_/tagged_argument.hpp>
+#include <boost/parameter/config.hpp>
 
 namespace boost { namespace parameter { namespace aux { 
 
@@ -54,6 +55,11 @@ namespace boost { namespace parameter { namespace aux {
         {
             typedef typename ::boost::parameter::aux::tag_ref<K,T>::type type;
         };
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        template <typename K, typename T>
+        using fn = typename ::boost::parameter::aux::tag_ref<K,T>::type;
+#endif
     };
 }}} // namespace boost::parameter::aux
 

--- a/include/boost/parameter/aux_/pack/tag_template_keyword_arg.hpp
+++ b/include/boost/parameter/aux_/pack/tag_template_keyword_arg.hpp
@@ -7,6 +7,7 @@
 #define BOOST_PARAMETER_AUX_PACK_TAG_TEMPLATE_KEYWORD_ARG_HPP
 
 #include <boost/parameter/template_keyword.hpp>
+#include <boost/parameter/config.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -17,6 +18,11 @@ namespace boost { namespace parameter { namespace aux {
         {
             typedef ::boost::parameter::template_keyword<K,T> type;
         };
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        template <typename K, typename T>
+        using fn = ::boost::parameter::template_keyword<K,T>;
+#endif
     };
 }}} // namespace boost::parameter::aux
 

--- a/include/boost/parameter/aux_/pack/tag_type.hpp
+++ b/include/boost/parameter/aux_/pack/tag_type.hpp
@@ -17,17 +17,26 @@ namespace boost { namespace parameter { namespace aux {
 }}} // namespace boost::parameter::aux
 
 #include <boost/parameter/deduced.hpp>
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/utility.hpp>
+#else
 #include <boost/mpl/eval_if.hpp>
-#include <boost/mpl/identity.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
     template <typename T>
     struct get_tag_type
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_if<
+#else
       : ::boost::mpl::eval_if<
-            ::boost::parameter::aux::is_deduced_aux<typename T::key_type>
+#endif
+            ::boost::parameter::aux::is_deduced0<T>
           , ::boost::parameter::aux::get_tag_type0<typename T::key_type>
-          , ::boost::mpl::identity<typename T::key_type>
+          , ::boost::parameter::aux::get_tag_type0<T>
         >
     {
     };
@@ -35,8 +44,28 @@ namespace boost { namespace parameter { namespace aux {
 
 #include <boost/parameter/required.hpp>
 #include <boost/parameter/optional.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename T>
+    using tag_type = ::boost::mp11::mp_if<
+        ::boost::mp11::mp_if<
+            ::boost::parameter::aux::is_optional<T>
+          , ::boost::mp11::mp_true
+          , ::boost::parameter::aux::is_required<T>
+        >
+      , ::boost::parameter::aux::get_tag_type<T>
+      , ::boost::mp11::mp_identity<T>
+    >;
+}}} // namespace boost::parameter::aux
+
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/mpl/identity.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -55,5 +84,6 @@ namespace boost { namespace parameter { namespace aux {
     };
 }}} // namespace boost::parameter::aux
 
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 #endif  // include guard
 

--- a/include/boost/parameter/aux_/pack/unmatched_argument.hpp
+++ b/include/boost/parameter/aux_/pack/unmatched_argument.hpp
@@ -6,16 +6,25 @@
 #ifndef BOOST_PARAMETER_AUX_PACK_UNMATCHED_ARGUMENT_HPP
 #define BOOST_PARAMETER_AUX_PACK_UNMATCHED_ARGUMENT_HPP
 
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_same.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
     template <typename T>
     struct unmatched_argument
     {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(::std::is_same<T,void>::value, "T == void");
+#else
         BOOST_MPL_ASSERT((
             typename ::boost::mpl::if_<
                 ::boost::is_same<T,void>
@@ -23,6 +32,7 @@ namespace boost { namespace parameter { namespace aux {
               , ::boost::mpl::false_
             >::type
         ));
+#endif
         typedef int type;
     }; 
 }}} // namespace boost::parameter::aux

--- a/include/boost/parameter/aux_/pp_impl/argument_pack.hpp
+++ b/include/boost/parameter/aux_/pp_impl/argument_pack.hpp
@@ -10,11 +10,17 @@
 #include <boost/parameter/aux_/pack/tag_keyword_arg.hpp>
 #include <boost/parameter/aux_/pack/make_arg_list.hpp>
 #include <boost/parameter/config.hpp>
-#include <boost/mpl/pair.hpp>
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
-
 #include <boost/parameter/aux_/pack/make_parameter_spec_items.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/list.hpp>
+#else
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/pair.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -28,19 +34,28 @@ namespace boost { namespace parameter { namespace aux {
             >::type
           , typename Parameters::deduced_list
           , ::boost::parameter::aux::tag_keyword_arg
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+          , ::boost::mp11::mp_false
+#else
           , ::boost::mpl::false_
+#endif
         >::type result;
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_at_c<result,0>;
+#else
         typedef typename ::boost::mpl::first<result>::type type;
+#endif
     };
 }}} // namespace boost::parameter::aux
 
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
-
 #include <boost/parameter/aux_/void.hpp>
 #include <boost/parameter/aux_/pack/make_items.hpp>
 #include <boost/parameter/aux_/preprocessor/no_perfect_forwarding_begin.hpp>
 #include <boost/preprocessor/facilities/intercept.hpp>
 #include <boost/preprocessor/repetition/enum_trailing_binary_params.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/pair.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 

--- a/include/boost/parameter/aux_/pp_impl/unwrap_predicate.hpp
+++ b/include/boost/parameter/aux_/pp_impl/unwrap_predicate.hpp
@@ -14,8 +14,7 @@ namespace boost { namespace parameter { namespace aux {
     struct unwrap_predicate;
 }}} // namespace boost::parameter::aux
 
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/always.hpp>
+#include <boost/parameter/aux_/always_true_predicate.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -23,7 +22,7 @@ namespace boost { namespace parameter { namespace aux {
     template <>
     struct unwrap_predicate<void*>
     {
-        typedef ::boost::mpl::always< ::boost::mpl::true_> type;
+        typedef ::boost::parameter::aux::always_true_predicate type;
     };
 }}} // namespace boost::parameter::aux
 
@@ -51,9 +50,15 @@ namespace boost { namespace parameter { namespace aux {
 #endif   // SunProCC workarounds needed.
 }}} // namespace boost::parameter::aux
 
-#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
+#include <boost/mpl/placeholders.hpp>
 #include <boost/type_traits/is_convertible.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -62,11 +67,29 @@ namespace boost { namespace parameter { namespace aux {
     template <typename Target>
     struct unwrap_predicate<void (Target)>
     {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        struct type
+        {
+            template <typename Argument, typename ArgumentPack>
+            struct apply
+              : ::boost::mpl::if_<
+                    ::std::is_convertible<Argument,Target>
+                  , ::boost::mpl::true_
+                  , ::boost::mpl::false_
+                >
+            {
+            };
+
+            template <typename Argument, typename ArgumentPack>
+            using fn = ::std::is_convertible<Argument,Target>;
+        };
+#else
         typedef ::boost::mpl::if_<
             ::boost::is_convertible< ::boost::mpl::_,Target>
           , ::boost::mpl::true_
           , ::boost::mpl::false_
         > type;
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
     };
 }}} // namespace boost::parameter::aux
 

--- a/include/boost/parameter/aux_/result_of0.hpp
+++ b/include/boost/parameter/aux_/result_of0.hpp
@@ -8,9 +8,15 @@
 
 #include <boost/parameter/aux_/use_default_tag.hpp>
 #include <boost/parameter/config.hpp>
-#include <boost/mpl/if.hpp>
 #include <boost/utility/result_of.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+#else
+#include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_void.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -26,11 +32,20 @@ namespace boost { namespace parameter { namespace aux {
 #endif
 
      public:
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_if<
+            ::std::is_void<result_of_F>
+#else
         typedef typename ::boost::mpl::if_<
             ::boost::is_void<result_of_F>
+#endif
           , ::boost::parameter::aux::use_default_tag
           , result_of_F
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        >;
+#else
         >::type type;
+#endif
     };
 }}} // namespace boost::parameter::aux
 

--- a/include/boost/parameter/aux_/set.hpp
+++ b/include/boost/parameter/aux_/set.hpp
@@ -8,8 +8,46 @@
 
 #include <boost/parameter/config.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/list.hpp>
 
+namespace boost { namespace parameter { namespace aux {
+
+    typedef ::boost::mp11::mp_list<> set0;
+}}} // namespace boost::parameter::aux
+
+#include <boost/mp11/algorithm.hpp>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename S, typename K>
+    struct insert_
+    {
+        using type = ::boost::mp11::mp_insert_c<S,0,K>;
+    };
+}}} // namespace boost::parameter::aux
+
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename Set, typename K>
+    struct has_key_
+    {
+        using type = ::boost::mp11::mp_if<
+            ::boost::mp11::mp_empty<Set>
+          , ::boost::mp11::mp_false
+          , ::std::is_same<
+                ::boost::mp11::mp_find<Set,K>
+              , ::boost::mp11::mp_size<Set>
+            >
+        >;
+    };
+}}} // namespace boost::parameter::aux
+
+#elif BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
 #include <boost/mpl/list.hpp>
 
 namespace boost { namespace parameter { namespace aux {
@@ -47,8 +85,7 @@ namespace boost { namespace parameter { namespace aux {
     };
 }}} // namespace boost::parameter::aux
 
-#else   // !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-
+#else   // !BOOST_PARAMETER_CAN_USE_MP11 && Borland workarounds not needed
 #include <boost/mpl/set/set0.hpp>
 
 namespace boost { namespace parameter { namespace aux {
@@ -76,6 +113,6 @@ namespace boost { namespace parameter { namespace aux {
     };
 }}} // namespace boost::parameter::aux
 
-#endif  // Borland workarounds needed.
+#endif  // BOOST_PARAMETER_CAN_USE_MP11 || Borland workarounds needed
 #endif  // include guard
 

--- a/include/boost/parameter/aux_/template_keyword.hpp
+++ b/include/boost/parameter/aux_/template_keyword.hpp
@@ -15,6 +15,22 @@ namespace boost { namespace parameter { namespace aux {
 }}} // namespace boost::parameter::aux
 
 #include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename T>
+    using is_template_keyword = ::std::is_base_of<
+        ::boost::parameter::aux::template_keyword_base
+      , typename ::std::remove_const<
+            typename ::std::remove_reference<T>::type
+        >::type
+    >;
+}}} // namespace boost::parameter::aux
+
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/remove_const.hpp>
@@ -58,7 +74,7 @@ namespace boost { namespace parameter { namespace aux {
             >
           , ::boost::mpl::true_
           , ::boost::mpl::false_
-#else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#else
             ::boost::is_lvalue_reference<T>
           , ::boost::mpl::false_
           , ::boost::parameter::aux::is_template_keyword_aux<T>
@@ -68,5 +84,6 @@ namespace boost { namespace parameter { namespace aux {
     };
 }}} // namespace boost::parameter::aux
 
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 #endif  // include guard
 

--- a/include/boost/parameter/aux_/yesno.hpp
+++ b/include/boost/parameter/aux_/yesno.hpp
@@ -1,26 +1,42 @@
-// Copyright Daniel Wallin, David Abrahams 2005. Use, modification and
-// distribution is subject to the Boost Software License, Version 1.0. (See
-// accompanying file LICENSE_1_0.txt or copy at
+// Copyright Daniel Wallin, David Abrahams 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef YESNO_050328_HPP
 #define YESNO_050328_HPP
 
+namespace boost { namespace parameter { namespace aux {
+
+    // types used with the "sizeof trick" to capture the results of
+    // overload resolution at compile-time.
+    typedef char yes_tag;
+    typedef char (&no_tag)[2];
+}}} // namespace boost::parameter::aux
+
 #include <boost/mpl/bool.hpp>
 
 namespace boost { namespace parameter { namespace aux {
 
-// types used with the "sizeof trick" to capture the results of
-// overload resolution at compile-time.
-typedef char yes_tag;
-typedef char (&no_tag)[2];
-
-// mpl::true_ and mpl::false_ are not distinguishable by sizeof(),
-// so we pass them through these functions to get a type that is.
-yes_tag to_yesno(mpl::true_);
-no_tag to_yesno(mpl::false_);
-
+    // mpl::true_ and mpl::false_ are not distinguishable by sizeof(),
+    // so we pass them through these functions to get a type that is.
+    ::boost::parameter::aux::yes_tag to_yesno(::boost::mpl::true_);
+    ::boost::parameter::aux::no_tag to_yesno(::boost::mpl::false_);
 }}} // namespace boost::parameter::aux
 
-#endif // YESNO_050328_HPP
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+
+namespace boost { namespace parameter { namespace aux {
+
+    // mp11::mp_true and mp11::mp_false are not distinguishable by sizeof(),
+    // so we pass them through these functions to get a type that is.
+    ::boost::parameter::aux::yes_tag to_yesno(::boost::mp11::mp_true);
+    ::boost::parameter::aux::no_tag to_yesno(::boost::mp11::mp_false);
+}}} // namespace boost::parameter::aux
+
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
+#endif  // include guard
 

--- a/include/boost/parameter/binding.hpp
+++ b/include/boost/parameter/binding.hpp
@@ -1,80 +1,164 @@
-// Copyright David Abrahams 2005. Distributed under the Boost
-// Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-#ifndef BOOST_PARAMETER_BINDING_DWA200558_HPP
-# define BOOST_PARAMETER_BINDING_DWA200558_HPP
+// Copyright David Abrahams 2005.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
-# include <boost/mpl/apply.hpp>
-# include <boost/mpl/assert.hpp>
-# include <boost/mpl/and.hpp>
-# include <boost/parameter/aux_/result_of0.hpp>
-# include <boost/parameter/aux_/void.hpp>
-# include <boost/type_traits/is_same.hpp>
+#ifndef BOOST_PARAMETER_BINDING_DWA200558_HPP
+#define BOOST_PARAMETER_BINDING_DWA200558_HPP
+
+#include <boost/parameter/aux_/void.hpp>
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+#else
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
+#include <boost/mpl/apply_wrap.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/type_traits/is_same.hpp>
+#endif
 
 namespace boost { namespace parameter { 
 
-// A metafunction that, given an argument pack, returns the type of
-// the parameter identified by the given keyword.  If no such
-// parameter has been specified, returns Default
+    // A metafunction that, given an argument pack, returns the reference type
+    // of the parameter identified by the given keyword.  If no such parameter
+    // has been specified, returns Default
 
-# if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-template <class Parameters, class Keyword, class Default>
-struct binding0
-{
-    typedef typename mpl::apply_wrap3<
-        typename Parameters::binding,Keyword,Default,mpl::true_
-    >::type type;
+    template <typename Parameters, typename Keyword, typename Default>
+    struct binding0
+    {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_apply_q<
+            typename Parameters::binding
+          , ::boost::mp11::mp_list<Keyword,Default,::boost::mp11::mp_true>
+        >;
 
-    BOOST_MPL_ASSERT_NOT((
-        mpl::and_<
-            is_same<Default, void_>
-          , is_same<type, void_>
-        >
-    ));
-};
-# endif
+        static_assert(
+            ::boost::mp11::mp_if<
+                ::std::is_same<Default,::boost::parameter::void_>
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<type,::boost::parameter::void_>
+                  , ::boost::mp11::mp_false
+                  , ::boost::mp11::mp_true
+                >
+              , ::boost::mp11::mp_true
+            >::value
+          , "required parameters must not result in void_ type"
+        );
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
+        typedef typename ::boost::mpl::apply_wrap3<
+            typename Parameters::binding
+          , Keyword
+          , Default
+          , ::boost::mpl::true_
+        >::type type;
 
-template <class Parameters, class Keyword, class Default = void_>
-struct binding
-{
-# if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-    typedef typename mpl::eval_if<
-        mpl::is_placeholder<Parameters>
-      , mpl::identity<int>
-      , binding0<Parameters,Keyword,Default>
-    >::type type;
-# else
-    typedef typename mpl::apply_wrap3<
-        typename Parameters::binding,Keyword,Default,mpl::true_
-    >::type type;
+        BOOST_MPL_ASSERT((
+            typename ::boost::mpl::eval_if<
+                ::boost::is_same<Default,::boost::parameter::void_>
+              , ::boost::mpl::if_<
+                    ::boost::is_same<type,::boost::parameter::void_>
+                  , ::boost::mpl::false_
+                  , ::boost::mpl::true_
+                >
+              , ::boost::mpl::true_
+            >::type
+        ));
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
+    };
 
-    BOOST_MPL_ASSERT_NOT((
-        mpl::and_<
-            is_same<Default, void_>
-          , is_same<type, void_>
-        >
-    ));
-# endif
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    template <typename Placeholder, typename Keyword, typename Default>
+    struct binding1
+    {
+        using type = ::boost::mp11::mp_apply_q<
+            Placeholder
+          , ::boost::mp11::mp_list<Keyword,Default,::boost::mp11::mp_true>
+        >;
 
-    BOOST_MPL_AUX_LAMBDA_SUPPORT(3,binding,(Parameters,Keyword,Default))
-};
-
-// A metafunction that, given an argument pack, returns the type of
-// the parameter identified by the given keyword.  If no such
-// parameter has been specified, returns the type returned by invoking
-// DefaultFn
-template <class Parameters, class Keyword, class DefaultFn>
-struct lazy_binding
-{
-  typedef typename mpl::apply_wrap3<
-      typename Parameters::binding
-    , Keyword
-    , typename aux::result_of0<DefaultFn>::type
-    , mpl::true_
-  >::type type;
-};
-
-
+        static_assert(
+            ::boost::mp11::mp_if<
+                ::std::is_same<Default,::boost::parameter::void_>
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<type,::boost::parameter::void_>
+                  , ::boost::mp11::mp_false
+                  , ::boost::mp11::mp_true
+                >
+              , ::boost::mp11::mp_true
+            >::value
+          , "required parameters must not result in void_ type"
+        );
+    };
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }} // namespace boost::parameter
 
-#endif // BOOST_PARAMETER_BINDING_DWA200558_HPP
+#include <boost/parameter/aux_/is_placeholder.hpp>
+
+namespace boost { namespace parameter { 
+
+    template <
+        typename Parameters
+      , typename Keyword
+      , typename Default = ::boost::parameter::void_
+    >
+    struct binding
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mpl::eval_if<
+            ::boost::parameter::aux::is_mpl_placeholder<Parameters>
+          , ::boost::mpl::identity<int>
+          , ::boost::parameter::binding0<Parameters,Keyword,Default>
+        >
+#endif
+    {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = typename ::boost::mp11::mp_if<
+            ::boost::parameter::aux::is_mpl_placeholder<Parameters>
+          , ::boost::mp11::mp_identity<int>
+          , ::boost::mp11::mp_if<
+                ::boost::parameter::aux::is_mp11_placeholder<Parameters>
+              , ::boost::parameter::binding1<Parameters,Keyword,Default>
+              , ::boost::parameter::binding0<Parameters,Keyword,Default>
+            >
+        >::type;
+#endif
+    };
+}} // namespace boost::parameter
+
+#include <boost/parameter/aux_/result_of0.hpp>
+
+namespace boost { namespace parameter { 
+
+    // A metafunction that, given an argument pack, returns the reference type
+    // of the parameter identified by the given keyword.  If no such parameter
+    // has been specified, returns the type returned by invoking DefaultFn
+    template <typename Parameters, typename Keyword, typename DefaultFn>
+    struct lazy_binding
+    {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_apply_q<
+            typename Parameters::binding
+          , ::boost::mp11::mp_list<
+                Keyword
+              , typename ::boost::parameter::aux::result_of0<DefaultFn>::type
+              , ::boost::mp11::mp_true
+            >
+        >;
+#else
+        typedef typename ::boost::mpl::apply_wrap3<
+            typename Parameters::binding
+          , Keyword
+          , typename ::boost::parameter::aux::result_of0<DefaultFn>::type
+          , ::boost::mpl::true_
+        >::type type;
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
+    };
+}} // namespace boost::parameter
+
+#endif  // include guard
+

--- a/include/boost/parameter/compose.hpp
+++ b/include/boost/parameter/compose.hpp
@@ -49,7 +49,12 @@ namespace boost { namespace parameter {
 
     template <typename TaggedArg0, typename ...TaggedArgs>
     inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        ::boost::parameter
+        ::are_tagged_arguments_mp11<TaggedArg0,TaggedArgs...>
+#else
         ::boost::parameter::are_tagged_arguments<TaggedArg0,TaggedArgs...>
+#endif
       , ::boost::parameter::aux
         ::compose_arg_list<TaggedArg0,TaggedArgs...>
     >::type

--- a/include/boost/parameter/deduced.hpp
+++ b/include/boost/parameter/deduced.hpp
@@ -23,18 +23,33 @@ namespace boost { namespace parameter {
     };
 }}
 
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#else
 #include <boost/mpl/bool.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
     template <typename T>
-    struct is_deduced_aux : ::boost::mpl::false_
+    struct is_deduced_aux
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_false
+#else
+      : ::boost::mpl::false_
+#endif
     {
     };
 
     template <typename Tag>
     struct is_deduced_aux< ::boost::parameter::deduced<Tag> >
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_true
+#else
       : ::boost::mpl::true_
+#endif
     {
     };
 
@@ -47,7 +62,12 @@ namespace boost { namespace parameter { namespace aux {
 
 #include <boost/parameter/required.hpp>
 #include <boost/parameter/optional.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/utility.hpp>
+#else
 #include <boost/mpl/if.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
@@ -64,6 +84,13 @@ namespace boost { namespace parameter { namespace aux {
     //
 
     template <typename T>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using has_default = ::boost::mp11::mp_if<
+        ::boost::parameter::aux::is_required<T>
+      , ::boost::mp11::mp_false
+      , ::boost::mp11::mp_true
+    >;
+#else
     struct has_default
       : ::boost::mpl::if_<
             ::boost::parameter::aux::is_required<T>
@@ -72,8 +99,20 @@ namespace boost { namespace parameter { namespace aux {
         >::type
     {
     };
+#endif
 
     template <typename T>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using is_deduced = ::boost::mp11::mp_if<
+        ::boost::mp11::mp_if<
+            ::boost::parameter::aux::is_optional<T>
+          , ::boost::mp11::mp_true
+          , ::boost::parameter::aux::is_required<T>
+        >
+      , ::boost::parameter::aux::is_deduced0<T>
+      , ::boost::mp11::mp_false
+    >;
+#else
     struct is_deduced
       : ::boost::mpl::if_<
             typename ::boost::mpl::if_<
@@ -86,6 +125,7 @@ namespace boost { namespace parameter { namespace aux {
         >::type
     {
     };
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }}} // namespace boost::parameter::aux
 
 #endif  // include guard

--- a/include/boost/parameter/is_argument_pack.hpp
+++ b/include/boost/parameter/is_argument_pack.hpp
@@ -25,5 +25,22 @@ namespace boost { namespace parameter {
     };
 }}
 
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#include <type_traits>
+
+namespace boost { namespace parameter {
+
+    template <typename T>
+    using is_argument_pack_mp11 = ::boost::mp11::mp_if<
+        ::std::is_base_of< ::boost::parameter::aux::empty_arg_list,T>
+      , ::boost::mp11::mp_true
+      , ::boost::parameter::aux::is_tagged_argument_mp11<T>
+    >;
+}} // namespace boost::parameter
+
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 #endif  // include guard
 

--- a/include/boost/parameter/keyword.hpp
+++ b/include/boost/parameter/keyword.hpp
@@ -13,15 +13,21 @@
 #include <boost/parameter/config.hpp>
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
+#include <boost/core/enable_if.hpp>
+#include <utility>
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/eval_if.hpp>
-#include <boost/core/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_scalar.hpp>
 #include <boost/type_traits/is_const.hpp>
-#include <utility>
+#endif
 
 namespace boost { namespace parameter {
 
@@ -51,6 +57,23 @@ namespace boost { namespace parameter {
 
         template <typename T>
         inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            ::boost::mp11::mp_if<
+                ::std::is_scalar<T>
+              , ::boost::mp11::mp_true
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::in_reference
+                    >
+                  , ::boost::mp11::mp_true
+                  , ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >
+            >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<T>
               , ::boost::mpl::true_
@@ -70,6 +93,7 @@ namespace boost { namespace parameter {
                     >
                 >
             >::type
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
           , ::boost::parameter::aux::tag<Tag,T const&>
         >::type
             operator=(T const& x) const
@@ -81,6 +105,23 @@ namespace boost { namespace parameter {
 
         template <typename Default>
         inline BOOST_CONSTEXPR typename ::boost::enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            ::boost::mp11::mp_if<
+                ::std::is_scalar<Default>
+              , ::boost::mp11::mp_true
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::in_reference
+                    >
+                  , ::boost::mp11::mp_true
+                  , ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >
+            >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<Default>
               , ::boost::mpl::true_
@@ -100,6 +141,7 @@ namespace boost { namespace parameter {
                     >
                 >
             >::type
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
           , ::boost::parameter::aux::default_<Tag,Default const>
         >::type
             operator|(Default const& d) const
@@ -109,6 +151,27 @@ namespace boost { namespace parameter {
 
         template <typename T>
         inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            ::boost::mp11::mp_if<
+                ::boost::mp11::mp_if<
+                    ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::out_reference
+                    >
+                  , ::boost::mp11::mp_true
+                  , ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >
+              , ::boost::mp11::mp_if<
+                    ::std::is_const<T>
+                  , ::boost::mp11::mp_false
+                  , ::boost::mp11::mp_true
+                >
+              , ::boost::mp11::mp_false
+            >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
             typename ::boost::mpl::eval_if<
                 typename ::boost::mpl::if_<
                     ::boost::is_same<
@@ -128,6 +191,7 @@ namespace boost { namespace parameter {
                 >
               , ::boost::mpl::false_
             >::type
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
           , ::boost::parameter::aux::tag<Tag,T&>
         >::type
             operator=(T& x) const
@@ -139,6 +203,27 @@ namespace boost { namespace parameter {
 
         template <typename Default>
         inline BOOST_CONSTEXPR typename ::boost::enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            ::boost::mp11::mp_if<
+                ::boost::mp11::mp_if<
+                    ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::out_reference
+                    >
+                  , ::boost::mp11::mp_true
+                  , ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >
+              , ::boost::mp11::mp_if<
+                    ::std::is_const<Default>
+                  , ::boost::mp11::mp_false
+                  , ::boost::mp11::mp_true
+                >
+              , ::boost::mp11::mp_false
+            >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
             typename ::boost::mpl::eval_if<
                 typename ::boost::mpl::if_<
                     ::boost::is_same<
@@ -158,6 +243,7 @@ namespace boost { namespace parameter {
                 >
               , ::boost::mpl::false_
             >::type
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
           , ::boost::parameter::aux::default_<Tag,Default>
         >::type
             operator|(Default& d) const
@@ -184,6 +270,23 @@ namespace boost { namespace parameter {
 
         template <typename T>
         inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            ::boost::mp11::mp_if<
+                ::std::is_scalar<T>
+              , ::boost::mp11::mp_false
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::in_reference
+                    >
+                  , ::boost::mp11::mp_true
+                  , ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >
+            >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<T>
               , ::boost::mpl::false_
@@ -203,6 +306,7 @@ namespace boost { namespace parameter {
                     >
                 >
             >::type
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
           , ::boost::parameter::aux::tag<Tag,T const>
         >::type
             operator=(T const&& x) const
@@ -214,6 +318,23 @@ namespace boost { namespace parameter {
 
         template <typename T>
         inline BOOST_CONSTEXPR typename ::boost::lazy_enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            ::boost::mp11::mp_if<
+                ::std::is_scalar<T>
+              , ::boost::mp11::mp_false
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::consume_reference
+                    >
+                  , ::boost::mp11::mp_true
+                  , ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >
+            >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<T>
               , ::boost::mpl::false_
@@ -233,6 +354,7 @@ namespace boost { namespace parameter {
                     >
                 >
             >::type
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
           , ::boost::parameter::aux::tag<Tag,T>
         >::type
             operator=(T&& x) const
@@ -243,6 +365,23 @@ namespace boost { namespace parameter {
 
         template <typename Default>
         inline BOOST_CONSTEXPR typename ::boost::enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            ::boost::mp11::mp_if<
+                ::std::is_scalar<Default>
+              , ::boost::mp11::mp_false
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::in_reference
+                    >
+                  , ::boost::mp11::mp_true
+                  , ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >
+            >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<Default>
               , ::boost::mpl::false_
@@ -262,6 +401,7 @@ namespace boost { namespace parameter {
                     >
                 >
             >::type
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
           , ::boost::parameter::aux::default_r_<Tag,Default const>
         >::type
             operator|(Default const&& d) const
@@ -273,6 +413,23 @@ namespace boost { namespace parameter {
 
         template <typename Default>
         inline BOOST_CONSTEXPR typename ::boost::enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            ::boost::mp11::mp_if<
+                ::std::is_scalar<Default>
+              , ::boost::mp11::mp_false
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::consume_reference
+                    >
+                  , ::boost::mp11::mp_true
+                  , ::std::is_same<
+                        typename Tag::qualifier
+                      , ::boost::parameter::forward_reference
+                    >
+                >
+            >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
             typename ::boost::mpl::eval_if<
                 ::boost::is_scalar<Default>
               , ::boost::mpl::false_
@@ -292,6 +449,7 @@ namespace boost { namespace parameter {
                     >
                 >
             >::type
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
           , ::boost::parameter::aux::default_r_<Tag,Default>
         >::type
             operator|(Default&& d) const
@@ -530,11 +688,13 @@ namespace boost { namespace parameter {
 #endif  // BOOST_PARAMETER_HAS_PERFECT_FORWARDING
 
 #include <boost/parameter/aux_/name.hpp>
+#include <boost/preprocessor/stringize.hpp>
 
 // Reduces boilerplate required to declare and initialize keywords without
 // violating ODR.  Declares a keyword tag type with the given name in
 // namespace tag_namespace, and declares and initializes a reference in an
 // anonymous namespace to a singleton instance of that type.
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
 #define BOOST_PARAMETER_KEYWORD(tag_namespace, name)                         \
     namespace tag_namespace                                                  \
     {                                                                        \
@@ -542,7 +702,30 @@ namespace boost { namespace parameter {
         {                                                                    \
             static BOOST_CONSTEXPR char const* keyword_name()                \
             {                                                                \
-                return #name;                                                \
+                return BOOST_PP_STRINGIZE(name);                             \
+            }                                                                \
+            using _ = BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(name);            \
+            using _1 = _;                                                    \
+            BOOST_PARAMETER_TAG_MP11_PLACEHOLDER_BINDING(binding_fn, name);  \
+            BOOST_PARAMETER_TAG_MP11_PLACEHOLDER_VALUE(fn, name);            \
+            using qualifier = ::boost::parameter::forward_reference;         \
+        };                                                                   \
+    }                                                                        \
+    namespace                                                                \
+    {                                                                        \
+        ::boost::parameter::keyword<tag_namespace::name> const& name         \
+            = ::boost::parameter::keyword<tag_namespace::name>::instance;    \
+    }
+/**/
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
+#define BOOST_PARAMETER_KEYWORD(tag_namespace, name)                         \
+    namespace tag_namespace                                                  \
+    {                                                                        \
+        struct name                                                          \
+        {                                                                    \
+            static BOOST_CONSTEXPR char const* keyword_name()                \
+            {                                                                \
+                return BOOST_PP_STRINGIZE(name);                             \
             }                                                                \
             typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(name) _;            \
             typedef BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(name) _1;           \
@@ -555,6 +738,7 @@ namespace boost { namespace parameter {
             = ::boost::parameter::keyword<tag_namespace::name>::instance;    \
     }
 /**/
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 
 #endif  // include guard
 

--- a/include/boost/parameter/name.hpp
+++ b/include/boost/parameter/name.hpp
@@ -8,9 +8,28 @@
 #define BOOST_PARAMETER_NAME_060806_HPP
 
 #include <boost/parameter/aux_/name.hpp>
-#include <boost/parameter/config.hpp>
 #include <boost/preprocessor/stringize.hpp>
+#include <boost/config.hpp>
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#define BOOST_PARAMETER_NAME_TAG(tag_namespace, tag, q)                      \
+    namespace tag_namespace                                                  \
+    {                                                                        \
+        struct tag                                                           \
+        {                                                                    \
+            static BOOST_CONSTEXPR char const* keyword_name()                \
+            {                                                                \
+                return BOOST_PP_STRINGIZE(tag);                              \
+            }                                                                \
+            using _ = BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(tag);             \
+            using _1 = _;                                                    \
+            BOOST_PARAMETER_TAG_MP11_PLACEHOLDER_BINDING(binding_fn, tag);   \
+            BOOST_PARAMETER_TAG_MP11_PLACEHOLDER_VALUE(fn, tag);             \
+            using qualifier = ::boost::parameter::q;                         \
+        };                                                                   \
+    }
+/**/
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #define BOOST_PARAMETER_NAME_TAG(tag_namespace, tag, q)                      \
     namespace tag_namespace                                                  \
     {                                                                        \
@@ -26,6 +45,7 @@
         };                                                                   \
     }
 /**/
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 
 #include <boost/parameter/keyword.hpp>
 

--- a/include/boost/parameter/nested_keyword.hpp
+++ b/include/boost/parameter/nested_keyword.hpp
@@ -12,6 +12,52 @@
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#define BOOST_PARAMETER_NESTED_KEYWORD_AUX(tag_namespace, q, name, alias)    \
+    namespace tag_namespace                                                  \
+    {                                                                        \
+        template <int Dummy = 0>                                             \
+        struct BOOST_PP_CAT(name, _)                                         \
+        {                                                                    \
+            static BOOST_CONSTEXPR char const* keyword_name()                \
+            {                                                                \
+                return BOOST_PP_STRINGIZE(name);                             \
+            }                                                                \
+            using _ = BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(                  \
+                BOOST_PP_CAT(name, _)<Dummy>                                 \
+            );                                                               \
+            using _1 = BOOST_PARAMETER_TAG_PLACEHOLDER_TYPE(                 \
+                BOOST_PP_CAT(name, _)<Dummy>                                 \
+            );                                                               \
+            BOOST_PARAMETER_TAG_MP11_PLACEHOLDER_BINDING(                    \
+                binding_fn                                                   \
+              , BOOST_PP_CAT(name, _)<Dummy>                                 \
+            );                                                               \
+            BOOST_PARAMETER_TAG_MP11_PLACEHOLDER_VALUE(                      \
+                fn                                                           \
+              , BOOST_PP_CAT(name, _)<Dummy>                                 \
+            );                                                               \
+            using qualifier = ::boost::parameter::q;                         \
+            static ::boost::parameter::keyword<                              \
+                BOOST_PP_CAT(name, _)<Dummy>                                 \
+            > const& alias;                                                  \
+        };                                                                   \
+        template <int Dummy>                                                 \
+        ::boost::parameter::keyword<                                         \
+            BOOST_PP_CAT(name, _)<Dummy>                                     \
+        > const& BOOST_PP_CAT(name, _)<Dummy>::alias                         \
+            = ::boost::parameter::keyword<                                   \
+                BOOST_PP_CAT(name, _)<Dummy>                                 \
+            >::instance;                                                     \
+        typedef BOOST_PP_CAT(name, _)<> name;                                \
+    }                                                                        \
+    namespace                                                                \
+    {                                                                        \
+        ::boost::parameter::keyword<tag_namespace::name> const& name         \
+            = ::boost::parameter::keyword<tag_namespace::name>::instance;    \
+    }
+/**/
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #define BOOST_PARAMETER_NESTED_KEYWORD_AUX(tag_namespace, q, name, alias)    \
     namespace tag_namespace                                                  \
     {                                                                        \
@@ -48,6 +94,7 @@
             = ::boost::parameter::keyword<tag_namespace::name>::instance;    \
     }
 /**/
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 
 #include <boost/parameter/aux_/preprocessor/qualifier.hpp>
 

--- a/include/boost/parameter/optional.hpp
+++ b/include/boost/parameter/optional.hpp
@@ -32,18 +32,33 @@ namespace boost { namespace parameter {
     };
 }}
 
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#else
 #include <boost/mpl/bool.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
     template <typename T>
-    struct is_optional : ::boost::mpl::false_
+    struct is_optional
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_false
+#else
+      : ::boost::mpl::false_
+#endif
     {
     };
 
     template <typename Tag, typename Predicate>
     struct is_optional< ::boost::parameter::optional<Tag,Predicate> >
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_true
+#else
       : ::boost::mpl::true_
+#endif
     {
     };
 }}} // namespace boost::parameter::aux

--- a/include/boost/parameter/required.hpp
+++ b/include/boost/parameter/required.hpp
@@ -31,18 +31,33 @@ namespace boost { namespace parameter {
     };
 }}
 
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#else
 #include <boost/mpl/bool.hpp>
+#endif
 
 namespace boost { namespace parameter { namespace aux {
 
     template <typename T>
-    struct is_required : ::boost::mpl::false_
+    struct is_required
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_false
+#else
+      : ::boost::mpl::false_
+#endif
     {
     };
 
     template <typename Tag, typename Predicate>
     struct is_required< ::boost::parameter::required<Tag,Predicate> >
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mp11::mp_true
+#else
       : ::boost::mpl::true_
+#endif
     {
     };
 }}} // namespace boost::parameter::aux

--- a/include/boost/parameter/template_keyword.hpp
+++ b/include/boost/parameter/template_keyword.hpp
@@ -8,6 +8,13 @@
 #define BOOST_PARAMETER_TEMPLATE_KEYWORD_HPP
 
 #include <boost/parameter/aux_/template_keyword.hpp>
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/eval_if.hpp>
@@ -15,6 +22,7 @@
 #include <boost/type_traits/add_lvalue_reference.hpp>
 #include <boost/type_traits/is_function.hpp>
 #include <boost/type_traits/is_array.hpp>
+#endif
 
 namespace boost { namespace parameter { 
 
@@ -39,6 +47,18 @@ namespace boost { namespace parameter {
         // Simply making reference == value_type& would break all the
         // legacy code that uses binding<...> to access named template
         // parameters. -- David Abrahams
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using reference = typename ::boost::mp11::mp_eval_if<
+            ::boost::mp11::mp_if<
+                ::std::is_function<value_type>
+              , ::boost::mp11::mp_true
+              , ::std::is_array<value_type>
+            >
+          , ::std::add_lvalue_reference<value_type>
+          , ::boost::mp11::mp_identity
+          , value_type
+        >::type;
+#else
         typedef typename ::boost::mpl::eval_if<
             typename ::boost::mpl::if_<
                 ::boost::is_function<value_type>
@@ -48,6 +68,7 @@ namespace boost { namespace parameter {
           , ::boost::add_lvalue_reference<value_type>
           , ::boost::mpl::identity<value_type>
         >::type reference;
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
     };
 }} // namespace boost::parameter
 

--- a/include/boost/parameter/value_type.hpp
+++ b/include/boost/parameter/value_type.hpp
@@ -1,82 +1,164 @@
-// Copyright Daniel Wallin 2006. Use, modification and distribution is
-// subject to the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright Daniel Wallin 2006.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_PARAMETER_VALUE_TYPE_060921_HPP
-# define BOOST_PARAMETER_VALUE_TYPE_060921_HPP
+#define BOOST_PARAMETER_VALUE_TYPE_060921_HPP
 
-# include <boost/mpl/apply.hpp>
-# include <boost/mpl/assert.hpp>
-# include <boost/mpl/and.hpp>
-# include <boost/parameter/aux_/result_of0.hpp>
-# include <boost/parameter/aux_/void.hpp>
-# include <boost/type_traits/is_same.hpp>
+#include <boost/parameter/aux_/void.hpp>
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+#else
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
+#include <boost/mpl/apply_wrap.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/type_traits/is_same.hpp>
+#endif
 
 namespace boost { namespace parameter { 
 
-// A metafunction that, given an argument pack, returns the type of
-// the parameter identified by the given keyword.  If no such
-// parameter has been specified, returns Default
+    // A metafunction that, given an argument pack, returns the value type
+    // of the parameter identified by the given keyword.  If no such parameter
+    // has been specified, returns Default
 
-# if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-template <class Parameters, class Keyword, class Default>
-struct value_type0
-{
-    typedef typename mpl::apply_wrap3<
-        typename Parameters::binding,Keyword,Default,mpl::false_
-    >::type type;
+    template <typename Parameters, typename Keyword, typename Default>
+    struct value_type0
+    {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_apply_q<
+            typename Parameters::binding
+          , ::boost::mp11::mp_list<Keyword,Default,::boost::mp11::mp_false>
+        >;
 
-    BOOST_MPL_ASSERT_NOT((
-        mpl::and_<
-            is_same<Default, void_>
-          , is_same<type, void_>
-        >
-    ));
-};
-# endif
+        static_assert(
+            ::boost::mp11::mp_if<
+                ::std::is_same<Default,::boost::parameter::void_>
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<type,::boost::parameter::void_>
+                  , ::boost::mp11::mp_false
+                  , ::boost::mp11::mp_true
+                >
+              , ::boost::mp11::mp_true
+            >::value
+          , "required parameters must not result in void_ type"
+        );
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
+        typedef typename ::boost::mpl::apply_wrap3<
+            typename Parameters::binding
+          , Keyword
+          , Default
+          , ::boost::mpl::false_
+        >::type type;
 
-template <class Parameters, class Keyword, class Default = void_>
-struct value_type
-{
-# if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
-    typedef typename mpl::eval_if<
-        mpl::is_placeholder<Parameters>
-      , mpl::identity<int>
-      , value_type0<Parameters,Keyword,Default>
-    >::type type;
-# else
-    typedef typename mpl::apply_wrap3<
-        typename Parameters::binding,Keyword,Default,mpl::false_
-    >::type type;
+        BOOST_MPL_ASSERT((
+            typename ::boost::mpl::eval_if<
+                ::boost::is_same<Default,::boost::parameter::void_>
+              , ::boost::mpl::if_<
+                    ::boost::is_same<type,::boost::parameter::void_>
+                  , ::boost::mpl::false_
+                  , ::boost::mpl::true_
+                >
+              , ::boost::mpl::true_
+            >::type
+        ));
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
+    };
 
-    BOOST_MPL_ASSERT_NOT((
-        mpl::and_<
-            is_same<Default, void_>
-          , is_same<type, void_>
-        >
-    ));
-# endif
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    template <typename Placeholder, typename Keyword, typename Default>
+    struct value_type1
+    {
+        using type = ::boost::mp11::mp_apply_q<
+            Placeholder
+          , ::boost::mp11::mp_list<Keyword,Default,::boost::mp11::mp_false>
+        >;
 
-    BOOST_MPL_AUX_LAMBDA_SUPPORT(3,value_type,(Parameters,Keyword,Default))
-};
-
-// A metafunction that, given an argument pack, returns the type of
-// the parameter identified by the given keyword.  If no such
-// parameter has been specified, returns the type returned by invoking
-// DefaultFn
-template <class Parameters, class Keyword, class DefaultFn>
-struct lazy_value_type
-{
-  typedef typename mpl::apply_wrap3<
-      typename Parameters::binding
-    , Keyword
-    , typename aux::result_of0<DefaultFn>::type
-    , mpl::false_
-  >::type type;
-};
-
-
+        static_assert(
+            ::boost::mp11::mp_if<
+                ::std::is_same<Default,::boost::parameter::void_>
+              , ::boost::mp11::mp_if<
+                    ::std::is_same<type,::boost::parameter::void_>
+                  , ::boost::mp11::mp_false
+                  , ::boost::mp11::mp_true
+                >
+              , ::boost::mp11::mp_true
+            >::value
+          , "required parameters must not result in void_ type"
+        );
+    };
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }} // namespace boost::parameter
 
-#endif // BOOST_PARAMETER_VALUE_TYPE_060921_HPP
+#include <boost/parameter/aux_/is_placeholder.hpp>
+
+namespace boost { namespace parameter { 
+
+    template <
+        typename Parameters
+      , typename Keyword
+      , typename Default = ::boost::parameter::void_
+    >
+    struct value_type
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
+      : ::boost::mpl::eval_if<
+            ::boost::parameter::aux::is_mpl_placeholder<Parameters>
+          , ::boost::mpl::identity<int>
+          , ::boost::parameter::value_type0<Parameters,Keyword,Default>
+        >
+#endif
+    {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = typename ::boost::mp11::mp_if<
+            ::boost::parameter::aux::is_mpl_placeholder<Parameters>
+          , ::boost::mp11::mp_identity<int>
+          , ::boost::mp11::mp_if<
+                ::boost::parameter::aux::is_mp11_placeholder<Parameters>
+              , ::boost::parameter::value_type1<Parameters,Keyword,Default>
+              , ::boost::parameter::value_type0<Parameters,Keyword,Default>
+            >
+        >::type;
+#endif
+    };
+}} // namespace boost::parameter
+
+#include <boost/parameter/aux_/result_of0.hpp>
+
+namespace boost { namespace parameter { 
+
+    // A metafunction that, given an argument pack, returns the value type
+    // of the parameter identified by the given keyword.  If no such parameter
+    // has been specified, returns the type returned by invoking DefaultFn
+    template <typename Parameters, typename Keyword, typename DefaultFn>
+    struct lazy_value_type
+    {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_apply_q<
+            typename Parameters::binding
+          , ::boost::mp11::mp_list<
+                Keyword
+              , typename ::boost::parameter::aux::result_of0<DefaultFn>::type
+              , ::boost::mp11::mp_false
+            >
+        >;
+#else
+        typedef typename ::boost::mpl::apply_wrap3<
+            typename Parameters::binding
+          , Keyword
+          , typename ::boost::parameter::aux::result_of0<DefaultFn>::type
+          , ::boost::mpl::false_
+        >::type type;
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
+    };
+}} // namespace boost::parameter
+
+#endif  // include guard
 

--- a/test/basics.hpp
+++ b/test/basics.hpp
@@ -18,12 +18,14 @@
 as 5 or greater.
 #endif
 
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/assert.hpp>
-#include <boost/assert.hpp>
-#include <boost/core/lightweight_test.hpp>
 #include <boost/type_traits/is_same.hpp>
+#endif
+
+#include <boost/core/lightweight_test.hpp>
 
 namespace test {
 
@@ -69,6 +71,20 @@ namespace test {
               , Index_ const& i_
             ) const
         {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            static_assert(
+                std::is_same<Index,Index_>::value
+              , "Index == Index_"
+            );
+            static_assert(
+                std::is_same<Value,Value_>::value
+              , "Value == Value_"
+            );
+            static_assert(
+                std::is_same<Name,Name_>::value
+              , "Name == Name_"
+            );
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
             BOOST_MPL_ASSERT((
                 typename boost::mpl::if_<
                     boost::is_same<Index,Index_>
@@ -90,6 +106,7 @@ namespace test {
                   , boost::mpl::false_
                 >::type
             ));
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
             BOOST_TEST(test::equal(n, n_));
             BOOST_TEST(test::equal(v, v_));
             BOOST_TEST(test::equal(i, i_));

--- a/test/compose.cpp
+++ b/test/compose.cpp
@@ -36,6 +36,11 @@ namespace param {
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/algorithm.hpp>
+#endif
+
 #if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function.hpp>
 #else
@@ -52,6 +57,82 @@ namespace test {
         template <typename ArgPack>
         A(ArgPack const& args) : i(args[param::a0]), j(args[param::a1])
         {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            static_assert(
+                boost::parameter::is_argument_pack_mp11<ArgPack>::value
+              , "args must model the ArgumentPack concept"
+            );
+            static_assert(
+                boost::mp11::mp_contains<ArgPack,param::tag::a0>::value
+              , "param::tag::a0 must be in ArgPack"
+            );
+            static_assert(
+                boost::mp11::mp_contains<ArgPack,param::tag::a1>::value
+              , "param::tag::a1 must be in ArgPack"
+            );
+            static_assert(
+                !boost::mp11::mp_contains<ArgPack,param::tag::lrc>::value
+              , "param::tag::lrc must not be in ArgPack"
+            );
+            static_assert(
+                !boost::mp11::mp_contains<ArgPack,param::tag::lr>::value
+              , "param::tag::lr must not be in ArgPack"
+            );
+            static_assert(
+                !boost::mp11::mp_contains<ArgPack,param::tag::rr>::value
+              , "param::tag::rr must not be in ArgPack"
+            );
+            static_assert(
+                1 == boost::mp11::mp_count<ArgPack,param::tag::a0>::value
+              , "param::tag::a0 must be in ArgPack exactly once"
+            );
+            static_assert(
+                1 == boost::mp11::mp_count<ArgPack,param::tag::a1>::value
+              , "param::tag::a1 must be in ArgPack exactly once"
+            );
+            static_assert(
+                0 == boost::mp11::mp_count<ArgPack,param::tag::lrc>::value
+              , "param::tag::lrc must be in ArgPack exactly zero times"
+            );
+            static_assert(
+                0 == boost::mp11::mp_count<ArgPack,param::tag::lr>::value
+              , "param::tag::lr must be in ArgPack exactly zero times"
+            );
+            static_assert(
+                0 == boost::mp11::mp_count<ArgPack,param::tag::rr>::value
+              , "param::tag::rr must be in ArgPack exactly zero times"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::a0>::value) < (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::a0 must be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::a1>::value) < (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::a1 must be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::lrc>::value) == (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::lrc must not be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::lr>::value) == (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::lr must not be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::rr>::value) == (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::rr must not be found in ArgPack"
+            );
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
             BOOST_MPL_ASSERT((boost::parameter::is_argument_pack<ArgPack>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::a0>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::a1>));
@@ -185,6 +266,110 @@ namespace test {
           , j(args[param::_lr])
           , k(args[param::_lrc])
         {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            static_assert(
+                boost::parameter::is_argument_pack_mp11<ArgPack>::value
+              , "args must model the ArgumentPack concept"
+            );
+            static_assert(
+                boost::mp11::mp_contains<ArgPack,param::tag::lrc>::value
+              , "param::tag::lrc must be in ArgPack"
+            );
+            static_assert(
+                boost::mp11::mp_contains<ArgPack,param::tag::lr>::value
+              , "param::tag::lr must be in ArgPack"
+            );
+            static_assert(
+                boost::mp11::mp_contains<ArgPack,param::tag::rr>::value
+              , "param::tag::rr must be in ArgPack"
+            );
+            static_assert(
+                !boost::mp11::mp_contains<ArgPack,param::tag::a0>::value
+              , "param::tag::a0 must not be in ArgPack"
+            );
+            static_assert(
+                !boost::mp11::mp_contains<ArgPack,param::tag::a1>::value
+              , "param::tag::a1 must not be in ArgPack"
+            );
+            static_assert(
+                !boost::mp11::mp_contains<ArgPack,param::tag::a2>::value
+              , "param::tag::a2 must not be in ArgPack"
+            );
+            static_assert(
+                !boost::mp11::mp_contains<ArgPack,param::tag::a3>::value
+              , "param::tag::a3 must not be in ArgPack"
+            );
+            static_assert(
+                1 == boost::mp11::mp_count<ArgPack,param::tag::rr>::value
+              , "param::tag::rr must be in ArgPack exactly once"
+            );
+            static_assert(
+                1 == boost::mp11::mp_count<ArgPack,param::tag::lr>::value
+              , "param::tag::lr must be in ArgPack exactly once"
+            );
+            static_assert(
+                1 == boost::mp11::mp_count<ArgPack,param::tag::lrc>::value
+              , "param::tag::lrc must be in ArgPack exactly once"
+            );
+            static_assert(
+                0 == boost::mp11::mp_count<ArgPack,param::tag::a0>::value
+              , "param::tag::a0 must be in ArgPack exactly zero times"
+            );
+            static_assert(
+                0 == boost::mp11::mp_count<ArgPack,param::tag::a1>::value
+              , "param::tag::a1 must be in ArgPack exactly zero times"
+            );
+            static_assert(
+                0 == boost::mp11::mp_count<ArgPack,param::tag::a2>::value
+              , "param::tag::a2 must be in ArgPack exactly zero times"
+            );
+            static_assert(
+                0 == boost::mp11::mp_count<ArgPack,param::tag::a3>::value
+              , "param::tag::a3 must be in ArgPack exactly zero times"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::lrc>::value) < (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::lrc must be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::lr>::value) < (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::lr must be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::rr>::value) < (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::rr must be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::a0>::value) == (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::a0 must not be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::a1>::value) == (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::a1 must not be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::a2>::value) == (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::a2 must not be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::a3>::value) == (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::a3 must not be found in ArgPack"
+            );
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
             BOOST_MPL_ASSERT((boost::parameter::is_argument_pack<ArgPack>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::rr>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::lr>));
@@ -311,6 +496,40 @@ namespace test {
           , j(args[param::_lr])
           , k(args[param::_lrc])
         {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+            static_assert(
+                boost::parameter::is_argument_pack_mp11<ArgPack>::value
+              , "args must model the ArgumentPack concept"
+            );
+            static_assert(
+                boost::mp11::mp_contains<ArgPack,param::tag::lrc>::value
+              , "param::tag::lrc must be in ArgPack"
+            );
+            static_assert(
+                boost::mp11::mp_contains<ArgPack,param::tag::lr>::value
+              , "param::tag::lr must be in ArgPack"
+            );
+            static_assert(
+                1 == boost::mp11::mp_count<ArgPack,param::tag::lr>::value
+              , "param::tag::lr must be in ArgPack exactly once"
+            );
+            static_assert(
+                1 == boost::mp11::mp_count<ArgPack,param::tag::lrc>::value
+              , "param::tag::lrc must be in ArgPack exactly once"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::lrc>::value) < (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::lrc must be found in ArgPack"
+            );
+            static_assert(
+                (boost::mp11::mp_find<ArgPack,param::tag::lr>::value) < (
+                    boost::mp11::mp_size<ArgPack>::value
+                )
+              , "param::tag::lr must be found in ArgPack"
+            );
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
             BOOST_MPL_ASSERT((boost::parameter::is_argument_pack<ArgPack>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::lr>));
             BOOST_MPL_ASSERT((boost::mpl::has_key<ArgPack,param::tag::lrc>));

--- a/test/deduced.cpp
+++ b/test/deduced.cpp
@@ -3,14 +3,19 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/parameter/config.hpp>
 #include <boost/parameter/parameters.hpp>
 #include <boost/parameter/name.hpp>
 #include <boost/parameter/binding.hpp>
+#include <boost/parameter/config.hpp>
+#include "deduced.hpp"
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_convertible.hpp>
-#include "deduced.hpp"
+#endif
 
 #if defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE)
 #include <boost/tti/detail/dnullptr.hpp>
@@ -26,6 +31,9 @@ namespace test {
     struct predicate
     {
         template <typename From, typename Args>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using fn = std::is_convertible<From,To>;
+#else
         struct apply
           : boost::mpl::if_<
                 boost::is_convertible<From,To>
@@ -34,6 +42,7 @@ namespace test {
             >
         {
         };
+#endif
     };
 } // namespace test
 

--- a/test/deduced_dependent_predicate.cpp
+++ b/test/deduced_dependent_predicate.cpp
@@ -7,6 +7,13 @@
 #include <boost/parameter/parameters.hpp>
 #include <boost/parameter/name.hpp>
 #include <boost/parameter/binding.hpp>
+#include "deduced.hpp"
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/bind.hpp>
+#include <boost/mp11/utility.hpp>
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/if.hpp>
@@ -16,8 +23,8 @@
 #include <boost/type_traits/remove_reference.hpp>
 #else
 #include <boost/type_traits/add_lvalue_reference.hpp>
-#endif  // Borland workarounds needed.
-#include "deduced.hpp"
+#endif  // Borland workarounds needed
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 
 namespace test {
 
@@ -35,6 +42,16 @@ int main()
             test::tag::x
           , boost::parameter::optional<
                 boost::parameter::deduced<test::tag::y>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+              , boost::mp11::mp_bind<
+                    std::is_same
+                  , boost::mp11::_1
+                  , boost::mp11::mp_bind<
+                        test::tag::x::binding_fn
+                      , boost::mp11::_2
+                    >
+                >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
               , boost::mpl::if_<
                     boost::is_same<
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
@@ -45,14 +62,15 @@ int main()
                               , test::tag::x
                             >
                         >
-#else   // !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#else
                         boost::add_lvalue_reference<boost::mpl::_1>
                       , boost::parameter::binding<boost::mpl::_2,test::tag::x>
-#endif  // Borland workarounds needed.
+#endif  // Borland workarounds needed
                     >
                   , boost::mpl::true_
                   , boost::mpl::false_
                 >
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
             >
         >
     >((test::_x = 0, test::_y = 1), 0, 1);
@@ -62,6 +80,16 @@ int main()
             test::tag::x
           , boost::parameter::optional<
                 boost::parameter::deduced<test::tag::y>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+              , boost::mp11::mp_bind<
+                    std::is_same
+                  , boost::mp11::_1
+                  , boost::mp11::mp_bind<
+                        test::tag::x::binding_fn
+                      , boost::mp11::_2
+                    >
+                >
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
               , boost::mpl::if_<
                     boost::is_same<
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
@@ -72,14 +100,15 @@ int main()
                               , test::tag::x
                             >
                         >
-#else   // !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#else
                         boost::add_lvalue_reference<boost::mpl::_1>
                       , boost::parameter::binding<boost::mpl::_2,test::tag::x>
-#endif  // Borland workarounds needed.
+#endif  // Borland workarounds needed
                     >
                   , boost::mpl::true_
                   , boost::mpl::false_
                 >
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
             >
         >
     >((test::_x = 0U, test::_y = 1U), 0U, 1U);
@@ -89,25 +118,41 @@ int main()
             test::tag::x
           , boost::parameter::optional<
                 boost::parameter::deduced<test::tag::y>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+              , boost::mp11::mp_bind<
+                    std::is_convertible
+                  , boost::mp11::_1
+                  , boost::mp11::mp_bind_q<test::tag::x,boost::mp11::_2>
+                >
+#else
               , boost::mpl::if_<
                     boost::is_convertible<boost::mpl::_1,test::tag::x::_>
                   , boost::mpl::true_
                   , boost::mpl::false_
                 >
+#endif
             >
         >
-    >((test::_x = 0U, test::_y = 1U), 0U, 1U);
+    >((test::_x = 0, test::_y = 1), 0, 1);
 
     test::check<
         boost::parameter::parameters<
             test::tag::x
           , boost::parameter::optional<
                 boost::parameter::deduced<test::tag::y>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+              , boost::mp11::mp_bind<
+                    std::is_convertible
+                  , boost::mp11::_1
+                  , boost::mp11::mp_bind_q<test::tag::x,boost::mp11::_2>
+                >
+#else
               , boost::mpl::if_<
                     boost::is_convertible<boost::mpl::_1,test::tag::x::_1>
                   , boost::mpl::true_
                   , boost::mpl::false_
                 >
+#endif
             >
         >
     >((test::_x = 0U, test::_y = 1U), 0U, 1U);

--- a/test/earwicker.cpp
+++ b/test/earwicker.cpp
@@ -24,6 +24,7 @@ namespace test {
     BOOST_PARAMETER_NAME(z)
 } // namespace test
 
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_convertible.hpp>
@@ -44,16 +45,38 @@ namespace test {
     };
 } // namespace test
 
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
+
 #include <boost/parameter/parameters.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/bind.hpp>
+#include <type_traits>
+#endif
 
 namespace test {
 
     struct f_parameters // vc6 is happier with inheritance than with a typedef
       : boost::parameter::parameters<
             boost::parameter::required<test::tag::w>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+          , boost::parameter::optional<
+                test::tag::x
+              , boost::mp11::mp_bind<std::is_convertible,boost::mp11::_1,int>
+            >
+          , boost::parameter::optional<
+                test::tag::y
+              , boost::mp11::mp_bind<std::is_convertible,boost::mp11::_1,int>
+            >
+          , boost::parameter::optional<
+                test::tag::z
+              , boost::mp11::mp_bind<std::is_convertible,boost::mp11::_1,int>
+            >
+#else
           , boost::parameter::optional<test::tag::x,test::f_predicate>
           , boost::parameter::optional<test::tag::y,test::f_predicate>
           , boost::parameter::optional<test::tag::z,test::f_predicate>
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
         >
     {
     };

--- a/test/evaluate_category.hpp
+++ b/test/evaluate_category.hpp
@@ -224,11 +224,16 @@ namespace test {
 } // namespace test
 
 #include <boost/parameter/value_type.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
+#endif
 
 namespace test {
 
@@ -236,6 +241,24 @@ namespace test {
     struct string_predicate
     {
         template <typename Arg, typename Args>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using fn = std::is_convertible<
+            Arg
+          , std::basic_string<
+                typename std::remove_const<
+                    typename std::remove_pointer<
+                        typename boost::parameter::value_type<
+                            Args
+                          , CharConstPtrParamTag
+#if !defined(LIBS_PARAMETER_TEST_COMPILE_FAILURE)
+                          , char const*
+#endif
+                        >::type
+                    >::type
+                >::type
+            >
+        >;
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
         struct apply
           : boost::mpl::if_<
                 boost::is_convertible<
@@ -259,6 +282,7 @@ namespace test {
             >
         {
         };
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
     };
 } // namespace test
 

--- a/test/function_type_tpl_param.cpp
+++ b/test/function_type_tpl_param.cpp
@@ -8,9 +8,15 @@
 #include <boost/parameter/parameters.hpp>
 #include <boost/parameter/required.hpp>
 #include <boost/parameter/value_type.hpp>
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_same.hpp>
+#endif
 
 namespace test {
     namespace keywords {
@@ -19,31 +25,47 @@ namespace test {
     } // namespace keywords
 
     template <typename K, typename A>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using X = boost::parameter::value_type<
+#else
     struct X
       : boost::parameter::value_type<
+#endif
             typename boost::parameter::parameters<
                 boost::parameter::required<K>
             >::BOOST_NESTED_TEMPLATE bind<A>::type
           , K
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    >;
+#else
         >
     {
     };
+#endif
 
     template <typename T>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    using Y = std::is_same<
+#else
     struct Y
       : boost::mpl::if_<
             boost::is_same<
+#endif
                 T
               , typename X<
                     test::keywords::tag::function_type
                   , test::keywords::function_type<T>
                 >::type
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    >;
+#else
             >
           , boost::mpl::true_
           , boost::mpl::false_
         >::type
     {
     };
+#endif
 
     struct Z
     {
@@ -54,13 +76,22 @@ namespace test {
     };
 } // namespace test
 
-#include <boost/mpl/assert.hpp>
 #include <boost/mpl/aux_/test.hpp>
+
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mpl/assert.hpp>
+#endif
 
 MPL_TEST_CASE()
 {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    static_assert(test::Y<void()>::value, "void()");
+    static_assert(test::Y<test::Z>::value, "test::Z");
+    static_assert(test::Y<double(double)>::value, "double(double)");
+#else
     BOOST_MPL_ASSERT((test::Y<void()>));
     BOOST_MPL_ASSERT((test::Y<test::Z>));
     BOOST_MPL_ASSERT((test::Y<double(double)>));
+#endif
 }
 

--- a/test/normalized_argument_types.cpp
+++ b/test/normalized_argument_types.cpp
@@ -58,10 +58,15 @@ namespace test {
 } // namespace test
 
 #include <boost/parameter/preprocessor.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_convertible.hpp>
+#endif
 
 namespace test {
 
@@ -74,6 +79,16 @@ namespace test {
         )
     )
     {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(
+            std::is_convertible<x_type,long>::value
+          , "is_convertible<x_type,long>"
+        );
+        static_assert(
+            std::is_convertible<y_type,long>::value
+          , "is_convertible<y_type,long>"
+        );
+#else
         BOOST_MPL_ASSERT((
             typename boost::mpl::if_<
                 boost::is_convertible<x_type,long>
@@ -88,6 +103,7 @@ namespace test {
               , boost::mpl::false_
             >::type
         ));
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
         return 0;
     }
 } // namespace test
@@ -102,6 +118,12 @@ namespace test {
         )
     )
     {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(
+            std::is_convertible<x_type,test::count_instances>::value
+          , "is_convertible<x_type,test::count_instances>"
+        );
+#else
         BOOST_MPL_ASSERT((
             typename boost::mpl::if_<
                 boost::is_convertible<x_type,test::count_instances>
@@ -109,6 +131,7 @@ namespace test {
               , boost::mpl::false_
             >::type
         ));
+#endif
         x.noop();
 #if !BOOST_WORKAROUND(BOOST_GCC, < 40000)
         BOOST_TEST_LT(0, test::count_instances::count);
@@ -122,6 +145,12 @@ namespace test {
         )
     )
     {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(
+            std::is_convertible<x_type,test::count_instances const>::value
+          , "is_convertible<x_type,test::count_instances const>"
+        );
+#else
         BOOST_MPL_ASSERT((
             typename boost::mpl::if_<
                 boost::is_convertible<x_type,test::count_instances const>
@@ -129,6 +158,7 @@ namespace test {
               , boost::mpl::false_
             >::type
         ));
+#endif
         x.noop();
 #if !BOOST_WORKAROUND(BOOST_GCC, < 40000)
         BOOST_TEST_EQ(1, test::count_instances::count);

--- a/test/preprocessor.cpp
+++ b/test/preprocessor.cpp
@@ -3,13 +3,18 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/parameter/config.hpp>
 #include <boost/parameter/preprocessor.hpp>
 #include <boost/parameter/binding.hpp>
+#include <boost/parameter/config.hpp>
+#include "basics.hpp"
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include "basics.hpp"
+#endif
 
 namespace test {
 
@@ -28,6 +33,12 @@ namespace test {
             Args,test::tag::index,int&
         >::type index_type;
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(
+            std::is_same<index_type,int&>::value
+          , "index_type == int&"
+        );
+#else
         BOOST_MPL_ASSERT((
             typename boost::mpl::if_<
                 boost::is_same<index_type,int&>
@@ -35,6 +46,7 @@ namespace test {
               , boost::mpl::false_
             >::type
         ));
+#endif
 
         args[test::_tester](
             args[test::_name]
@@ -47,7 +59,10 @@ namespace test {
 } // namespace test
 
 #include <boost/parameter/value_type.hpp>
+
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/type_traits/remove_const.hpp>
+#endif
 
 namespace test {
 
@@ -66,6 +81,15 @@ namespace test {
             Args,test::tag::index,int
         >::type index_type;
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(
+            std::is_same<
+                typename std::remove_const<index_type>::type
+              , int
+            >::value
+          , "remove_const<index_type>::type == int"
+        );
+#else
         BOOST_MPL_ASSERT((
             typename boost::mpl::if_<
                 boost::is_same<
@@ -76,6 +100,7 @@ namespace test {
               , boost::mpl::false_
             >::type
         ));
+#endif
 
         args[test::_tester](
             args[test::_name]
@@ -87,7 +112,9 @@ namespace test {
     }
 } // namespace test
 
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/type_traits/remove_reference.hpp>
+#endif
 
 namespace test {
 
@@ -102,7 +129,17 @@ namespace test {
         )
     )
     {
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(
+            std::is_same<
+                typename std::remove_const<
+                    typename std::remove_reference<index_type>::type
+                >::type
+              , int
+            >::value
+          , "remove_cref<index_type>::type == int"
+        );
+#elif !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
     !BOOST_WORKAROUND(BOOST_MSVC, <= 1300)
         BOOST_MPL_ASSERT((
             typename boost::mpl::if_<
@@ -116,7 +153,7 @@ namespace test {
               , boost::mpl::false_
             >::type
         ));
-#endif  // Borland/MSVC workarounds not needed.
+#endif  // BOOST_PARAMETER_CAN_USE_MP11 || Borland/MSVC workarounds not needed
 
         tester(name, value, index);
 
@@ -134,7 +171,17 @@ namespace test {
         )
     )
     {
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(
+            std::is_same<
+                typename std::remove_const<
+                    typename std::remove_reference<index_type>::type
+                >::type
+              , int
+            >::value
+          , "remove_cref<index_type>::type == int"
+        );
+#elif !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
     !BOOST_WORKAROUND(BOOST_MSVC, <= 1300)
         BOOST_MPL_ASSERT((
             typename boost::mpl::if_<
@@ -148,7 +195,7 @@ namespace test {
               , boost::mpl::false_
             >::type
         ));
-#endif  // Borland/MSVC workarounds not needed.
+#endif  // BOOST_PARAMETER_CAN_USE_MP11 || Borland/MSVC workarounds not needed
 
         tester(name, value, index);
 
@@ -161,7 +208,10 @@ namespace test {
 #if !defined(BOOST_NO_SFINAE)
 #include <boost/tti/detail/dnullptr.hpp>
 #include <boost/core/enable_if.hpp>
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/type_traits/is_base_of.hpp>
+#include <boost/type_traits/is_convertible.hpp>
+#endif
 #endif
 
 namespace test {
@@ -217,11 +267,15 @@ namespace test {
             Args const& args
 #if !defined(BOOST_NO_SFINAE)
           , typename boost::disable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+                std::is_base_of<base_1,Args>
+#else
                 typename boost::mpl::if_<
                     boost::is_base_of<base_1,Args>
                   , boost::mpl::true_
                   , boost::mpl::false_
                 >::type
+#endif
             >::type* = BOOST_TTI_DETAIL_NULLPTR
 #endif  // BOOST_NO_SFINAE
         )
@@ -380,11 +434,15 @@ namespace test {
     // about SFINAE-enabled code will work, except of course the SFINAE.
     template <typename A0>
     typename boost::enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        std::is_same<int,A0>
+#else
         typename boost::mpl::if_<
             boost::is_same<int,A0>
           , boost::mpl::true_
           , boost::mpl::false_
         >::type
+#endif
       , int
     >::type
         sfinae(A0 const& a0)
@@ -396,6 +454,9 @@ namespace test {
     struct predicate
     {
         template <typename T, typename Args>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using fn = std::is_convertible<T,std::string>;
+#else
         struct apply
           : boost::mpl::if_<
                 boost::is_convertible<T,std::string>
@@ -404,6 +465,7 @@ namespace test {
             >
         {
         };
+#endif
 
         BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR((bool), test::tag,
             (required
@@ -433,11 +495,15 @@ namespace test {
     // about SFINAE-enabled code will work, except of course the SFINAE.
     template <typename A0>
     typename boost::enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        std::is_same<int,A0>
+#else
         typename boost::mpl::if_<
             boost::is_same<int,A0>
           , boost::mpl::true_
           , boost::mpl::false_
         >::type
+#endif
       , int
     >::type
         sfinae1(A0 const& a0)

--- a/test/preprocessor_deduced.cpp
+++ b/test/preprocessor_deduced.cpp
@@ -7,16 +7,21 @@
 #include <boost/parameter/preprocessor.hpp>
 #include <boost/parameter/name.hpp>
 #include <boost/tuple/tuple.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/type_traits/is_convertible.hpp>
 #include <map>
 #include <string>
 #include "basics.hpp"
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/core/enable_if.hpp>
+#include <type_traits>
+#else
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 #if !defined(BOOST_NO_SFINAE)
 #include <boost/core/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
+#endif
 #endif
 
 namespace test {
@@ -26,12 +31,26 @@ namespace test {
     BOOST_PARAMETER_NAME(y)
     BOOST_PARAMETER_NAME(z)
 
-#if BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
-    // Sun has problems with this syntax:
-    //
-    //   template1< r* ( template2<x> ) >
-    //
-    // Workaround: factor template2<x> into separate typedefs
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    template <typename To>
+    struct predicate
+    {
+        template <typename From, typename Args>
+        using fn = std::is_convertible<From,To>;
+    };
+
+    BOOST_PARAMETER_FUNCTION((int), f, test::tag,
+        (required
+            (expected, *)
+        )
+        (deduced
+            (required
+                (x, *(test::predicate<int>))
+                (y, *(test::predicate<std::string>))
+            )
+        )
+    )
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
     struct predicate_int
     {
         template <typename From, typename Args>
@@ -69,33 +88,7 @@ namespace test {
             )
         )
     )
-#else   // !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
-    template <typename To>
-    struct predicate
-    {
-        template <typename From, typename Args>
-        struct apply
-          : boost::mpl::if_<
-                boost::is_convertible<From,To>
-              , boost::mpl::true_
-              , boost::mpl::false_
-            >
-        {
-        };
-    };
-
-    BOOST_PARAMETER_FUNCTION((int), f, test::tag,
-        (required
-            (expected, *)
-        )
-        (deduced
-            (required
-                (x, *(test::predicate<int>))
-                (y, *(test::predicate<std::string>))
-            )
-        )
-    )
-#endif  // SunPro CC workarounds needed.
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
     {
         BOOST_TEST(test::equal(x, boost::tuples::get<0>(expected)));
         BOOST_TEST(test::equal(y, boost::tuples::get<1>(expected)));
@@ -116,8 +109,22 @@ namespace test {
         int x;
     };
 
-#if BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
-    // SunPro workaround; see above
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    BOOST_PARAMETER_FUNCTION((int), g, test::tag,
+        (required
+            (expected, *)
+        )
+        (deduced
+            (required
+                (x, *(test::predicate<int>))
+                (y, *(test::predicate<std::string>))
+            )
+            (optional
+                (z, *(test::predicate<test::X>), test::X())
+            )
+        )
+    )
+#else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
     struct predicate_X
     {
         template <typename From, typename Args>
@@ -145,22 +152,7 @@ namespace test {
             )
         )
     )
-#else   // !BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
-    BOOST_PARAMETER_FUNCTION((int), g, test::tag,
-        (required
-            (expected, *)
-        )
-        (deduced
-            (required
-                (x, *(test::predicate<int>))
-                (y, *(test::predicate<std::string>))
-            )
-            (optional
-                (z, *(test::predicate<test::X>), test::X())
-            )
-        )
-    )
-#endif  // SunPro CC workarounds needed.
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
     {
         BOOST_TEST(test::equal(x, boost::tuples::get<0>(expected)));
         BOOST_TEST(test::equal(y, boost::tuples::get<1>(expected)));
@@ -168,11 +160,11 @@ namespace test {
         return 1;
     }
 
-#if BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x580))
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
     BOOST_PARAMETER_FUNCTION((int), sfinae, test::tag,
         (deduced
             (required
-                (x, *(test::predicate_string))
+                (x, *(test::predicate<std::string>))
             )
         )
     )
@@ -180,7 +172,7 @@ namespace test {
     BOOST_PARAMETER_FUNCTION((int), sfinae, test::tag,
         (deduced
             (required
-                (x, *(test::predicate<std::string>))
+                (x, *(test::predicate_string))
             )
         )
     )
@@ -197,11 +189,15 @@ namespace test {
     // about SFINAE-enabled code will work, except of course the SFINAE.
     template <typename A0>
     typename boost::enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        std::is_same<int,A0>
+#else
         typename boost::mpl::if_<
             boost::is_same<int,A0>
           , boost::mpl::true_
           , boost::mpl::false_
         >::type
+#endif
       , int
     >::type
         sfinae(A0 const& a0)

--- a/test/sfinae.cpp
+++ b/test/sfinae.cpp
@@ -15,7 +15,7 @@ as 3 or greater.
 #endif
 #endif
 
-#include <boost/parameter.hpp>
+#include <boost/parameter/name.hpp>
 
 namespace test {
 
@@ -23,9 +23,13 @@ namespace test {
     BOOST_PARAMETER_NAME((value, keywords) in(value))
 } // namespace test
 
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_convertible.hpp>
+#endif
 
 namespace test {
 
@@ -33,6 +37,9 @@ namespace test {
     struct f_predicate
     {
         template <typename From, typename Args>
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using fn = std::is_convertible<From,To>;
+#else
         struct apply
           : boost::mpl::if_<
                 boost::is_convertible<From,To>
@@ -41,9 +48,12 @@ namespace test {
             >
         {
         };
+#endif
     };
 } // namespace test
 
+#include <boost/parameter/parameters.hpp>
+#include <boost/parameter/optional.hpp>
 #include <string>
 
 namespace test {
@@ -116,9 +126,11 @@ namespace test {
 
 #if !defined(BOOST_NO_SFINAE) && \
     !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
-
 #include <boost/core/enable_if.hpp>
+
+#if !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/type_traits/is_same.hpp>
+#endif
 
 namespace test {
 
@@ -129,11 +141,15 @@ namespace test {
     // SFINAE-enabled code will work, except of course the SFINAE.
     template <typename A0, typename A1>
     typename boost::enable_if<
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        std::is_same<int,A0>
+#else
         typename boost::mpl::if_<
             boost::is_same<int,A0>
           , boost::mpl::true_
           , boost::mpl::false_
         >::type
+#endif
       , int
     >::type
         f(A0 const& a0, A1 const& a1)

--- a/test/singular.cpp
+++ b/test/singular.cpp
@@ -26,15 +26,38 @@ namespace test {
 } // namespace test
 
 #include <boost/parameter/is_argument_pack.hpp>
+#include <boost/parameter/config.hpp>
 #include <boost/mpl/has_key.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/core/lightweight_test.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/algorithm.hpp>
+#endif
 
 namespace test {
 
     template <typename ArgumentPack, typename K, typename T>
     void check0(ArgumentPack const& p, K const& kw, T const& value)
     {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(
+            boost::parameter::is_argument_pack_mp11<ArgumentPack>::value
+          , "p must model the ArgumentPack concept"
+        );
+        static_assert(
+            !boost::mp11::mp_contains<ArgumentPack,test::tag::z>::value
+          , "test::tag::z must not be in ArgumentPack"
+        );
+        static_assert(
+            0 == boost::mp11::mp_count<ArgumentPack,test::tag::z>::value
+          , "typename K::tag must not be found in ArgumentPack"
+        );
+        static_assert(
+            1 == boost::mp11::mp_find<ArgumentPack,test::tag::z>::value
+          , "typename K::tag must not be found in ArgumentPack"
+        );
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
         BOOST_MPL_ASSERT((boost::parameter::is_argument_pack<ArgumentPack>));
         BOOST_MPL_ASSERT_NOT((
             boost::mpl::has_key<ArgumentPack,test::tag::z>
@@ -51,12 +74,35 @@ namespace test {
 #include <boost/mpl/order.hpp>
 #include <boost/mpl/count.hpp>
 #include <boost/mpl/equal_to.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 namespace test {
 
     template <typename ArgumentPack, typename K, typename T>
     void check1(ArgumentPack const& p, K const& kw, T const& value)
     {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        static_assert(
+            boost::parameter::is_argument_pack_mp11<ArgumentPack>::value
+          , "p must model the ArgumentPack concept"
+        );
+        static_assert(
+            boost::mp11::mp_contains<ArgumentPack,typename K::tag>::value
+          , "typename K::tag must be in ArgumentPack"
+        );
+        static_assert(
+            !boost::mp11::mp_contains<ArgumentPack,test::tag::z>::value
+          , "test::tag::z must not be in ArgumentPack"
+        );
+        static_assert(
+            1 == boost::mp11::mp_count<ArgumentPack,typename K::tag>::value
+          , "typename K::tag must be in ArgumentPack exactly once"
+        );
+        static_assert(
+            0 == boost::mp11::mp_find<ArgumentPack,typename K::tag>::value
+          , "typename K::tag must be in ArgumentPack at index 0"
+        );
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
         BOOST_MPL_ASSERT((boost::parameter::is_argument_pack<ArgumentPack>));
         BOOST_MPL_ASSERT((boost::mpl::has_key<ArgumentPack,typename K::tag>));
         BOOST_MPL_ASSERT_NOT((

--- a/test/unwrap_cv_reference.cpp
+++ b/test/unwrap_cv_reference.cpp
@@ -5,14 +5,51 @@
 
 #include <boost/parameter/aux_/unwrap_cv_reference.hpp>
 #include <boost/parameter/config.hpp>
+#include <boost/mpl/aux_/test.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <type_traits>
+#else
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/assert.hpp>
-#include <boost/mpl/aux_/test.hpp>
 #include <boost/type_traits/is_same.hpp>
+#endif
 
 MPL_TEST_CASE()
 {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<int>::type
+          , int
+        >::value
+      , "unwrap_cv_reference<int>::type == int"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<int const>::type
+          , int const
+        >::value
+      , "unwrap_cv_reference<int const>::type == int const"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<int volatile>::type
+          , int volatile
+        >::value
+      , "unwrap_cv_reference<int volatile>::type == int volatile"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                int const volatile
+            >::type
+          , int const volatile
+        >::value
+      , "unwrap_cv_reference<int cv>::type == int cv"
+    );
+#else  // !defined(BOOST_PARAMETER_CAN_USE_MP11)
     BOOST_MPL_ASSERT((
         boost::mpl::if_<
             boost::is_same<
@@ -55,6 +92,7 @@ MPL_TEST_CASE()
           , boost::mpl::false_
         >::type
     ));
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }
 
 namespace test {
@@ -66,6 +104,40 @@ namespace test {
 
 MPL_TEST_CASE()
 {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<test::foo>::type
+          , test::foo
+        >::value
+      , "unwrap_cv_reference<test::foo>::type == test::foo"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<test::foo const>::type
+          , test::foo const
+        >::value
+      , "unwrap_cv_reference<test::foo const>::type == test::foo const"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                test::foo volatile
+            >::type
+          , test::foo volatile
+        >::value
+      , "unwrap_cv_reference<test::foo volatile>::type == test::foo volatile"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                test::foo const volatile
+            >::type
+          , test::foo const volatile
+        >::value
+      , "unwrap_cv_reference<test::foo cv>::type == test::foo cv"
+    );
+#else  // !defined(BOOST_PARAMETER_CAN_USE_MP11)
     BOOST_MPL_ASSERT((
         boost::mpl::if_<
             boost::is_same<
@@ -112,12 +184,51 @@ MPL_TEST_CASE()
           , boost::mpl::false_
         >::type
     ));
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }
 
 #include <boost/ref.hpp>
 
 MPL_TEST_CASE()
 {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                boost::reference_wrapper<test::foo>
+            >::type
+          , test::foo
+        >::value
+      , "unwrap_cv_reference<ref(test::foo)>::type == test::foo"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                boost::reference_wrapper<test::foo> const
+            >::type
+          , test::foo
+        >::value
+      , "unwrap_cv_reference<ref(test::foo) const>::type == test::foo"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                boost::reference_wrapper<test::foo> volatile
+            >::type
+          , test::foo
+        >::value
+      , "unwrap_cv_reference<ref(test::foo) volatile>::type == test::foo"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                boost::reference_wrapper<test::foo> const volatile
+            >::type
+          , test::foo
+        >::value
+      , "unwrap_cv_reference<ref(test::foo) cv>::type == test::foo"
+    );
+#else  // !defined(BOOST_PARAMETER_CAN_USE_MP11)
     BOOST_MPL_ASSERT((
         boost::mpl::if_<
             boost::is_same<
@@ -166,14 +277,52 @@ MPL_TEST_CASE()
           , boost::mpl::false_
         >::type
     ));
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }
 
 #if !defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
-
 #include <functional>
 
 MPL_TEST_CASE()
 {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                std::reference_wrapper<test::foo>
+            >::type
+          , test::foo
+        >::value
+      , "unwrap_cv_reference<std::ref(test::foo)>::type == test::foo"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                std::reference_wrapper<test::foo> const
+            >::type
+          , test::foo
+        >::value
+      , "unwrap_cv_reference<std::ref(test::foo) const>::type == test::foo"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                std::reference_wrapper<test::foo> volatile
+            >::type
+          , test::foo
+        >::value
+      , "unwrap_cv_reference<std::ref(test::foo) volatile>::type == test::foo"
+    );
+    static_assert(
+        std::is_same<
+            boost::parameter::aux::unwrap_cv_reference<
+                std::reference_wrapper<test::foo> const volatile
+            >::type
+          , test::foo
+        >::value
+      , "unwrap_cv_reference<std::ref(test::foo) cv>::type == test::foo"
+    );
+#else  // !defined(BOOST_PARAMETER_CAN_USE_MP11)
     BOOST_MPL_ASSERT((
         boost::mpl::if_<
             boost::is_same<
@@ -222,6 +371,7 @@ MPL_TEST_CASE()
           , boost::mpl::false_
         >::type
     ));
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 }
 
 #endif  // BOOST_NO_CXX11_HDR_FUNCTIONAL


### PR DESCRIPTION
* Add are_tagged_arguments_mp11 and is_argument_pack_mp11 metafunctions when Boost.MP11 is usable.
* Predicate requirements can be encoded as Boost.MP11-style quoted metafunctions as well as by MPL binary metafunction classes.
* Argument packs qualify as Boost.MP11-style lists as well as MPL sequences.
* Internal components and test programs use Boost.MP11 and C++11 type traits vice MPL and Boost.TypeTraits when Boost.MP11 is usable.