### PR TITLE
Add metafunction result_of::compose

### DIFF
--- a/doc/html/reference.html
+++ b/doc/html/reference.html
@@ -109,6 +109,9 @@ src="../../../../boost.png" /></a></p>
 <li><a class="reference internal" href="#is-argument-pack" id="id50"
 >5.5&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
 >is_argument_pack</tt></a></li>
+<li><a class="reference internal" href="#result-of-compose" id="id51"
+>5.6&nbsp;&nbsp;&nbsp;<tt class="docutils literal"
+>result_of::compose</tt></a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#function-templates" id="id53"
@@ -1604,7 +1607,7 @@ default</a>.</p>
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field">
-<th class="field-name">Defined n:</th>
+<th class="field-name">Defined in:</th>
 <td class="field-body"><a class="reference external"
 href="../../../../boost/parameter/value_type.hpp"
 >boost/parameter/value_type.hpp</a></td>
@@ -1832,6 +1835,68 @@ href="../../../type_traits/doc/html/boost_typetraits/is_convertible.html"
 </tbody>
 </table>
 </div>
+<div class="section" id="result-of-compose">
+<h2><a class="toc-backref" href="#id51">5.6&nbsp;&nbsp;&nbsp;<tt
+class="docutils literal">result_of::compose</tt></a></h2>
+<p>Returns the result type of the <a class="reference internal"
+href="#compose">compose()</a> function.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Defined in:</th>
+<td class="field-body"><a class="reference external"
+href="../../../../boost/parameter/compose.hpp"
+>boost/parameter/compose.hpp</a></td>
+</tr>
+</tbody>
+</table>
+<pre class="literal-block">
+namespace boost { namespace parameter { namespace result_of {
+
+template &lt;typename ...TaggedArgs&gt;
+struct compose
+  : boost::<a class="reference external"
+href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
+        <a class="reference internal" href="#are-tagged-arguments"
+>are_tagged_arguments</a>&lt;T0,Pack...&gt;
+      , <a class="reference internal" href="#argumentpack"><span
+class="concept">ArgumentPack</span></a>
+    &gt;
+{
+};
+
+template &lt;&gt;
+struct compose&lt;&gt;
+{
+    typedef <em>empty</em> <a class="reference internal" href="#argumentpack"
+><span class="concept">ArgumentPack</span></a> type;
+};
+}}}
+</pre>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field">
+<th class="field-name">Requires:</th>
+<td class="field-body">
+<p class="first">All elements in <tt class="docutils literal">TaggedArgs</tt>
+must be <a class="reference internal" href="#tagged-reference">tagged
+reference</a> types, if specified.</p>
+</td>
+</tr>
+<tr class="field">
+<th class="field-name">Returns:</th>
+<td class="field-body">
+<p class="last">the result type of the <a class="reference internal"
+href="#compose">compose()</a> function.</p>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
 </div>
 <hr class="docutils" />
 <div class="section" id="function-templates">
@@ -1853,18 +1918,10 @@ href="../../../../boost/parameter/compose.hpp"
 </tbody>
 </table>
 <pre class="literal-block">
-constexpr <em>empty</em> <a class="reference internal" href="#argumentpack"
-><span class="concept">ArgumentPack</span></a> compose();
-
-template &lt;typename T0, typename ...Pack&gt;
-constexpr typename boost::<a class="reference external"
-href="../../../core/doc/html/core/enable_if.html">enable_if</a>&lt;
-    <a class="reference internal" href="#are-tagged-arguments"
->are_tagged_arguments</a>&lt;T0,Pack...&gt;
-  , <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a>
-&gt;::type
-    compose(T0 const&amp; t0, Pack const&amp;... args);
+template &lt;typename ...Pack&gt;
+constexpr typename <a class="reference internal" href="#result-of-compose"
+>result_of::compose</a>&lt;Pack...&gt;::type
+    compose(Pack const&amp;... args);
 </pre>
 <p>This function facilitates easier variadic argument composition.  It is used
 by the <a class="reference internal"
