### PR TITLE
This removes test project ID that will conflict with modular ID.

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -9,7 +9,7 @@
 import os ;
 import testing ;
 
-project boost/parameter
+project
     :
         default-build
         <warnings>off


### PR DESCRIPTION
This removes the superfluous test project ID that will conflict with the modular project IDs for all libraries. When libraries are modular they will have the standard global ID of /boost/*lib-name*. Having colliding IDs will cause build errors.

#modular-boost https://github.com/users/grafikrobot/projects/1