### PR TITLE
Upgrade .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://boost.org/LICENSE_1_0.txt)
 
+dist: xenial
 language: cpp
 
 python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,7 +189,7 @@ matrix:
             - clang-4.0
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
+            - llvm-toolchain-xenial-4.0
 
     - os: linux
       compiler: clang++-5.0
@@ -200,36 +200,49 @@ matrix:
             - clang-5.0
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
+            - llvm-toolchain-xenial-5.0
 
     - os: linux
       compiler: clang++-6.0
-      env: TOOLSET=clang COMPILER=clang++-6.0 CXXSTD=03,11,14,1z
+      env: TOOLSET=clang COMPILER=clang++-6.0 CXXSTD=03,11,14,1z,2a
       addons:
         apt:
           packages:
             - clang-6.0
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
-
-    - os: linux
-      compiler: clang++
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
-      addons:
-        apt:
-          packages:
-            - libstdc++-5-dev
-          sources:
-            - ubuntu-toolchain-r-test
-
-    - os: linux
-      compiler: clang++-libc++
-      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=03,11,14,1z
-      addons:
-        apt:
-          packages:
+            - libc6-dbg
             - libc++-dev
+            - libstdc++-8-dev
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-xenial-6.0
+
+    - os: linux
+      compiler: clang++-7
+      env: TOOLSET=clang COMPILER=clang++-7 CXXSTD=14,1z,2a
+      addons:
+        apt:
+          packages:
+            - clang-7
+            - libc6-dbg
+            - libc++-dev
+            - libstdc++-8-dev
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-xenial-7
+
+    - os: linux
+      compiler: clang++-8
+      env: TOOLSET=clang COMPILER=clang++-8 CXXSTD=14,1z,2a
+      addons:
+        apt:
+          packages:
+            - clang-8
+            - libc6-dbg
+            - libc++-dev
+            - libstdc++-8-dev
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-xenial-8
 
     - os: osx
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,7 +190,7 @@ matrix:
             - clang-4.0
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-4.0
+            - llvm-toolchain-trusty-4.0
 
     - os: linux
       compiler: clang++-5.0
@@ -201,7 +201,7 @@ matrix:
             - clang-5.0
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-5.0
+            - llvm-toolchain-trusty-5.0
 
     - os: linux
       compiler: clang++-6.0
@@ -215,7 +215,7 @@ matrix:
             - libstdc++-8-dev
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-6.0
+            - llvm-toolchain-trusty-6.0
 
     - os: linux
       compiler: clang++-7
@@ -229,7 +229,7 @@ matrix:
             - libstdc++-8-dev
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-7
+            - llvm-toolchain-trusty-7
 
     - os: linux
       compiler: clang++-8
@@ -243,7 +243,7 @@ matrix:
             - libstdc++-8-dev
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-8
+            - llvm-toolchain-trusty-8
 
     - os: osx
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z


### PR DESCRIPTION
* Add clang++-6.0 with cxxstd=2a for linux, clang++-7 for linux, and clang++-8 for linux to test matrix.
* Change sources to adapt to change in Travis Cl test environment from "trusty" to "xenial".