### PR TITLE
Add minimal cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Parameter is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required( VERSION 3.5 )
+project( BoostParameter LANGUAGES CXX)
+
+add_library( boost_parameter INTERFACE )
+add_library( Boost::parameter ALIAS boost_parameter )
+
+target_include_directories( boost_parameter INTERFACE include )
+
+target_link_libraries( boost_parameter
+    INTERFACE
+        Boost::config
+        Boost::core
+        Boost::function
+        Boost::fusion
+		# TODO: we only need mp11 or mpl
+		Boost::mp11
+        Boost::mpl
+        Boost::optional
+        Boost::preprocessor
+        Boost::type_traits
+        Boost::utility
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@
 cmake_minimum_required( VERSION 3.5 )
 project( BoostParameter LANGUAGES CXX)
 
+option(BOOST_PARAMETER_INCLUDE_TESTS OFF "Include Boost.Parameter tests")
+
 add_library( boost_parameter INTERFACE )
 add_library( Boost::parameter ALIAS boost_parameter )
 
@@ -28,3 +30,7 @@ target_link_libraries( boost_parameter
         Boost::utility
 )
 
+if(BOOST_PARAMETER_INCLUDE_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ target_link_libraries( boost_parameter
         Boost::core
         Boost::function
         Boost::fusion
-		# TODO: we only need mp11 or mpl
-		Boost::mp11
+        # TODO: we only need mp11 or mpl
+        Boost::mp11
         Boost::mpl
         Boost::optional
         Boost::preprocessor

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,8 +19,8 @@ foreach(file IN LISTS test_files)
     set(test_name test_boost_parameter_${core_name})
 
     add_executable(${test_name} ${file})
-    # add Boost.Parameter and any libraries that are only needed by the tests
-    target_link_libraries(${test_name} Boost::parameter Boost::core)
+    # add Boost.Parameter and any libraries that are only needed by the tests (none at the moment)
+    target_link_libraries(${test_name} Boost::parameter)
 
     add_test(NAME ${test_name} COMMAND ${test_name})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Parameter is currently experimental at best
+#       and the interface is likely to change in the future
+
+# TODO: Also process literate tests
+file(GLOB test_files *.cpp)
+
+# remove some test for which the dependencies are not yet available or have special requirements
+# TODO: enable more tests
+list(FILTER test_files EXCLUDE REGEX
+    efficiency|deduced_unmatched_arg|python_test|duplicates)
+
+foreach(file IN LISTS test_files)
+
+    get_filename_component(core_name ${file} NAME_WE)
+    set(test_name test_boost_parameter_${core_name})
+
+    add_executable(${test_name} ${file})
+    # add Boost.Parameter and any libraries that are only needed by the tests
+    target_link_libraries(${test_name} Boost::parameter Boost::core)
+
+    add_test(NAME ${test_name} COMMAND ${test_name})
+
+endforeach()


### PR DESCRIPTION
Functionality:

- CMake file only supports add_subdirectory workflow.
- Provides target `Boost::parameter` to "link" against (effectively providing the include directory of parameter and information about its dependencies).
- Allows compilation and running of most of the unit tests. 
- Doesn't support installation (That is taken care of via b2).

For basic testing:

1) Make sure you have checked out the latest (develop) version of all other boost libraries you are depending on (directly or indirectly) into sibling folders of this library (e.g. recursively check out branch develop of boostorg/boost).

2) Copy a file like the one in: https://github.com/boostorg/boost/pull/193/files into the boost root directory. Essentially, that file will simply call `add_subdirectory( )` on all boost libraries with a cmake file to make sure all dependencies are known to cmake. However, it will also ignore some libraries that are known to be troublesome with the add_subdirectory workflow.

3) Then (from boost root)

      mkdir __build__ 
      cd __build__
      cmake -DBOOST_PARAMETER_INCLUDE_TESTS=ON ..
      cmake --build .
      ctest .

