### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/parameter/aux_/arg_list.hpp
+++ b/include/boost/parameter/aux_/arg_list.hpp
@@ -599,7 +599,7 @@ namespace boost { namespace parameter { namespace aux {
         template <typename KW>
         static ::boost::parameter::aux::no_tag has_key(KW*);
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
         // The overload set technique doesn't work with these older compilers,
         // so they need some explicit handholding.
 
@@ -670,7 +670,7 @@ namespace boost { namespace parameter { namespace aux {
 #include <boost/core/enable_if.hpp>
 #endif
 
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #include <boost/parameter/aux_/preprocessor/nullptr.hpp>
 #endif
 
@@ -767,7 +767,7 @@ namespace boost { namespace parameter { namespace aux {
             };
         };
 
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
         // Overload for key_type, so the assert below will fire
         // if the same keyword is used again.
         static ::boost::parameter::aux::yes_tag has_key(key_type*);
@@ -827,7 +827,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
      public:
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
         // These older compilers don't support the overload set creation
         // idiom well, so we need to do all the return type calculation
         // for the compiler and dispatch through an outer function template.
@@ -927,7 +927,7 @@ namespace boost { namespace parameter { namespace aux {
         {
             return this->arg.get_value();
         }
-#else   // !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#else   // !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
         inline BOOST_CONSTEXPR reference
             operator[](::boost::parameter::keyword<key_type> const&) const
         {

--- a/include/boost/parameter/aux_/maybe.hpp
+++ b/include/boost/parameter/aux_/maybe.hpp
@@ -49,7 +49,7 @@ namespace boost { namespace parameter { namespace aux {
 #else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
 #include <boost/type_traits/add_lvalue_reference.hpp>
 #include <boost/type_traits/remove_cv.hpp>
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #include <boost/type_traits/add_const.hpp>
 #endif
 #endif  // BOOST_PARAMETER_CAN_USE_MP11
@@ -64,7 +64,7 @@ namespace boost { namespace parameter { namespace aux {
             typename ::std::add_const<T>::type
 #else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
         typedef typename ::boost::add_lvalue_reference<
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
             T const
 #else
             typename ::boost::add_const<T>::type

--- a/include/boost/parameter/aux_/name.hpp
+++ b/include/boost/parameter/aux_/name.hpp
@@ -34,7 +34,7 @@ namespace boost { namespace parameter { namespace aux {
 #include <boost/config/workaround.hpp>
 
 #if !defined(BOOST_NO_SFINAE) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x592))
 #include <boost/parameter/aux_/lambda_tag.hpp>
 #include <boost/mpl/lambda.hpp>
 #include <boost/mpl/bind.hpp>

--- a/include/boost/parameter/aux_/pack/item.hpp
+++ b/include/boost/parameter/aux_/pack/item.hpp
@@ -10,7 +10,7 @@
 #include <boost/config.hpp>
 #include <boost/config/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #endif
@@ -26,7 +26,7 @@ namespace boost { namespace parameter { namespace aux {
     struct item
     {
         typedef Spec spec;
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
         typedef ::boost::is_const<
             typename ::boost::remove_reference<Arg>::type
         > is_arg_const;

--- a/include/boost/parameter/aux_/pack/make_arg_list.hpp
+++ b/include/boost/parameter/aux_/pack/make_arg_list.hpp
@@ -75,19 +75,19 @@ namespace boost { namespace parameter { namespace aux {
       , typename IsPositional
       , typename UsedArgs
       , typename ArgumentPack
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
       , typename _argument
 #endif
       , typename Error
       , typename EmitsErrors
     >
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     class make_arg_list00
 #else
     class make_arg_list0
 #endif
     {
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
         typedef typename List::arg _argument;
 #endif
 #if defined(BOOST_PARAMETER_CAN_USE_MP11)
@@ -290,7 +290,7 @@ namespace boost { namespace parameter { namespace aux {
         >::type type;
     };
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     template <
         typename List
       , typename DeducedArgs

--- a/include/boost/parameter/aux_/pack/tag_keyword_arg_ref.hpp
+++ b/include/boost/parameter/aux_/pack/tag_keyword_arg_ref.hpp
@@ -15,7 +15,7 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename Keyword
       , typename ActualArg
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
       , typename = typename ::boost::parameter::aux
         ::is_cv_reference_wrapper<ActualArg>::type
 #endif
@@ -30,7 +30,7 @@ namespace boost { namespace parameter { namespace aux {
     };
 }}} // namespace boost::parameter::aux_
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 
 #include <boost/mpl/bool.hpp>
 

--- a/include/boost/parameter/aux_/preprocessor/impl/function_cast.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_cast.hpp
@@ -472,7 +472,7 @@ namespace boost { namespace parameter { namespace aux {
     }
 }}} // namespace boost::parameter::aux
 
-#elif BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#elif BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #define BOOST_PARAMETER_FUNCTION_CAST_T(value_t, predicate, args) value_t
 #define BOOST_PARAMETER_FUNCTION_CAST_B(value, predicate, args) value
 #else   // no perfect forwarding support and no Borland workarounds needed

--- a/include/boost/parameter/aux_/preprocessor/impl/function_forward_match.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/function_forward_match.hpp
@@ -9,7 +9,7 @@
 #include <boost/parameter/config.hpp>
 
 #if !defined(BOOST_NO_SFINAE) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x592))
 
 #include <boost/parameter/aux_/pp_impl/match.hpp>
 #include <boost/preprocessor/repetition/enum_trailing_params.hpp>

--- a/include/boost/parameter/aux_/preprocessor/impl/specification.hpp
+++ b/include/boost/parameter/aux_/preprocessor/impl/specification.hpp
@@ -34,7 +34,7 @@
 #include <boost/preprocessor/punctuation/comma_if.hpp>
 #include <boost/preprocessor/cat.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 
 #include <boost/parameter/aux_/use_default.hpp>
 
@@ -47,7 +47,7 @@
     >
 /**/
 
-#else   // !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#else   // !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 
 #include <boost/parameter/aux_/pp_impl/unwrap_predicate.hpp>
 

--- a/include/boost/parameter/aux_/preprocessor/is_binary.hpp
+++ b/include/boost/parameter/aux_/preprocessor/is_binary.hpp
@@ -9,7 +9,7 @@
 #include <boost/config.hpp>
 #include <boost/config/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 // From Paul Mensonides
 #include <boost/preprocessor/punctuation/comma.hpp>
 #include <boost/preprocessor/detail/split.hpp>

--- a/include/boost/parameter/aux_/preprocessor/is_nullary.hpp
+++ b/include/boost/parameter/aux_/preprocessor/is_nullary.hpp
@@ -9,7 +9,7 @@
 #include <boost/config.hpp>
 #include <boost/config/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 // From Paul Mensonides
 #include <boost/preprocessor/punctuation/comma.hpp>
 #include <boost/preprocessor/detail/split.hpp>

--- a/include/boost/parameter/aux_/set.hpp
+++ b/include/boost/parameter/aux_/set.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace parameter { namespace aux {
     };
 }}} // namespace boost::parameter::aux
 
-#elif BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#elif BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #include <boost/mpl/list.hpp>
 
 namespace boost { namespace parameter { namespace aux {

--- a/include/boost/parameter/aux_/tag.hpp
+++ b/include/boost/parameter/aux_/tag.hpp
@@ -124,7 +124,7 @@ namespace boost { namespace parameter { namespace aux {
     template <
         typename Keyword
       , typename Arg
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
       , typename = typename ::boost::parameter::aux
         ::is_cv_reference_wrapper<Arg>::type
 #endif
@@ -138,7 +138,7 @@ namespace boost { namespace parameter { namespace aux {
     };
 }}} // namespace boost::parameter::aux_
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #include <boost/mpl/bool.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 

--- a/include/boost/parameter/aux_/tagged_argument.hpp
+++ b/include/boost/parameter/aux_/tagged_argument.hpp
@@ -704,7 +704,7 @@ namespace boost { namespace parameter { namespace aux {
         }
 
 #if defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING) || \
-    BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+    BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
         template <typename KW, typename Default>
         inline BOOST_CONSTEXPR Default&
             get_with_default(

--- a/include/boost/parameter/aux_/unwrap_cv_reference.hpp
+++ b/include/boost/parameter/aux_/unwrap_cv_reference.hpp
@@ -60,7 +60,7 @@ namespace boost { namespace parameter { namespace aux {
 #else   // !defined(BOOST_PARAMETER_CAN_USE_MP11) || MSVC-14.0
 #include <boost/mpl/bool.hpp>
 #include <boost/type_traits/remove_reference.hpp>
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) && \
     !BOOST_WORKAROUND(BOOST_GCC, < 40000)
 #include <boost/mpl/eval_if.hpp>
 #endif
@@ -119,13 +119,13 @@ namespace boost { namespace parameter { namespace aux {
         );
 
         typedef boost::mpl::bool_<
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
             is_cv_reference_wrapper::
 #endif 
         value> type;
     };
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) || \
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) || \
     BOOST_WORKAROUND(BOOST_GCC, < 40000)
     template <
         typename T

--- a/include/boost/parameter/config.hpp
+++ b/include/boost/parameter/config.hpp
@@ -30,7 +30,7 @@
     !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
     !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && \
     !defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && !( \
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) && !( \
         defined(BOOST_CLANG) && (1 == BOOST_CLANG) && ( \
             (__clang_major__ < 3) || ( \
                 (3 == __clang_major__) && (__clang_minor__ < 2) \

--- a/include/boost/parameter/macros.hpp
+++ b/include/boost/parameter/macros.hpp
@@ -11,7 +11,7 @@
 #include <boost/preprocessor/repetition/enum_params.hpp>
 
 #if !defined(BOOST_NO_SFINAE) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x592))
 
 #define BOOST_PARAMETER_MATCH_TYPE(n, param)                                 \
   , typename param::match<BOOST_PP_ENUM_PARAMS(n, T)>::type kw = param()

--- a/include/boost/parameter/match.hpp
+++ b/include/boost/parameter/match.hpp
@@ -8,7 +8,7 @@
 
 #include <boost/parameter/config.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #include <boost/parameter/aux_/void.hpp>
 #include <boost/preprocessor/arithmetic/sub.hpp>
 #include <boost/preprocessor/facilities/intercept.hpp>

--- a/include/boost/parameter/parameters.hpp
+++ b/include/boost/parameter/parameters.hpp
@@ -306,7 +306,7 @@ namespace boost { namespace parameter {
 #endif
 
 #if !defined(BOOST_NO_SFINAE) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x592))
 #include <boost/parameter/aux_/pack/tag_keyword_arg.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/if.hpp>
@@ -314,7 +314,7 @@ namespace boost { namespace parameter {
 #include <boost/type_traits/is_same.hpp>
 #endif
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #include <boost/preprocessor/repetition/enum_params.hpp>
 #else
 #include <boost/preprocessor/repetition/enum_binary_params.hpp>
@@ -345,7 +345,7 @@ namespace boost { namespace parameter {
         // parameters.  Otherwise, this is not a valid metafunction
         // (no nested ::type).
 #if !defined(BOOST_NO_SFINAE) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x592))
         // If NamedList satisfies the PS0, PS1, ..., this is a metafunction
         // returning parameters.  Otherwise it has no nested ::type.
         template <typename ArgumentPackAndError>
@@ -386,7 +386,7 @@ namespace boost { namespace parameter {
         // Specializations are to be used as an optional argument
         // to eliminate overloads via SFINAE.
         template <
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
             // Borland simply can't handle default arguments in member
             // class templates.  People wishing to write portable code can
             // explicitly specify BOOST_PARAMETER_MAX_ARITY arguments.
@@ -401,7 +401,7 @@ namespace boost { namespace parameter {
         >
         struct match
 #if !defined(BOOST_NO_SFINAE) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x592))
           : ::boost::parameter::parameters<
                 BOOST_PP_ENUM_PARAMS(BOOST_PARAMETER_MAX_ARITY, PS)
             >::BOOST_NESTED_TEMPLATE match_base<
@@ -434,7 +434,7 @@ namespace boost { namespace parameter {
         // of make_arg_list.
 
         template <
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
             // Borland simply can't handle default arguments in member
             // class templates.  People wishing to write portable code can
             // explicitly specify BOOST_PARAMETER_MAX_ARITY arguments.

--- a/test/basics.cpp
+++ b/test/basics.cpp
@@ -97,7 +97,7 @@ int main()
       , test::_name = std::string("foo")
     );
 
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     x = 56;
     test::f_list((
         test::_tester = test::values(std::string("foo"), 666.222, 56)

--- a/test/deduced_dependent_predicate.cpp
+++ b/test/deduced_dependent_predicate.cpp
@@ -19,7 +19,7 @@
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_convertible.hpp>
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 #include <boost/type_traits/remove_reference.hpp>
 #else
 #include <boost/type_traits/add_lvalue_reference.hpp>
@@ -54,7 +54,7 @@ int main()
 #else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
               , boost::mpl::if_<
                     boost::is_same<
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
                         boost::mpl::_1
                       , boost::remove_reference<
                             boost::parameter::binding<
@@ -92,7 +92,7 @@ int main()
 #else   // !defined(BOOST_PARAMETER_CAN_USE_MP11)
               , boost::mpl::if_<
                     boost::is_same<
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
                         boost::mpl::_1
                       , boost::remove_reference<
                             boost::parameter::binding<

--- a/test/ntp.cpp
+++ b/test/ntp.cpp
@@ -113,7 +113,7 @@ namespace test {
           , A1
           , A2
           , A3
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
           , boost::parameter::void_
 #endif
         >::type args;

--- a/test/preprocessor.cpp
+++ b/test/preprocessor.cpp
@@ -139,7 +139,7 @@ namespace test {
             >::value
           , "remove_cref<index_type>::type == int"
         );
-#elif !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
+#elif !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) && \
     !BOOST_WORKAROUND(BOOST_MSVC, <= 1300)
         BOOST_MPL_ASSERT((
             typename boost::mpl::if_<
@@ -181,7 +181,7 @@ namespace test {
             >::value
           , "remove_cref<index_type>::type == int"
         );
-#elif !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) && \
+#elif !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) && \
     !BOOST_WORKAROUND(BOOST_MSVC, <= 1300)
         BOOST_MPL_ASSERT((
             typename boost::mpl::if_<
@@ -663,7 +663,7 @@ int main()
     BOOST_TEST(!p_const(test::_index = 3, test::_value = 4));
 
 #if !defined(BOOST_NO_SFINAE) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x592))
     // GCC 3- tries to bind string literals
     // to non-const references to char const*.
     // BOOST_TEST(test::sfinae("foo") == 1);

--- a/test/sfinae.cpp
+++ b/test/sfinae.cpp
@@ -125,7 +125,7 @@ namespace test {
 } // namespace test
 
 #if !defined(BOOST_NO_SFINAE) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x592))
 #include <boost/core/enable_if.hpp>
 
 #if !defined(BOOST_PARAMETER_CAN_USE_MP11)
@@ -166,7 +166,7 @@ int main()
     test::f("foo", 3.f);
     test::f(test::value = 3.f, test::name = "foo");
 #if !defined(BOOST_NO_SFINAE) && \
-    !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x592))
+    !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x592))
     BOOST_TEST_EQ(0, test::f(3, 4));
 #endif
     return boost::report_errors();


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.