### PR TITLE
Fix default_r_ move constructor on MSVC 2015

### DIFF
--- a/include/boost/parameter/aux_/default.hpp
+++ b/include/boost/parameter/aux_/default.hpp
@@ -91,6 +91,16 @@ namespace boost { namespace parameter { namespace aux {
         {
         }
 
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1910)
+        // MSVC 2015 misscompiles moves for classes containing RValue refs
+        // using the default generated move constructor
+        // when moving into a function
+        inline BOOST_CONSTEXPR default_r_(default_r_&& x)
+          : value(::std::forward<Value>(x.value))
+        {
+        }
+#endif
+
         Value&& value;
     };
 }}} // namespace boost::parameter::aux


### PR DESCRIPTION
The default compiler-generated move constructor on MSVC 2015
does not move the Rvalue references correctly.

Fixes boostorg/log#132