@@ -1909,17 +1966,16 @@ for compilers that do not support perfect forwarding.</p>
 <tr class="field">
 <th class="field-name">Requires:</th>
 <td class="field-body">
-<p class="first"><tt class="docutils literal">t0</tt> and all elements in <tt
-class="docutils literal">args</tt> must be <a class="reference internal"
-href="#tagged-reference">tagged reference</a> objects, if specified.</p>
+<p class="first">All elements in <tt class="docutils literal">args</tt> must
+be <a class="reference internal" href="#tagged-reference">tagged reference</a>
+objects, if specified.</p>
 </td>
 </tr>
 <tr class="field">
 <th class="field-name">Returns:</th>
 <td class="field-body">
 <p class="first">An <a class="reference internal" href="#argumentpack"><span
-class="concept">ArgumentPack</span></a> containing <tt
-class="docutils literal">t0</tt> and all elements in <tt
+class="concept">ArgumentPack</span></a> containing all elements in <tt
 class="docutils literal">args</tt>, if specified; an empty <a
 class="reference internal" href="#argumentpack"><span class="concept"
 >ArgumentPack</span></a> otherwise.</p>

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -1051,6 +1051,37 @@ in conjunction with ``enable_if``.
 
 .. _`is_convertible`: ../../../type_traits/doc/html/boost_typetraits/is_convertible.html
 
+``result_of::compose``
+----------------------
+
+Returns the result type of the |compose|_ function.
+
+:Defined in: `boost/parameter/compose.hpp`__
+
+__ ../../../../boost/parameter/compose.hpp
+
+.. parsed-literal::
+
+    template <typename ...TaggedArgs>
+    struct compose
+      : boost::`enable_if`_<
+            |are_tagged_arguments|_<T0,Pack...>
+          , |ArgumentPack|_
+        >
+    {
+    };
+
+    template <>
+    struct compose<>
+    {
+        typedef *empty* |ArgumentPack|_ type;
+    };
+
+:Requires: All elements in ``TaggedArgs`` must be |tagged reference| types, if
+specified.
+
+:Returns: the result type of the |compose|_ function.
+
 //////////////////////////////////////////////////////////////////////////////
 
 Function Templates
@@ -1065,14 +1096,9 @@ __ ../../../../boost/parameter/compose.hpp
 
 .. parsed-literal::
 
-    constexpr *empty* |ArgumentPack|_ compose();
-
-    template <typename T0, typename ...Pack>
-    constexpr typename boost::`enable_if`_<
-        |are_tagged_arguments|_<T0,Pack...>
-      , |ArgumentPack|_
-    >::type
-        compose(T0 const& t0, Pack const&... args);
+    template <typename ...Pack>
+    constexpr typename |result_of::compose|_<Pack...>::type
+        compose(Pack const&... args);
 
 This function facilitates easier variadic argument composition.  It is used by
 the |BOOST_PARAMETER_NO_SPEC_FUNCTION|,
@@ -1092,11 +1118,11 @@ resulting |ArgumentPack|, while the ``compose()`` function cannot take in more
 than |BOOST_PARAMETER_COMPOSE_MAX_ARITY| arguments for compilers that do not
 support perfect forwarding.
 
-:Requires: ``t0`` and all elements in ``args`` must be |tagged reference|
-objects, if specified.
+:Requires: All elements in ``args`` must be |tagged reference| objects, if
+specified.
 
-:Returns: an |ArgumentPack|_ containing ``t0`` and all elements in ``args``,
-if specified; an empty |ArgumentPack|_ otherwise.
+:Returns: an |ArgumentPack|_ containing all elements in ``args``, if
+specified; an empty |ArgumentPack|_ otherwise.
 
 :Example usage:
 .. parsed-literal::


### PR DESCRIPTION
Some Boost.Graph algorithms return one of their optional named function parameters.  If the user doesn't specify the parameter, then the default return type must necessarily be different.  This metafunction is needed to help facilitate computation of such a return type without resorting to decltype(), which not all compilers support.