### PR TITLE
Set BOOST_PARAMETER_COMPOSE_MAX_ARITY to 20 for MinGW

### DIFF
--- a/include/boost/parameter/config.hpp
+++ b/include/boost/parameter/config.hpp
@@ -65,8 +65,11 @@
 #define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY 0
 #endif
 #if !defined(BOOST_PARAMETER_COMPOSE_MAX_ARITY)
-#if BOOST_WORKAROUND(BOOST_MSVC, < 1800)
-// Some tests cause MSVC-11.0 and earlier to run out of heap space
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1800) || ( \
+        defined(__MINGW32__) && (__GNUC__ < 6) \
+    )
+// Some tests cause MSVC-11.0 and earlier to run out of heap space, while
+// some other tests cause MinGW with GCC 5 and earlier to do the same,
 // if the value is set any higher. -- Cromwell D. Enage
 #define BOOST_PARAMETER_COMPOSE_MAX_ARITY 20
 #else

--- a/include/boost/parameter/config.hpp
+++ b/include/boost/parameter/config.hpp
@@ -65,11 +65,10 @@
 #define BOOST_PARAMETER_EXPONENTIAL_OVERLOAD_THRESHOLD_ARITY 0
 #endif
 #if !defined(BOOST_PARAMETER_COMPOSE_MAX_ARITY)
-#if BOOST_WORKAROUND(BOOST_MSVC, < 1800) || ( \
-        defined(__MINGW32__) && (__GNUC__ < 6) \
-    )
-// Some tests cause MSVC-11.0 and earlier to run out of heap space, while
-// some other tests cause MinGW with GCC 5 and earlier to do the same,
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1800) || \
+    BOOST_WORKAROUND(BOOST_GCC, < 60000)
+// Some tests cause MSVC-11.0 and earlier to run out of heap space,
+// while some other tests cause GCC 5 and earlier to do the same,
 // if the value is set any higher. -- Cromwell D. Enage
 #define BOOST_PARAMETER_COMPOSE_MAX_ARITY 20
 #else


### PR DESCRIPTION
In my GitHub fork of Boost.Graph, I've been upgrading some algorithms to use BOOST_PARAMETER_FUNCTION, but MinGW with GCC 5.3.0 has been running out of heap space on some of the affected tests.  The goal of this commit is to eliminate these occurrences.