### PR TITLE
Improve support for parameter-dependent return types of functions generated by preprocessor macros

### DIFF
--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -1438,6 +1438,82 @@ href="../../test/deduced_dependent_predicate.cpp"
 >test/deduced_dependent_predicate.cpp</a> test programs demonstrate
 additional usage of deduced parameter support.</p>
 </div>
+<div class="section" id="parameter-dependent-return-types">
+<h4>2.1.5.8&nbsp;&nbsp;&nbsp;Parameter-Dependent Return Types</h4>
+<p>For some algorithms, the return type depends on at least one of the
+argument types.  However, there is one gotcha to avoid when encoding this
+return type while using <tt class="docutils literal"
+>BOOST_PARAMETER_FUNCTION</tt> or other code generation macros.  As an
+example, given the following definitions:</p>
+<pre class="literal-block">
+BOOST_PARAMETER_NAME(x)
+BOOST_PARAMETER_NAME(y)
+BOOST_PARAMETER_NAME(z)
+</pre>
+<p>Let our algorithm simply return one of its arguments.  If we naïvely
+implement its return type in terms of <tt class="docutils literal"
+>parameter::value_type</tt>:</p>
+<pre class="literal-block">
+BOOST_PARAMETER_FUNCTION(
+    (typename parameter::value_type&lt;Args,tag::y&gt;::type), return_y, tag,
+    (deduced
+        (required
+            (x, (std::map&lt;char const*,std::string&gt;))
+            (y, (char const*))
+        )
+        (optional
+            (z, (int), 4)
+        )
+    )
+)
+{
+    return y;
+}
+</pre>
+<p>Then using <tt class="docutils literal">return_y</tt> in any manner other
+than with positional arguments will result in a compiler error:</p>
+<pre class="literal-block">
+std::map&lt;char const*,std::string&gt; k2s;
+assert("foo" == return_y(2, k2s, "foo"));  // error!
+</pre>
+<p>The problem is that even though <tt class="docutils literal">y</tt> is a
+required parameter, <tt class="docutils literal">BOOST_PARAMETER_FUNCTION</tt>
+will generate certain overloads for which the argument pack type <tt
+class="docutils literal">Args</tt> does not actually contain the keyword tag
+type <tt class="docutils literal">tag::y</tt>.  The solution is to use SFINAE
+to preclude generation of those overloads.  Since <tt class="docutils literal"
+>parameter::value_type</tt> is a metafunction, our tool for the job is <tt
+class="docutils literal">lazy_enable_if</tt>:</p>
+<pre class="literal-block">
+BOOST_PARAMETER_FUNCTION(
+    (
+        // Whenever using 'enable_if', 'disable_if', and so on,
+        // do not add the 'typename' keyword in front.
+        boost::lazy_enable_if&lt;
+            typename mpl::has_key&lt;Args,tag::y&gt;::type
+          , parameter::value_type&lt;Args,tag::y&gt;
+        &gt;
+        // Whenever using 'enable_if', 'disable_if', and so on,
+        // do not add '::type' here.
+    ), return_y, tag,
+    (deduced
+        (required
+            (x, (std::map&lt;char const*,std::string&gt;))
+            (y, (char const*))
+        )
+        (optional
+            (z, (int), 4)
+        )
+    )
+)
+{
+    return y;
+}
+</pre>
+<p>For a working demonstration, see <a class="reference external"
+href="../../test/preprocessor_deduced.cpp"
+>test/preprocessor_deduced.cpp</a>.</p>
+</div>
 </div>
 </div>
 <div class="section" id="parameter-enabled-member-functions">

