### PR TITLE
Fix argument value selection with an rvalue default

### DIFF
--- a/include/boost/parameter/aux_/tagged_argument.hpp
+++ b/include/boost/parameter/aux_/tagged_argument.hpp
@@ -295,6 +295,15 @@ namespace boost { namespace parameter { namespace aux {
             return this->get_value();
         }
 
+        template <typename Default>
+        inline BOOST_CONSTEXPR reference
+            operator[](
+                ::boost::parameter::aux::default_r_<key_type,Default> const&
+            ) const
+        {
+            return this->get_value();
+        }
+
         template <typename F>
         inline BOOST_CONSTEXPR reference
             operator[](
@@ -662,7 +671,7 @@ namespace boost { namespace parameter { namespace aux {
             ::boost::parameter::aux::tagged_argument<Keyword,Arg>
           , ::boost::parameter::aux::arg_list<
                 ::boost::parameter::aux::tagged_argument<Keyword2,Arg2>
-            > 
+            >
         >
             operator,(
                 ::boost::parameter::aux
@@ -673,7 +682,7 @@ namespace boost { namespace parameter { namespace aux {
                 ::boost::parameter::aux::tagged_argument<Keyword,Arg>
               , ::boost::parameter::aux::arg_list<
                     ::boost::parameter::aux::tagged_argument<Keyword2,Arg2>
-                > 
+                >
             >(
                 *this
               , ::boost::parameter::aux::arg_list<


### PR DESCRIPTION
In C++11 mode, when named parameter pack was a single tagged argument, parameter value was not extracted when an rvalue default value was provided by the user (instead, the default value was returned). This commit adds a missing overload for `default_r_`, which returns the parameter
value.

Fixes https://github.com/boostorg/parameter/issues/97.