--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -2326,7 +2326,28 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_ ## __LINE__ ## <strong>name</strong> = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
 {
     typedef <strong>result</strong> type;
@@ -2920,7 +2941,28 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_ ## __LINE__ ## <strong>name</strong> = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
 {
     typedef <strong>result</strong> type;
@@ -3470,7 +3512,28 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_const_ ## __LINE__ ## <strong>name</strong> = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_const_ ## __LINE__ ## <strong>name</strong>
 {
     typedef <strong>result</strong> type;
@@ -3892,7 +3955,27 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_ ## __LINE__ ## operator = <strong>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_ ## __LINE__ ## operator
 {
     typedef <strong>result</strong> type;
@@ -4439,7 +4522,28 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_const_ ## __LINE__ ## operator = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_const_ ## __LINE__ ## operator
 {
     typedef <strong>result</strong> type;
@@ -5253,7 +5357,28 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_ ## __LINE__ ## <strong>name</strong> = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
 {
     typedef <strong>result</strong> type;
@@ -5693,7 +5818,28 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_ ## __LINE__ ## <strong>name</strong> = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_ ## __LINE__ ## <strong>name</strong>
 {
     typedef <strong>result</strong> type;
@@ -6130,7 +6276,28 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_const_ ## __LINE__ ## <strong>name</strong> = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_const_ ## __LINE__ ## <strong>name</strong>
 {
     typedef <strong>result</strong> type;
@@ -6435,7 +6602,27 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_ ## __LINE__ ## operator = <strong>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_ ## __LINE__ ## operator
 {
     typedef <strong>result</strong> type;
@@ -6861,7 +7048,28 @@ determined from <tt class="docutils literal">arguments</tt>.</li>
 determined from <tt class="docutils literal">arguments</tt>.</li>
 </ul>
 <pre class="last literal-block">
-template &lt;typename T&gt;
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename Args&gt;
+using boost_param_result_const_ ## __LINE__ ## operator = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
+template &lt;typename Args&gt;
 struct boost_param_result_const_ ## __LINE__ ## operator
 {
     typedef <strong>result</strong> type;
@@ -7143,6 +7351,27 @@ it determines the name of the generated implementation function.</li>
 <dt>Approximate expansion:</dt>
 <dd>
 <pre class="last literal-block">
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+using boost_param_no_spec_result_ ## __LINE__ ## <strong
+>name</strong> = <strong>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
 template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
 struct boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>
 {
@@ -7384,6 +7613,27 @@ and its helpers as not associated with any object of the enclosing type.</li>
 <dt>Approximate expansion:</dt>
 <dd>
 <pre class="last literal-block">
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+using boost_param_no_spec_result_ ## __LINE__ ## <strong
+>name</strong> = <strong>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
 template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
 struct boost_param_no_spec_result_ ## __LINE__ ## <strong>name</strong>
 {
@@ -7657,6 +7907,27 @@ it determines the name of the generated implementation function.</li>
 <dt>Approximate expansion:</dt>
 <dd>
 <pre class="last literal-block">
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+using boost_param_no_spec_result_const_ ## __LINE__ ## <strong
+>name</strong> = <strong>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
 template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
 struct boost_param_no_spec_result_const_ ## __LINE__ ## <strong>name</strong>
 {
@@ -7888,6 +8159,27 @@ of the function call operator.</li>
 <dt>Approximate expansion:</dt>
 <dd>
 <pre class="last literal-block">
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+using boost_param_no_spec_result_ ## __LINE__ ## operator = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
 template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
 struct boost_param_no_spec_result_ ## __LINE__ ## operator
 {
@@ -8156,6 +8448,27 @@ of the function call operator.</li>
 <dt>Approximate expansion:</dt>
 <dd>
 <pre class="last literal-block">
+// If <strong>result</strong> is a template instantiation of <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>enable_if</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_enable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_enable_if_c</a>, <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>disable_if_c</a>,
+// <a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">lazy_disable_if</a>, <a
+class="reference external" href="../../../core/doc/html/core/enable_if.html"
+>lazy_disable_if_c</a>, or <a class="reference external"
+href="http://en.cppreference.com/w/cpp/types/enable_if">std::enable_if</a>:
+template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
+using boost_param_no_spec_result_const_ ## __LINE__ ## operator = <strong
+>result</strong>;
+
+// If <strong>result</strong> is a simple return type:
 template &lt;typename TaggedArg0, typename ...TaggedArgs&gt;
 struct boost_param_no_spec_result_const_ ## __LINE__ ## operator
 {

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -1408,7 +1408,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result\_ ## __LINE__ ## **name** = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result\_ ## __LINE__ ## **name**
     {
         typedef **result** type;
@@ -1580,6 +1587,15 @@ Approximate expansion:
           , *argument name* ## **m** ## _type&& *argument name* ## **m**
         )
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 .. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
@@ -1866,7 +1882,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result\_ ## __LINE__ ## **name** = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result\_ ## __LINE__ ## **name**
     {
         typedef **result** type;
@@ -2000,6 +2023,15 @@ Approximate expansion:
           , *argument name* ## **m** ## _type&& *argument name* ## **m**
         )
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 .. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
@@ -2286,7 +2318,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result_const\_ ## __LINE__ ## **name** = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result_const\_ ## __LINE__ ## **name**
     {
         typedef **result** type;
@@ -2422,6 +2461,15 @@ Approximate expansion:
           , *argument name* ## **m** ## _type&& *argument name* ## **m**
         ) const
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 .. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
@@ -2603,7 +2651,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result\_ ## __LINE__ ## operator = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result\_ ## __LINE__ ## operator
     {
         typedef **result** type;
@@ -2737,6 +2792,15 @@ Approximate expansion:
           , *argument name* ## **m** ## _type&& *argument name* ## **m**
         )
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 .. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
@@ -3027,7 +3091,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result_const\_ ## __LINE__ ## operator = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result_const\_ ## __LINE__ ## operator
     {
         typedef **result** type;
@@ -3163,6 +3234,15 @@ Approximate expansion:
           , *argument name* ## **m** ## _type&& *argument name* ## **m**
         ) const
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 .. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
@@ -3647,7 +3727,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result\_ ## __LINE__ ## **name** = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result\_ ## __LINE__ ## **name**
     {
         typedef **result** type;
@@ -3710,6 +3797,15 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function body.
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_BASIC_MEMBER_FUNCTION(result, name, tag_ns, arguments)``
@@ -3987,7 +4083,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result\_ ## __LINE__ ## **name** = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result\_ ## __LINE__ ## **name**
     {
         typedef **result** type;
@@ -4046,6 +4149,15 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function body.
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_BASIC_CONST_MEMBER_FUNCTION(result, name, tag_ns, args)``
@@ -4326,7 +4438,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result_const\_ ## __LINE__ ## **name** = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result_const\_ ## __LINE__ ## **name**
     {
         typedef **result** type;
@@ -4385,6 +4504,15 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function body.
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_BASIC_FUNCTION_CALL_OPERATOR(result, tag_ns, arguments)``
@@ -4552,7 +4680,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result\_ ## __LINE__ ## operator = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result\_ ## __LINE__ ## operator
     {
         typedef **result** type;
@@ -4611,6 +4746,15 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function call operator body.
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_BASIC_CONST_FUNCTION_CALL_OPERATOR(result, tag_ns, args)``
@@ -4888,7 +5032,14 @@ Approximate expansion:
 
 .. parsed-literal::
 
-    template <typename T>
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename Args>
+    using boost_param_result_const\_ ## __LINE__ ## operator = **result**;
+
+    // If **result** is a simple return type:
+    template <typename Args>
     struct boost_param_result_const\_ ## __LINE__ ## operator
     {
         typedef **result** type;
@@ -4947,6 +5098,15 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function call operator body.
 
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
 .. _`forward`: http\://en.cppreference.com/w/cpp/utility/forward
 
 ``BOOST_PARAMETER_NO_SPEC_FUNCTION(result, name)``
@@ -5104,6 +5264,13 @@ None.
 Approximate expansion:
 .. parsed-literal::
 
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    using boost_param_no_spec_result\_ ## __LINE__ ## **name** = **result**;
+
+    // If **result** is a simple return type:
     template <typename TaggedArg0, typename ...TaggedArgs>
     struct boost_param_no_spec_result\_ ## __LINE__ ## **name**
     {
@@ -5149,8 +5316,16 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function body.
 
-.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
 .. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
+.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
 ``BOOST_PARAMETER_NO_SPEC_MEMBER_FUNCTION(result, name)``
 ---------------------------------------------------------
@@ -5308,6 +5483,13 @@ None.
 Approximate expansion:
 .. parsed-literal::
 
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    using boost_param_no_spec_result\_ ## __LINE__ ## **name** = **result**;
+
+    // If **result** is a simple return type:
     template <typename TaggedArg0, typename ...TaggedArgs>
     struct boost_param_no_spec_result\_ ## __LINE__ ## **name**
     {
@@ -5346,8 +5528,16 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function body.
 
-.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
 .. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
+.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
 ``BOOST_PARAMETER_NO_SPEC_CONST_MEMBER_FUNCTION(result, name)``
 ---------------------------------------------------------------
@@ -5515,6 +5705,13 @@ None.
 Approximate expansion:
 .. parsed-literal::
 
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    using boost_param_no_spec_result_const\_ ## __LINE__ ## **name** = **result**;
+
+    // If **result** is a simple return type:
     template <typename TaggedArg0, typename ...TaggedArgs>
     struct boost_param_no_spec_result_const\_ ## __LINE__ ## **name**
     {
@@ -5553,8 +5750,16 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function body.
 
-.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
 .. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
+.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
 ``BOOST_PARAMETER_NO_SPEC_FUNCTION_CALL_OPERATOR(result)``
 ----------------------------------------------------------
@@ -5708,6 +5913,13 @@ None.
 Approximate expansion:
 .. parsed-literal::
 
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    using boost_param_no_spec_result\_ ## __LINE__ ## operator = **result**;
+
+    // If **result** is a simple return type:
     template <typename TaggedArg0, typename ...TaggedArgs>
     struct boost_param_no_spec_result\_ ## __LINE__ ## operator
     {
@@ -5746,8 +5958,16 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function body.
 
-.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
 .. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
+.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
 ``BOOST_PARAMETER_NO_SPEC_CONST_FUNCTION_CALL_OPERATOR(result)``
 ----------------------------------------------------------------
@@ -5914,6 +6134,13 @@ None.
 Approximate expansion:
 .. parsed-literal::
 
+    // If **result** is a template instantiation of `enable_if`_, `enable_if_c`_,
+    // `lazy_enable_if`_, `lazy_enable_if_c`_, `disable_if`_, `disable_if_c`_,
+    // `lazy_disable_if`_, `lazy_disable_if_c`_, or `std_enable_if`_:
+    template <typename TaggedArg0, typename ...TaggedArgs>
+    using boost_param_no_spec_result_const\_ ## __LINE__ ## operator = **result**;
+
+    // If **result** is a simple return type:
     template <typename TaggedArg0, typename ...TaggedArgs>
     struct boost_param_no_spec_result_const\_ ## __LINE__ ## operator
     {
@@ -5955,8 +6182,16 @@ Approximate expansion:
 Only the |ArgumentPack|_ type ``Args`` and its object instance ``args`` are
 available for use within the function body.
 
-.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
+.. _`enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`enable_if_c`: ../../../core/doc/html/core/enable_if.html
 .. _`lazy_enable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_enable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if`: ../../../core/doc/html/core/enable_if.html
+.. _`lazy_disable_if_c`: ../../../core/doc/html/core/enable_if.html
+.. _`std_enable_if`: http\://en.cppreference.com/w/cpp/types/enable_if
+.. _`nullptr`: http\://en.cppreference.com/w/cpp/language/nullptr
 
 ``BOOST_PARAMETER_NO_SPEC_CONSTRUCTOR(cls, impl)``
 --------------------------------------------------

--- a/include/boost/parameter/aux_/preprocessor/impl/no_spec_overloads.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/no_spec_overloads.hpp
@@ -21,19 +21,29 @@
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 
-#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
+#include \
+<boost/parameter/aux_/preprocessor/impl/parenthesized_return_type.hpp>
 
 // Expands to the result metafunction for the specified no-spec function.
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#define BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, name, is_const)        \
+    template <typename TaggedArg0, typename ...TaggedArgs>                   \
+    using BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(name, is_const)       \
+    = typename BOOST_PARAMETER_PARENTHESIZED_RETURN_TYPE(result);
+/**/
+#else
 #define BOOST_PARAMETER_NO_SPEC_FUNCTION_HEAD(result, name, is_const)        \
     template <typename TaggedArg0, typename ...TaggedArgs>                   \
     struct BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(name, is_const)      \
+      : BOOST_PARAMETER_PARENTHESIZED_RETURN_TYPE(result)                    \
     {                                                                        \
-        typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
     };
 /**/
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 
 #include <boost/parameter/compose.hpp>
 #include <boost/parameter/are_tagged_arguments.hpp>
+#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
 #include <boost/core/enable_if.hpp>
 
 // Exapnds to a variadic constructor that is enabled if and only if all its

--- a/include/boost/parameter/aux_/preprocessor/impl/no_spec_overloads.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/no_spec_overloads.hpp
@@ -21,8 +21,7 @@
 
 #if defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 
-#include \
-<boost/parameter/aux_/preprocessor/impl/parenthesized_return_type.hpp>
+#include <boost/parameter/aux_/preprocessor/impl/parenthesized_return_type.hpp>
 
 // Expands to the result metafunction for the specified no-spec function.
 #if defined(BOOST_PARAMETER_CAN_USE_MP11)
@@ -118,7 +117,7 @@
 #else   // !defined(BOOST_PARAMETER_HAS_PERFECT_FORWARDING)
 
 #include <boost/parameter/aux_/void.hpp>
-#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
+#include <boost/parameter/aux_/preprocessor/impl/parenthesized_return_type.hpp>
 #include <boost/preprocessor/facilities/intercept.hpp>
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
 
@@ -132,12 +131,13 @@
         )                                                                    \
     >                                                                        \
     struct BOOST_PARAMETER_NO_SPEC_FUNCTION_RESULT_NAME(name, is_const)      \
+      : BOOST_PARAMETER_PARENTHESIZED_RETURN_TYPE(result)                    \
     {                                                                        \
-        typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
     };
 /**/
 
 #include <boost/parameter/compose.hpp>
+#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
 #include <boost/preprocessor/control/expr_if.hpp>
 #include <boost/preprocessor/repetition/enum_params.hpp>

--- a/include/boost/parameter/aux_/preprocessor/impl/parenthesized_return_type.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/parenthesized_return_type.hpp
@@ -1,0 +1,122 @@
+// Copyright Cromwell D. Enage 2019.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_PARENTHESIZED_RETURN_TYPE_HPP
+#define BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_PARENTHESIZED_RETURN_TYPE_HPP
+
+namespace boost { namespace parameter { namespace aux {
+
+    // A metafunction that transforms void(*)(T) -> identity<T>
+    template <typename UnaryFunctionPointer>
+    struct unaryfunptr_return_type;
+}}} // namespace boost::parameter::aux
+
+#include <boost/parameter/config.hpp>
+
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#include <boost/mp11/utility.hpp>
+#else
+#include <boost/mpl/identity.hpp>
+#endif
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename Arg>
+    struct unaryfunptr_return_type<void(*)(Arg)>
+    {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_identity<Arg>;
+#else
+        typedef ::boost::mpl::identity<Arg> type;
+#endif
+    };
+
+    template <>
+    struct unaryfunptr_return_type<void(*)(void)>
+    {
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+        using type = ::boost::mp11::mp_identity<void>;
+#else
+        typedef ::boost::mpl::identity<void> type;
+#endif
+    };
+}}} // namespace boost::parameter::aux
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/core/enable_if.hpp>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <typename Pred, typename Ret>
+    struct unaryfunptr_return_type<void(*)(::boost::enable_if<Pred,Ret>)>
+    {
+        typedef ::boost::enable_if<Pred,Ret> type;
+    };
+
+    template <bool b, typename Ret>
+    struct unaryfunptr_return_type<void(*)(::boost::enable_if_c<b,Ret>)>
+    {
+        typedef ::boost::enable_if_c<b,Ret> type;
+    };
+
+    template <typename Pred, typename Ret>
+    struct unaryfunptr_return_type<void(*)(::boost::lazy_enable_if<Pred,Ret>)>
+    {
+        typedef ::boost::lazy_enable_if<Pred,Ret> type;
+    };
+
+    template <bool b, typename Ret>
+    struct unaryfunptr_return_type<void(*)(::boost::lazy_enable_if_c<b,Ret>)>
+    {
+        typedef ::boost::lazy_enable_if_c<b,Ret> type;
+    };
+
+    template <typename Pred, typename Ret>
+    struct unaryfunptr_return_type<void(*)(::boost::disable_if<Pred,Ret>)>
+    {
+        typedef ::boost::disable_if<Pred,Ret> type;
+    };
+
+    template <bool b, typename Ret>
+    struct unaryfunptr_return_type<void(*)(::boost::disable_if_c<b,Ret>)>
+    {
+        typedef ::boost::disable_if_c<b,Ret> type;
+    };
+
+    template <typename B, typename Ret>
+    struct unaryfunptr_return_type<void(*)(::boost::lazy_disable_if<B,Ret>)>
+    {
+        typedef ::boost::lazy_disable_if<B,Ret> type;
+    };
+
+    template <bool b, typename Ret>
+    struct unaryfunptr_return_type<void(*)(::boost::lazy_disable_if_c<b,Ret>)>
+    {
+        typedef ::boost::lazy_disable_if_c<b,Ret> type;
+    };
+}}} // namespace boost::parameter::aux
+
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+#include <type_traits>
+
+namespace boost { namespace parameter { namespace aux {
+
+    template <bool b, typename Ret>
+    struct unaryfunptr_return_type<void(*)(::std::enable_if<b,Ret>)>
+    {
+        typedef ::std::enable_if<b,Ret> type;
+    };
+}}} // namespace boost::parameter::aux
+
+#endif  // BOOST_NO_CXX11_HDR_TYPE_TRAITS
+#endif  // BOOST_NO_SFINAE
+
+// A macro that takes a parenthesized C++ type name (T) and transforms it
+// into an un-parenthesized type expression equivalent to identity<T>.
+#define BOOST_PARAMETER_PARENTHESIZED_RETURN_TYPE(x)                         \
+    ::boost::parameter::aux::unaryfunptr_return_type< void(*)x >::type
+
+#endif  // include guard
+

--- a/include/boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp
@@ -6,7 +6,7 @@
 #ifndef BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_PARENTHESIZED_TYPE_HPP
 #define BOOST_PARAMETER_AUX_PREPROCESSOR_IMPL_PARENTHESIZED_TYPE_HPP
 
-namespace boost { namespace parameter { namespace aux { 
+namespace boost { namespace parameter { namespace aux {
 
     // A metafunction that transforms void(*)(T) -> T
     template <typename UnaryFunctionPointer>

--- a/include/boost/parameter/preprocessor.hpp
+++ b/include/boost/parameter/preprocessor.hpp
@@ -30,18 +30,30 @@
     )
 /**/
 
-#include <boost/parameter/aux_/preprocessor/impl/parenthesized_type.hpp>
+#include \
+<boost/parameter/aux_/preprocessor/impl/parenthesized_return_type.hpp>
+#include <boost/parameter/config.hpp>
 
 // Expands to the result metafunction and the parameters specialization.
+#if defined(BOOST_PARAMETER_CAN_USE_MP11)
+#define BOOST_PARAMETER_FUNCTION_HEAD(result, name, tag_ns, args, is_const)  \
+    template <typename Args>                                                 \
+    using BOOST_PARAMETER_FUNCTION_RESULT_NAME(name, is_const)               \
+    = typename BOOST_PARAMETER_PARENTHESIZED_RETURN_TYPE(result);            \
+    BOOST_PARAMETER_SPECIFICATION(tag_ns, name, args, is_const)              \
+        BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(name, is_const);
+/**/
+#else
 #define BOOST_PARAMETER_FUNCTION_HEAD(result, name, tag_ns, args, is_const)  \
     template <typename Args>                                                 \
     struct BOOST_PARAMETER_FUNCTION_RESULT_NAME(name, is_const)              \
+      : BOOST_PARAMETER_PARENTHESIZED_RETURN_TYPE(result)                    \
     {                                                                        \
-        typedef typename BOOST_PARAMETER_PARENTHESIZED_TYPE(result) type;    \
     };                                                                       \
     BOOST_PARAMETER_SPECIFICATION(tag_ns, name, args, is_const)              \
         BOOST_PARAMETER_FUNCTION_SPECIFICATION_NAME(name, is_const);
 /**/
+#endif  // BOOST_PARAMETER_CAN_USE_MP11
 
 // Helper macro for BOOST_PARAMETER_BASIC_FUNCTION.
 #define BOOST_PARAMETER_BASIC_FUNCTION_AUX(result, name, tag_ns, args)       \

--- a/include/boost/parameter/preprocessor.hpp
+++ b/include/boost/parameter/preprocessor.hpp
@@ -30,8 +30,7 @@
     )
 /**/
 
-#include \
-<boost/parameter/aux_/preprocessor/impl/parenthesized_return_type.hpp>
+#include <boost/parameter/aux_/preprocessor/impl/parenthesized_return_type.hpp>
 #include <boost/parameter/config.hpp>
 
 // Expands to the result metafunction and the parameters specialization.

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -248,6 +248,14 @@ alias parameter_standard_tests
         :
             evaluate_category_fail
     ]
+    [ compile-fail preprocessor_deduced.cpp
+        :
+            <define>BOOST_PARAMETER_MAX_ARITY=4
+            <define>BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY=5
+            <define>LIBS_PARAMETER_TEST_COMPILE_FAILURE
+        :
+            preprocessor_deduced_fail
+    ]
     [ compile-fail deduced.cpp
         :
             <define>BOOST_PARAMETER_MAX_ARITY=4


### PR DESCRIPTION
The code generation macros are supposed to support parameter-dependent return types, but it turns out that they currently don't really do that.  This commit fixes the issue.